### PR TITLE
Gregorian Months for UoM

### DIFF
--- a/vocabularies/gregorian-months.ttl
+++ b/vocabularies/gregorian-months.ttl
@@ -1,0 +1,289 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix greg: <http://www.w3.org/ns/time/gregorian/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.w3.org/ns/time/gregorian>
+  a skos:ConceptScheme , owl:Ontology ;
+  dcterms:created "2017-01-20"^^xsd:date ;
+  dcterms:creator <http://orcid.org/0000-0002-3884-3420> ;
+  dcterms:modified "2017-01-20"^^xsd:date ; 
+  dcterms:publisher <https://www.w3.org> ;
+  skos:definition "The set of months-of-the-year from the Gregorian calendar."@en ;
+  skos:prefLabel "Gregorian Months"@en ;
+  owl:imports <http://www.w3.org/2006/time> , <http://www.w3.org/2004/02/skos/core> ;
+  skos:hasTopConcept
+    greg:January ,
+    greg:February ,
+    greg:March ,
+    greg:April ,
+    greg:May ,
+    greg:June ,
+    greg:July ,
+    greg:August ,
+    greg:September ,
+    greg:October ,
+    greg:November ,
+    greg:December ;
+.
+<https://orcid.org/0000-0002-8742-7730>
+  a sdo:Person ;
+  sdo:name "Nicholas J. Car" ;
+  sdo:email <mailto:nicholas.car@surroundaustralia.com> ;
+  sdo:affiliation <https://surroundaustralia.com> ;
+.
+<https://surroundaustralia.com>
+  a sdo:Organization ;
+  sdo:name "SURROUND Australia Pty Ltd" ;
+  sdo:url <https://surroundaustralia.com> ;
+.
+<http://orcid.org/0000-0002-3884-3420>
+  a sdo:Person ;
+  sdo:name "Simon J.D. Cox" ;
+  sdo:email <mailto:simon.cox@csiro.au> ;
+  sdo:affiliation <http://linked.data.gov.au/org/csiro> ;
+.
+<http://linked.data.gov.au/org/csiro>
+  a sdo:Organization ;
+  sdo:name "CSIRO" ;
+  sdo:url <https://www.csiro.au> ;
+.
+<https://www.w3.org>
+  a sdo:Organization ;
+  sdo:name "World Wide Web Consortium" ;
+  sdo:url <https://www.w3.org> ;
+.
+greg:April
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "4月"@ja ;
+  skos:prefLabel "4月"@zh ;
+  skos:prefLabel "Abril"@es ;
+  skos:prefLabel "Abril"@pt ;
+  skos:prefLabel "April"@de ;
+  skos:prefLabel "April"@en ;
+  skos:prefLabel "April"@nl ;
+  skos:prefLabel "Aprile"@it ;
+  skos:prefLabel "Avril"@fr ;
+  skos:prefLabel "Kwiecień"@pl ;
+  skos:prefLabel "Апрель"@ru ;
+  skos:prefLabel "أبريل"@ar ;
+  time:month "--04"^^xsd:gMonth ;
+  time:unitType time:unitMonth ;
+  skos:definition "April is the fourth month of the year in the Gregorian calendar, the fifth in the early Julian, the first of four months to have a length of 30 days, and the second of five months to have a length of less than 31 days."@en ;  
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/April> ;
+.
+greg:August
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "8月"@ja ;
+  skos:prefLabel "8月"@zh ;
+  skos:prefLabel "Agosto"@es ;
+  skos:prefLabel "Agosto"@it ;
+  skos:prefLabel "Agosto"@pt ;
+  skos:prefLabel "Août"@fr ;
+  skos:prefLabel "August"@de ;
+  skos:prefLabel "August"@en ;
+  skos:prefLabel "Augustus (maand)"@nl ;
+  skos:prefLabel "Sierpień"@pl ;
+  skos:prefLabel "Август"@ru ;
+  skos:prefLabel "أغسطس"@ar ;
+  time:month "--08"^^xsd:gMonth ;
+  time:unitType time:unitMonth ;
+  skos:definition "August is the eighth month of the year in the Julian and Gregorian calendars, and the fifth of seven months to have a length of 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/August> ;
+.
+greg:December
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "12月"@ja ;
+  skos:prefLabel "12月"@zh ;
+  skos:prefLabel "December"@en ;
+  skos:prefLabel "December"@nl ;
+  skos:prefLabel "Dezember"@de ;
+  skos:prefLabel "Dezembro"@pt ;
+  skos:prefLabel "Dicembre"@it ;
+  skos:prefLabel "Diciembre"@es ;
+  skos:prefLabel "Décembre"@fr ;
+  skos:prefLabel "Grudzień"@pl ;
+  skos:prefLabel "Декабрь"@ru ;
+  skos:prefLabel "ديسمبر"@ar ;
+  time:month "--12"^^xsd:gMonth ;
+  skos:definition "December is the twelfth and final month of the year in the Julian and Gregorian Calendars. It is also the last of seven months to have a length of 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/December> ;
+.
+greg:February
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "2月"@ja ;
+  skos:prefLabel "2月"@zh ;
+  skos:prefLabel "Febbraio"@it ;
+  skos:prefLabel "Febrero"@es ;
+  skos:prefLabel "Februar"@de ;
+  skos:prefLabel "Februari"@nl ;
+  skos:prefLabel "February"@en ;
+  skos:prefLabel "Fevereiro"@pt ;
+  skos:prefLabel "Février"@fr ;
+  skos:prefLabel "Luty"@pl ;
+  skos:prefLabel "Февраль"@ru ;
+  skos:prefLabel "فبراير"@ar ;
+  time:month "--02"^^xsd:gMonth ;
+  skos:definition "February is the second month of the year in the Julian and Gregorian calendars, with 28 days in common years and 29 days in leap years, with the quadrennial 29th day being called the leap day."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/February> ;
+.
+greg:January
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "/=20@L"@ru ;
+  skos:prefLabel "1"@ja ;
+  skos:prefLabel "1"@zh ;
+  skos:prefLabel "Enero"@es ;
+  skos:prefLabel "Gennaio"@it ;
+  skos:prefLabel "JF'J1 (4G1)"@ar ;
+  skos:prefLabel "Janeiro"@pt ;
+  skos:prefLabel "Januar"@de ;
+  skos:prefLabel "Januari"@nl ;
+  skos:prefLabel "January"@en ;
+  skos:prefLabel "Janvier"@fr ;
+  skos:prefLabel "StyczeD"@pl ;
+  time:month "--01"^^xsd:gMonth ;
+  skos:definition "January is the first month of the year in the Julian and Gregorian calendars and the first of seven months to have a length of 31 days."@en ;
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/January> ;
+.
+greg:July
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "N;L"@ru ;
+  skos:prefLabel "7"@ja ;
+  skos:prefLabel "7"@zh ;
+  skos:prefLabel "JHDJH"@ar ;
+  skos:prefLabel "Juillet"@fr ;
+  skos:prefLabel "Julho"@pt ;
+  skos:prefLabel "Juli"@de ;
+  skos:prefLabel "Juli"@nl ;
+  skos:prefLabel "Julio"@es ;
+  skos:prefLabel "July"@en ;
+  skos:prefLabel "Lipiec"@pl ;
+  skos:prefLabel "Luglio"@it ;
+  time:month "--07"^^xsd:gMonth ;
+  skos:definition "July is the seventh month of the year (between June and August) in the Julian and Gregorian Calendars and the fourth of seven months to have a length of 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/July> ;
+.
+greg:June
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "N=L"@ru ;
+  skos:prefLabel "6"@ja ;
+  skos:prefLabel "6"@zh ;
+  skos:prefLabel "Czerwiec"@pl ;
+  skos:prefLabel "Giugno"@it ;
+  skos:prefLabel "JHFJH"@ar ;
+  skos:prefLabel "Juin"@fr ;
+  skos:prefLabel "June"@en ;
+  skos:prefLabel "Junho"@pt ;
+  skos:prefLabel "Juni"@de ;
+  skos:prefLabel "Juni"@nl ;
+  skos:prefLabel "Junio"@es ;
+  time:month "--06"^^xsd:gMonth ;
+  skos:definition "June is the sixth month of the year in the Julian and Gregorian calendars, the second of four months to have a length of 30 days, and the third of five months to have a length of less than 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/June> ;
+.
+greg:March
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "3月"@ja ;
+  skos:prefLabel "3月"@zh ;
+  skos:prefLabel "Maart"@nl ;
+  skos:prefLabel "March"@en ;
+  skos:prefLabel "Mars (mois)"@fr ;
+  skos:prefLabel "Marzec"@pl ;
+  skos:prefLabel "Marzo"@es ;
+  skos:prefLabel "Marzo"@it ;
+  skos:prefLabel "Março"@pt ;
+  skos:prefLabel "März"@de ;
+  skos:prefLabel "Март"@ru ;
+  skos:prefLabel "مارس"@ar ;
+  time:month "--03"^^xsd:gMonth ;
+  skos:definition "March is the third month of the year and named after Mars in both the Julian and Gregorian calendars. It is the second of seven months to have a length of 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/March> ;
+.
+greg:May
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "5月"@ja ;
+  skos:prefLabel "5月"@zh ;
+  skos:prefLabel "Maggio"@it ;
+  skos:prefLabel "Mai"@de ;
+  skos:prefLabel "Mai"@fr ;
+  skos:prefLabel "Maio"@pt ;
+  skos:prefLabel "Maj"@pl ;
+  skos:prefLabel "May"@en ;
+  skos:prefLabel "Mayo"@es ;
+  skos:prefLabel "Mei"@nl ;
+  skos:prefLabel "Май"@ru ;
+  skos:prefLabel "مايو"@ar ;
+  time:month "--05"^^xsd:gMonth ;
+  skos:definition "May is the fifth month of the year in the Julian and Gregorian calendars and the third of seven months to have a length of 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/May> ;
+.
+greg:November
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "11月"@ja ;
+  skos:prefLabel "11月"@zh ;
+  skos:prefLabel "Listopad"@pl ;
+  skos:prefLabel "November"@de ;
+  skos:prefLabel "November"@en ;
+  skos:prefLabel "November"@nl ;
+  skos:prefLabel "Novembre"@fr ;
+  skos:prefLabel "Novembre"@it ;
+  skos:prefLabel "Novembro"@pt ;
+  skos:prefLabel "Noviembre"@es ;
+  skos:prefLabel "Ноябрь"@ru ;
+  skos:prefLabel "نوفمبر"@ar ;
+  time:month "--11"^^xsd:gMonth ;
+  skos:definition "November is the eleventh month of the year in the Julian and Gregorian Calendars, the fourth and last of four months to have a length of 30 days and the fifth and last of five months to have a length of fewer than 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/November> ;
+.
+greg:October
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "10月"@ja ;
+  skos:prefLabel "10月"@zh ;
+  skos:prefLabel "October"@en ;
+  skos:prefLabel "Octobre"@fr ;
+  skos:prefLabel "Octubre"@es ;
+  skos:prefLabel "Oktober"@de ;
+  skos:prefLabel "Oktober"@nl ;
+  skos:prefLabel "Ottobre"@it ;
+  skos:prefLabel "Outubro"@pt ;
+  skos:prefLabel "Październik"@pl ;
+  skos:prefLabel "Октябрь"@ru ;
+  skos:prefLabel "أكتوبر"@ar ;
+  time:month "--10"^^xsd:gMonth ;
+  skos:definition "October is the tenth month of the year in the Julian and Gregorian Calendars and the sixth of seven months to have a length of 31 days."@en ; 
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/October> ;
+.
+greg:September
+  a skos:Concept , time:MonthOfYear ;
+  skos:prefLabel "9月"@ja ;
+  skos:prefLabel "9月"@zh ;
+  skos:prefLabel "September"@de ;
+  skos:prefLabel "September"@en ;
+  skos:prefLabel "September"@nl ;
+  skos:prefLabel "Septembre"@fr ;
+  skos:prefLabel "Septiembre"@es ;
+  skos:prefLabel "Setembro"@pt ;
+  skos:prefLabel "Settembre"@it ;
+  skos:prefLabel "Wrzesień"@pl ;
+  skos:prefLabel "Сентябрь"@ru ;
+  skos:prefLabel "سبتمبر"@ar ;
+  time:month "--09"^^xsd:gMonth ;
+  skos:definition "September is the ninth month of the year in the Julian and Gregorian calendars, the third of four months to have a length of 30 days, and the fourth of five months to have a length of less than 31 days."@en ; 
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/September> ;
+  skos:inScheme <http://www.w3.org/ns/time/gregorian> ;
+.


### PR DESCRIPTION
This is a standard W3C vocab that I've enhanced for GSQ SKOS compliance.

This vocab has been tested in an updated VocPrez that handles multi-lingual labels. Initially the multi-lingual labels won't show.

Note that this vocab is 99% compliant with the GSQ vocab shape files (in ../shapes). Since it uses multiple language lables, I had to disable the language checker in the Concept shape as this requires only English prefLabels. I can't work out how to require at least English prefLabels (and allow others). Work for another day when we have more multi-language vocs.