### PR TITLE
new sample relationship vocab from SOSA

### DIFF
--- a/sample-relationship.ttl
+++ b/sample-relationship.ttl
@@ -1,0 +1,60 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-sdo#> .
+@prefix sdo: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://linked.data.gov.au/def/sample-relationship> a owl:Ontology , skos:ConceptScheme ;
+    dcterms:created "2020-03-24T09:03:21"^^xsd:dateTime ;
+    dcterms:creator <http://linked.data.gov.au/org/gsq> ;
+    dcterms:modified "2020-03-24T09:03:21"^^xsd:dateTime ;
+    dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
+    dcterms:source "Source information from https://www.w3.org/TR/vocab-ssn/#Sample_Relations and the SOSA Extensions ontology, modified by the Geological Survey of Queensland." ;
+    skos:definition """Relationships between Samples.
+
+This vocabulary is derived from the SOSA Ontology and the SOSA Extensions Ontology where the Samples are defined by the class sosa:Sample and the relationships are OWL objectProperties. It reuses the original ontology URIs directly and retains the relationship's non-SKSO properties too so it is a SKOS+ ontology (SKOS + other things)."""@en ;
+    skos:hasTopConcept
+        sosa:hasSample ,
+        sosa:isSampleOf ,
+        sosa:hasOriginalSample ;
+    skos:prefLabel "Sample Relationship"@en ;
+.
+
+sosa:hasSample 
+    a owl:ObjectProperty , skos:Concept ;
+    skos:prefLabel "has sample"@en ;
+    skos:definition "Relation between a FeatureOfInterest and the Sample used to represent it."@en ;
+    sdo:domainIncludes sosa:FeatureOfInterest ;
+    sdo:rangeIncludes sosa:Sample ;
+    owl:inverseOf sosa:isSampleOf ;
+    rdfs:isDefinedBy sosa: ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-relationship> .
+
+sosa:isSampleOf 
+    a owl:ObjectProperty , skos:Concept ;
+    skos:prefLabel "is sample of"@en ;
+    skos:definition "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of."@en ;
+    sdo:domainIncludes sosa:Sample ;
+    sdo:rangeIncludes sosa:FeatureOfInterest ;
+    owl:inverseOf sosa:hasSample ;
+    rdfs:isDefinedBy sosa: ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-relationship> .
+
+sosa:hasOriginalSample
+    a owl:ObjectProperty , skos:Concept ;
+    skos:prefLabel "has original sample"@en ;
+    sdo:domainIncludes sosa:Sample ;
+    sdo:rangeIncludes sosa:Sample ;
+    skos:definition "A Link to the original sample that is related to the context sample through a chain of isSampleOf relations."@en ;
+    rdfs:domain sosa:Sample ;
+    rdfs:range sosa:Sample ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-relationship> .
+
+
+<http://linked.data.gov.au/org/gsq>
+    a sdo:Organization ;
+    sdo:name "Geological Survey of Queensland" ;
+    sdo:url <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq> ;
+.


### PR DESCRIPTION
This is a reimplementation of the Sample Relations vocab retaining the definitions and URIs of SOSA and the SOSA Extensions Ontologies. It is a SKOS+ vocab.

This vocab contains the same essential content as the last version and passes all the SHACL shape validators.

This should replace the previously approved version.