### PR TITLE
first version - missing concave hull defn

### DIFF
--- a/vocabularies/geometry-roles.ttl
+++ b/vocabularies/geometry-roles.ttl
@@ -51,7 +51,7 @@ grole:bounding-box a skos:Concept ;
 grole:bounding-circle a skos:Concept ;
     skos:broader grole:boundary ;
     dct:source <https://en.wikipedia.org/wiki/Smallest-circle_problem> ;
-    skos:definition "The circle with the smallest area that contains all the Points in a Feature's Geometry.."@en ;
+    skos:definition "The circle with the smallest area that contains all the Points in a Feature's Geometry."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
     skos:prefLabel "Bounding circle"@en .
 
@@ -63,14 +63,14 @@ grole:boundary a skos:Concept ;
 
 grole:concave-hull a skos:Concept ;
     skos:broader grole:boundary ;
-    skos:definition "."@en ;
+    skos:definition "The minimum bounding Polygon encompassing all the Points in a Features Geometry, based on a user-defined distance threshold for vectors between Points."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
     skos:prefLabel "Concave hull"@en .
 
 grole:convex-hull a skos:Concept ;    
     dct:source <https://www.arcgis.com/home/item.html?id=a6129839e96d4c0682250673cd89589d> ;
     skos:broader grole:boundary ;
-    skos:definition "The minimum bounding Polygon for the all Points in a Feature's Geometry."@en ;
+    skos:definition "The minimum bounding Polygon encompassing all the all Points in a Feature's Geometry."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
     skos:prefLabel "Convex hull"@en .
 

--- a/vocabularies/geometry-roles.ttl
+++ b/vocabularies/geometry-roles.ttl
@@ -1,0 +1,82 @@
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix geox: <http://linked.data.gov.au/def/geox> .
+@prefix grole: <http://linked.data.gov.au/def/borehole-status/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://linked.data.gov.au/def/geometry-roles> 
+    a owl:Ontology , skos:ConceptScheme ;
+    dct:creator <http://linked.data.gov.au/org/gsq> ;
+    dct:created "2020-03-12"^^xsd:date ;
+    dct:modified "2020-03-12"^^xsd:date ;
+    dct:publisher <http://linked.data.gov.au/org/gsq> ;
+    skos:definition """A Geometry Role is the function a Geometry plays in relation to the Feature it is a Geometry for where Feature and Geometry are defined by the GeoSPARQL Ontology.
+    
+Geometry Role is not geometry type and does not indicate sub classes of geometry. Well known Geometry types or subclasses of geometry include Point, Polygon, LineString MultiPolygon etc."""@en ;
+    skos:hasTopConcept 
+        grole:centroid ,
+        grole:boundary ,
+        grole:detailed-geometry ;
+    skos:prefLabel "Geometry Role"@en ;
+    skos:scopeNote "Concepts in this vocabulary indicate should, but do not have to only be, used with instances of the GeoSPARQL Ontology's Geometry class using the GeoSPARQL Extensions Ontology's hasRole property."@en .
+
+<http://linked.data.gov.au/org/gsq>
+    a sdo:Organization ;
+    sdo:name "Geological Survey of Queensland" ;
+    sdo:url <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq> ;
+.
+
+grole:centroid a skos:Concept ;
+    dct:source <https://en.wikipedia.org/wiki/Centroid> ;
+    skos:altLabel "barycenter"@en ;
+    skos:definition "The arithmetic mean position of all the Points in a Feature's Geometry, expressed as a single Point."@en ;
+    skos:hiddenLabel "center of mass"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
+    skos:prefLabel "Centroid"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geometry-roles> .
+
+grole:bounding-box a skos:Concept ;
+    skos:broader grole:boundary ;
+    dct:source <https://en.wikipedia.org/wiki/Minimum_bounding_box> ;
+    skos:altLabel "minimum bounding box"@en , "smallest bounding box"@en , "enclosing box"@en , "bounding rectangle"@en ;
+    skos:definition "The box (rectangle) with the smallest area that contains all the Points in a Feature's Geometry."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
+    skos:prefLabel "Bounding box"@en .
+
+grole:bounding-circle a skos:Concept ;
+    skos:broader grole:boundary ;
+    dct:source <https://en.wikipedia.org/wiki/Smallest-circle_problem> ;
+    skos:definition "The circle with the smallest area that contains all the Points in a Feature's Geometry.."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
+    skos:prefLabel "Bounding circle"@en .
+
+grole:boundary a skos:Concept ;
+    skos:definition "A polygon which denotes the extent of a Feature's Geometry."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
+    skos:prefLabel "Boundary"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geometry-roles> .
+
+grole:concave-hull a skos:Concept ;
+    skos:broader grole:boundary ;
+    skos:definition "."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
+    skos:prefLabel "Concave hull"@en .
+
+grole:convex-hull a skos:Concept ;    
+    dct:source <https://www.arcgis.com/home/item.html?id=a6129839e96d4c0682250673cd89589d> ;
+    skos:broader grole:boundary ;
+    skos:definition "The minimum bounding Polygon for the all Points in a Feature's Geometry."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
+    skos:prefLabel "Convex hull"@en .
+
+grole:detailed-geometry a skos:Concept ;
+    skos:definition "A Feature's Geometry in detail. It may be regular or irrigular but it does not constitute a Boundary for the Feature."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geometry-roles> ;
+    skos:prefLabel "Detailed geometry"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geometry-roles> .                    
+


### PR DESCRIPTION
Hi @KellyVance. I've made this first version of the vocab with all the terms we discussed however I've put Concave & Convex Hull in as narrower terms of Boundary since they are! They are boundaries under certain restrictions: rectangular & circular respectively.

I've not provided a definition for Concave Hull, please could you?