### PR TITLE
Reviews (tech and content) GSQ Alias

### DIFF
--- a/vocabularies/gsq-alias.ttl
+++ b/vocabularies/gsq-alias.ttl
@@ -59,7 +59,7 @@ als:des a skos:Concept ;
     skos:topConceptOf als:conceptScheme .
 
 als:geoscience-australia a skos:Concept ;
-    skos:altLabel "G.A."@en ;
+    skos:altLabel "GA"@en ;
     skos:definition "An identifier used by Geoscience Australia"@en ;
     skos:inScheme als:conceptScheme ;
     skos:prefLabel "Geoscience Australia"@en ;
@@ -73,11 +73,11 @@ als:mmol a skos:Concept ;
     skos:topConceptOf als:conceptScheme .
 
 als:ogia a skos:Concept ;
-    skos:altLabel "Office of Groundwater Impact Assessment"@en ;
+    skos:altLabel "Office of Groundwater Impact Assessment"@en,
+        "OGIA" ;
     skos:definition "An identifier used by the Office of Groundwater Impact Assessment."@en ;
     skos:inScheme als:conceptScheme ;
-    skos:notation "QWRC" ;
-    skos:prefLabel "OGIA"@en ;
+    skos:prefLabel "QWRC"@en ;
     skos:topConceptOf als:conceptScheme .
 
 als:operator a skos:Concept ;

--- a/vocabularies/gsq-alias.ttl
+++ b/vocabularies/gsq-alias.ttl
@@ -1,0 +1,117 @@
+@prefix als: <http://linked.data.gov.au/def/gsq-alias/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://linked.data.gov.au/def/gsq-alias> a owl:Ontology .
+
+als:conceptScheme a skos:ConceptScheme ;
+    dct:created "2020-03-23T16:19:50+10:00"^^xsd:dateTime ;
+    dct:creator <http://linked.data.gov.au/org/gsq> ;
+    dct:modified "2020-03-23T16:38:10+10:00"^^xsd:dateTime ;
+    dct:source "Compiled by the Geological Survey of Queensland" ;
+    skos:definition "Sources for any alternate names for features, sites, surveys, or samples catalogued by the Geological Survey of Queensland."@en ;
+    skos:hasTopConcept als:colloquial,
+        als:des,
+        als:geoscience-australia,
+        als:gsq-legacy,
+        als:igsn,
+        als:mmol,
+        als:ogia,
+        als:operator,
+        als:service-provider,
+        als:treasury ;
+    skos:prefLabel "GSQ Alias"@en .
+
+als:colloquial a skos:Concept ;
+    skos:altLabel "Common"@en,
+        "Informal"@en,
+        "Popular"@en,
+        "Public"@en ;
+    skos:definition "An unofficial, informal, or colloquial name or reference used by the general public, industry, or government."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "Colloquial"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:gsq-legacy a skos:Concept ;
+    skos:definition "Any superseded identifier, code, or name previously used by the Geological Survey of Queensland."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "GSQ Legacy"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:igsn a skos:Concept ;
+    skos:altLabel "International Geo Sample Number"@en ;
+    skos:definition "An identifier used as a globally unique and persistent identifier for material samples."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "IGSN"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:des a skos:Concept ;
+    skos:altLabel "Department of Environment and Science"@en ;
+    skos:definition "An identifier used by the Department of Environment and Science"@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "DES"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:geoscience-australia a skos:Concept ;
+    skos:altLabel "G.A."@en ;
+    skos:definition "An identifier used by Geoscience Australia"@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "Geoscience Australia"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:mmol a skos:Concept ;
+    skos:altLabel "MyMinesOnline"@en ;
+    skos:definition "An identifier used by the MyMinesOnline system administered by the Department."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "MMOL"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:ogia a skos:Concept ;
+    skos:altLabel "Office of Groundwater Impact Assessment"@en ;
+    skos:definition "An identifier used by the Office of Groundwater Impact Assessment."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:notation "QWRC" ;
+    skos:prefLabel "OGIA"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:operator a skos:Concept ;
+    skos:definition "An identifier used by the company who originally owned or operated an asset or activity."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "Operator"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:service-provider a skos:Concept ;
+    skos:altLabel "Contractor"@en ;
+    skos:definition "An identifier used by the company who originally conducted activity on behalf of the operator."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "Service Provider"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+als:treasury a skos:Concept ;
+    skos:altLabel "Queensland Treasury"@en ;
+    skos:definition "An identifier used by the Queensland Treasury."@en ;
+    skos:inScheme als:conceptScheme ;
+    skos:prefLabel "Treasury"@en ;
+    skos:topConceptOf als:conceptScheme .
+
+
+als:company a skos:Collection ;
+    skos:definition "Aliases for entities or activities used by companies."@en ;
+    skos:member als:operator,
+        als:service-provider ;
+    skos:prefLabel "Company"@en .
+
+als:government- a skos:Collection ;
+    skos:definition "Aliases used by other groups within the Department, other departments within Queensland Government, or other Government Agencies."@en ;
+    skos:member als:des,
+        als:geoscience-australia,
+        als:mmol,
+        als:ogia,
+        als:treasury ;
+    skos:prefLabel "Government"@en .


### PR DESCRIPTION
Review of alias types used by the Geological Survey of Queensland.