### PR TITLE
Update qld-resource-permit-status.ttl

### DIFF
--- a/vocabularies/qld-resource-permit-status.ttl
+++ b/vocabularies/qld-resource-permit-status.ttl
@@ -28,12 +28,6 @@ gmps:abandoned a skos:Concept ;
     skos:inScheme gmps:conceptScheme ;
     skos:prefLabel "Abandoned"@en .
 
-gmps:accepted a skos:Concept ;
-    skos:definition "The application has been accepted."@en ;
-    skos:broader gmps:granted ;
-    skos:inScheme gmps:conceptScheme ;
-    skos:prefLabel "Accepted"@en .
-
 gmps:competing-application a skos:Concept ;
     skos:definition "This application represents a competing application that was lodged on the same date for the same mineral."@en ;
     skos:broader gmps:application,
@@ -53,23 +47,11 @@ gmps:conversion-of-ml-to-mc a skos:Concept ;
     skos:inScheme gmps:conceptScheme ;
     skos:prefLabel "Conversion of ML to MC"@en .
 
-gmps:expired a skos:Concept ;
-    skos:definition "The Resource Permit has expired."@en ;
-    skos:broader gmps:granted,
-    skos:inScheme gmps:conceptScheme ;
-    skos:prefLabel "Expired"@en .
-
 gmps:finalised a skos:Concept ;
     skos:definition "The Resource Permit has no outstanding requirements."@en ;
     skos:broader gmps:non-current ;
     skos:inScheme gmps:conceptScheme ;
     skos:prefLabel "Finalised"@en .
-
-gmps:on-hold-oil-shale-application a skos:Concept ;
-    skos:definition "The oil-shale application has been placed on-hold."@en ;
-    skos:broader gmps:application ;
-    skos:inScheme gmps:conceptScheme ;
-    skos:prefLabel "On-hold oil shale application"@en .
 
 gmps:preferred-tenderer a skos:Concept ;
     skos:definition "The applicant is the preferred tenderer."@en ;
@@ -77,8 +59,8 @@ gmps:preferred-tenderer a skos:Concept ;
     skos:inScheme gmps:conceptScheme ;
     skos:prefLabel "Preferred Tenderer"@en .
 
-gmps:priority-applicant a skos:Concept ;
-    skos:definition "The applicant is a Priority Applicant for competing application."@en ;
+gmps:priority-application a skos:Concept ;
+    skos:definition "Priority Application substatus is accorded to the application of highest rank that has been determined by the Department from an assessment and ranking of competitive applications (generally for Exploration Permits Mineral) lodged on the same day for the same mineral and for the same area."@en ;
     skos:broader gmps:application ;
     skos:inScheme gmps:conceptScheme ;
     skos:prefLabel "Priority Applicant"@en .
@@ -102,7 +84,7 @@ gmps:renewal-withdrawn a skos:Concept ;
     skos:prefLabel "Renewal withdrawn"@en .
 
 gmps:replacement-permit-application a skos:Concept ;
-    skos:definition "The application represents a Replacement Permit Application."@en ;
+    skos:definition "The application represents a Replacement Permit Application. Such applications relate to petroleum and gas permits for which a holder can replace a 1923 Act permit for a permit under the Petroleum and Gas Act 2004."@en ;
     skos:broader gmps:application,
         gmps:granted ;
     skos:inScheme gmps:conceptScheme ;


### PR DESCRIPTION
Adding the new definitions (please review) from Jodie and eliminating: on-hold oil shale; expired under granted; and accepted under granted. We can sort out the remainder tomorrow, 29.10.2019.
Cheers