### PR TITLE
Fixed file:// errors

### DIFF
--- a/vocabularies/sample-material.ttl
+++ b/vocabularies/sample-material.ttl
@@ -71,7 +71,7 @@ spmt:bitumen a skos:Concept ;
     skos:prefLabel "Bitumen"@en .
 
 spmt:coal a skos:Concept ;
-    skos:broader <file:///tmp/skosify-cgiUmGo8g/input.ttl#organic-material>,
+    skos:broader spmt:organic-material,
         spmt:rock ;
     skos:definition "A readily combustible organic rock containing more than 50% by weight and more than 70% by volume of carbonaceous material."@en ;
     skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/coal> ;
@@ -79,7 +79,7 @@ spmt:coal a skos:Concept ;
     skos:prefLabel "Coal"@en .
 
 spmt:coke a skos:Concept ;
-    skos:broader <file:///tmp/skosify-cgiUmGo8g/input.ttl#organic-material>,
+    skos:broader spmt:organic-material,
         spmt:rock ;
     skos:definition "A solid of carbonaceous material derived from the destructive distillation of low-ash, low-sulphur bituminous coal."@en ;
     skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/coke> ;
@@ -261,7 +261,7 @@ spmt:biological a skos:Concept ;
     skos:prefLabel "Biological"@en .
 
 spmt:fluid-hydrocarbon a skos:Concept ;
-    skos:broader <file:///tmp/skosify-cgiUmGo8g/input.ttl#hydrocarbon-material>,
+    skos:broader spmt:hydrocarbon-material,
         spmt:fluid ;
     skos:definition "Any carbon-hydrogen fluid material"@en ;
     skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/fluid_hydrocarbon> ;
@@ -309,72 +309,3 @@ spmt:fluid a skos:Concept ;
     skos:inScheme spmt:conceptScheme ;
     skos:prefLabel "Fluid"@en ;
     skos:topConceptOf spmt:conceptScheme .
-
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/air> skos:exactMatch spmt:air .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/animal_material> skos:exactMatch spmt:animal-material .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/bitumen> skos:exactMatch spmt:bitumen .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/coal> skos:exactMatch spmt:coal .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/coke> skos:exactMatch spmt:coke .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/condensate> skos:exactMatch spmt:condensate .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/crude_oil> skos:exactMatch spmt:crude-oil .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/drilling_fluid> skos:exactMatch spmt:drilling-fluid .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/estuarine_water> skos:exactMatch spmt:estuarine-water .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/fluid> skos:exactMatch spmt:fluid .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/fluid_hydrocarbon> skos:exactMatch spmt:fluid-hydrocarbon .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/groundwater> skos:exactMatch spmt:groundwater .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/hydrocarbon_gas> skos:exactMatch spmt:hydrocarbon-gas .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/hydrocarbon_material> skos:exactMatch spmt:hydrocarbon-material .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/kerogen> skos:exactMatch spmt:kerogen .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/lag> skos:exactMatch spmt:lag .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/mineral> skos:exactMatch spmt:mineral .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/organic_material> skos:exactMatch spmt:organic-material .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/pitch> skos:exactMatch spmt:pitch .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/porewater> skos:exactMatch spmt:porewater .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/rain_water> skos:exactMatch spmt:rain-water .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/refined_oil> skos:exactMatch spmt:refined-oil .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/regolith> skos:exactMatch spmt:regolith .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/resin> skos:exactMatch spmt:resin .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/rock> skos:exactMatch spmt:rock .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/sea_water> skos:exactMatch spmt:sea-water .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/sediment> skos:exactMatch spmt:sediment .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/soil> skos:exactMatch spmt:soil .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/surface_water> skos:exactMatch spmt:surface-water .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/unknown> skos:exactMatch spmt:unknown .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/vegetation> skos:exactMatch spmt:vegetation .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/water> skos:exactMatch spmt:water .
-
-<http://pid.geoscience.gov.au/def/voc/ga/materialtype/wax> skos:exactMatch spmt:wax .
-
-


### PR DESCRIPTION
Following fixes:
1. Removed error links such as <file:///tmp/skosify-cgiUmGo8g/input.ttl#organic-material>
2. Removed duplicate exact matches at bottom of file.

Can you please verify that coal and coke are narrower terms of 'rocks'?