### PR TITLE
removed -datum

### DIFF
--- a/scripts/config-template-production.py
+++ b/scripts/config-template-production.py
@@ -1,10 +1,10 @@
 # Configuration file for vocabs_load.py file. Edit this template and save as config.py
 
-GRAPHDB_REPO_ID = 'GSQ_Vocabularies_Master' 
-GRAPHDB_REPO_URI = 'https://graphdb.gsq.digital/repositories/{}'.format(GRAPHDB_REPO_ID) 
-GRAPHDB_LOAD_DATA_URI = 'https://graphdb.gsq.digital/rest/data/import/upload/{}/url'.format(GRAPHDB_REPO_ID) 
-GRAPHDB_USR = 'graphdb_username'
-GRAPHDB_PWD = 'graphdb_password'
+GRAPHDB_REPO_ID = 'vocabs'
+GRAPHDB_REPO_URI = 'http://localhost:7200/repositories/{}'.format(GRAPHDB_REPO_ID)
+GRAPHDB_LOAD_DATA_URI = 'http://localhost:7200/rest/data/import/upload/{}/url'.format(GRAPHDB_REPO_ID)
+GRAPHDB_USR = ''
+GRAPHDB_PWD = ''
 
 GITHUB_RAW_URI_BASE = 'https://raw.githubusercontent.com/geological-survey-of-queensland/vocabularies/master/vocabularies/'
 

--- a/vocabularies/depth-reference.ttl
+++ b/vocabularies/depth-reference.ttl
@@ -1,14 +1,10 @@
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix drd: <http://linked.data.gov.au/def/depth-reference-datum/> .
+@prefix drd: <http://linked.data.gov.au/def/depth-reference/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://linked.data.gov.au/def/depth-reference-datum> a owl:Ontology , skos:ConceptScheme ;
+<http://linked.data.gov.au/def/depth-reference> a owl:Ontology , skos:ConceptScheme ;
     dct:creator "Geological Survey of Queensland" ;
     dct:modified "2020-01-21T11:03:47"^^xsd:dateTime,
         "2020-01-28T11:44:20"^^xsd:dateTime ;
@@ -24,17 +20,17 @@
         drd:seismic-reference-datum,
         drd:water-bottom,
         drd:well-head ;
-    skos:prefLabel "Depth Reference Datum"@en .
+    skos:prefLabel "Depth Reference"@en .
     
 drd:absolute a skos:Collection ;
-    skos:definition "A datum that describes an absolute plane of reference at a global or regional scale."@en ;
+    skos:definition "A reference that describes an absolute plane of depth at a global or regional scale."@en ;
     skos:member drd:australian-height-datum,
         drd:mean-sea-level,
         drd:metres-sub-sea ;
     skos:prefLabel "Absolute"@en .
 
 drd:borehole a skos:Collection ;
-    skos:definition "A point datum to which measurements are referenced to in a borehole."@en ;
+    skos:definition "A point to which measurements are referenced to in a borehole."@en ;
     skos:member drd:drill-collar,
         drd:ground-level,
         drd:kelly-bushing,
@@ -44,7 +40,7 @@ drd:borehole a skos:Collection ;
     skos:prefLabel "Borehole"@en .
 
 drd:seismic a skos:Collection ;
-    skos:definition "A reference datum relating to time based measurements and datasets, such as seismic surveys. Reported in a unit of measure of time."@en ;
+    skos:definition "A reference relating to time based measurements and datasets, such as seismic surveys. Reported in a unit of measure of time."@en ;
     skos:member drd:seismic-reference-datum ;
     skos:prefLabel "Seismic"@en .
 
@@ -59,68 +55,68 @@ drd:australian-height-datum a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
     skos:notation "AHD" ;
     skos:prefLabel "Australian Height Datum"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:drill-collar a skos:Concept ;
     skos:definition "A component of a drillstring that provides weight on bit for drilling. Drill collars are thick-walled tubular pieces machined from solid bars of steel or alloy. Source: Schlumberger Oilfield Glossary"@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "DC" ;
     skos:prefLabel "Drill Collar"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:kelly-bushing a skos:Concept ;
     skos:definition "An adapter that serves to connect the rotary table to the kelly (A long square or hexagonal steel bar with a hole drilled through the middle for a fluid path).Source: Schlumberger Oilfield Glossary"@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "KB" ;
     skos:prefLabel "Kelly Bushing"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:mean-sea-level a skos:Concept ;
     skos:definition "The elevation (on the ground) or altitude (in the air) of an object, relative to the average sea level."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "MSL" ;
     skos:prefLabel "Mean Sea Level"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:metres-sub-sea a skos:Concept ;
     skos:definition "The distance below mean sea level, the inverse of measurements to Mean Sea Level."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "MSS" ;
     skos:prefLabel "Metres Sub-Sea"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:rotary-table a skos:Concept ;
     skos:definition "The revolving or spinning section of the drillfloor that provides power to turn the drillstring in a clockwise direction (as viewed from above).Source: Schlumberger Oilfield Glossary"@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "RT" ;
     skos:prefLabel "Rotary Table"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:seismic-reference-datum a skos:Concept ;
     skos:definition "The SRD is a plane that sits above the highest elevation in the data. In a land project with a seismic reference datum set, the SRD will have a time of 0 ms. All time data, e.g. seismic and velocities, will start at this datum."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "SRD" ;
     skos:prefLabel "Seismic Reference Datum"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:ground-level a skos:Concept ;
     skos:definition "Ground level elevation without additional equipment"@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "GL" ;
     skos:prefLabel "Ground Level"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:water-bottom a skos:Concept ;
     skos:definition "The depth of the interface between water and solid substrate, such as the sea bed or the bottom of a terrestrial body of water."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "WB" ;
     skos:prefLabel "Water Bottom"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 
 drd:well-head a skos:Concept ;
     skos:definition "A wellhead is the component at the surface of an oil or gas well that provides the structural and pressure-containing interface for the drilling and production equipment. Iolation valves and choke equipment control the flow of well fluids during production. Elevation is typically equivalent to the valve or outlet point from which samples are extracted."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/depth-reference-datum> ;
+    skos:inScheme <http://linked.data.gov.au/def/depth-reference> ;
     skos:notation "WH" ;
     skos:prefLabel "Well Head"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference-datum> .
+    skos:topConceptOf <http://linked.data.gov.au/def/depth-reference> .
 

--- a/vocabularies/depth-reference.ttl
+++ b/vocabularies/depth-reference.ttl
@@ -23,7 +23,7 @@
     skos:prefLabel "Depth Reference"@en .
     
 drd:absolute a skos:Collection ;
-    skos:definition "A reference that describes an absolute plane of depth at a global or regional scale."@en ;
+    skos:definition "A fixed plane or point that describes an absolute reference for depth observations."@en ;
     skos:member drd:australian-height-datum,
         drd:mean-sea-level,
         drd:metres-sub-sea ;


### PR DESCRIPTION
I've removed the "-datum" part of the URI and Datum from the vocab name since not all of the depth references contained are Datums: some are reference points.

I think `/def/depth-reference` will work much better as a vocab URI as it would be open to other references and doesn't indicate a restriction to datums that isn't supported by the vocab.