### PR TITLE
GeoSPARQL alignment; SHACL validation fixes

### DIFF
--- a/vocabularies/site-relationships.ttl
+++ b/vocabularies/site-relationships.ttl
@@ -1,18 +1,20 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix strel: <http://linked.data.gov.au/def/site-relationships/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://linked.data.gov.au/def/site-relationships> a owl:Ontology , skos:ConceptScheme ;
-    dct:creator "Geological Survey of Queensland" ;
-    dct:modified "2020-01-21T15:45:34"^^xsd:dateTime,
-        "2020-01-21T15:51:19"^^xsd:dateTime ;
-    dct:source "Compiled by the Geological Survey of Queensland" ;
+    dcterms:creator <http://linked.data.gov.au/org/gsq> ;
+    dcterms:created "2020-01-21T15:45:34"^^xsd:dateTime ;
+    dcterms:modified "2020-05-07T23:13:00"^^xsd:dateTime ;
+    dcterms:publisher <http://linked.data.gov.au/org/gsq> ;    
+    dcterms:source "Compiled by the Geological Survey of Queensland" ;
     skos:definition "The relationships between sites both topological and functional."@en ;
     skos:hasTopConcept strel:above,
         strel:below,
@@ -22,15 +24,21 @@
         strel:disjoint,
         strel:equals,
         strel:injection-extraction-pair,
-        strel:meets,
+        strel:touches,
         strel:observation,
-        strel:overlaps,
+        strel:intersects,
         strel:parent,
         strel:re-entry,
         strel:redrill,
         strel:twinned,
         strel:well-pad ;
     skos:prefLabel "Site Relationships"@en .
+
+<http://linked.data.gov.au/org/gsq>
+    a sdo:Organization ;
+    sdo:name "Geological Survey of Queensland" ;
+    sdo:url <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq> ;
+.
 
 strel:borehole a skos:Collection ;
     skos:definition "Relationships between associated boreholes and boreholes with other operational sites such as well pads."@en ;
@@ -52,7 +60,7 @@ strel:interval a skos:Collection ;
         strel:disjoint,
         strel:equals,
         strel:meets,
-        strel:overlaps ;
+        strel:intersects ;
     skos:prefLabel "Interval"@en .
 
 strel:topological a skos:Collection ;
@@ -61,7 +69,7 @@ strel:topological a skos:Collection ;
         strel:covers,
         strel:disjoint,
         strel:equals,
-        strel:meets,
+        strel:touches,
         strel:overlaps ;
     skos:prefLabel "Topological"@en .
 
@@ -136,6 +144,7 @@ strel:contains a skos:Concept ;
     skos:definition "Object A contains object B, and the boundaries do not intersect."@en ;
     skos:inScheme <http://linked.data.gov.au/def/site-relationships> ;
     skos:prefLabel "Contains"@en ;
+    skos:scopeNote "Use of strel:contains in a ternary relationship (A related_to B, related_to of type strel:contains) entails A geo:sfContains B" ;
     skos:topConceptOf <http://linked.data.gov.au/def/site-relationships> .
 
 strel:covers a skos:Concept ;
@@ -148,23 +157,28 @@ strel:disjoint a skos:Concept ;
     skos:definition "There is no intersection area between object A and object B."@en ;
     skos:inScheme <http://linked.data.gov.au/def/site-relationships> ;
     skos:prefLabel "Disjoint"@en ;
+    skos:scopeNote "Use of strel:disjoint in a ternary relationship (A related_to B, related_to of type strel:disjoint) entails A geo:sfDisjoint B" ;
     skos:topConceptOf <http://linked.data.gov.au/def/site-relationships> .
 
 strel:equals a skos:Concept ;
     skos:definition "Object B and object A match."@en ;
     skos:inScheme <http://linked.data.gov.au/def/site-relationships> ;
     skos:prefLabel "Equals"@en ;
+    skos:scopeNote "Use of strel:equals in a ternary relationship (A related_to B, related_to of type strel:equals) entails A geo:sfEquals B" ;
     skos:topConceptOf <http://linked.data.gov.au/def/site-relationships> .
 
-strel:meets a skos:Concept ;
-    skos:altLabel "Touches"@en ;
-    skos:definition "Object A and object B meet at the boundary."@en ;
+strel:touches a skos:Concept ;
+    skos:altLabel "Meets"@en ;
+    skos:definition "Object A and object B touch at the boundary."@en ;
     skos:inScheme <http://linked.data.gov.au/def/site-relationships> ;
-    skos:prefLabel "Meets"@en ;
+    skos:prefLabel "Touches"@en ;
+    skos:scopeNote "Use of strel:touches in a ternary relationship (A related_to B, related_to of type strel:touches) entails A geo:sfTouches B" ;
     skos:topConceptOf <http://linked.data.gov.au/def/site-relationships> .
 
-strel:overlaps a skos:Concept ;
-    skos:definition "Object A and object B overlap."@en ;
+strel:intersects a skos:Concept ;
+    skos:altLabel "Overlaps"@en ;
+    skos:definition "Object A and B intersect spatially."@en ;
     skos:inScheme <http://linked.data.gov.au/def/site-relationships> ;
-    skos:prefLabel "Overlaps"@en ;
+    skos:prefLabel "Intersects"@en ;
+    skos:scopeNote "Use of strel:intersects in a ternary relationship (A related_to B, related_to of type strel:intersects) entails A geo:sfIntersects B" ;
     skos:topConceptOf <http://linked.data.gov.au/def/site-relationships> .


### PR DESCRIPTION
1. Alignment of spatial terms with GeoSPARQL's Simple Features relationships
    - using skos:scopeNote to explain the relationship (same names so easy)
    - two Concpets' name changes to align with GeoSPARQL naming

2. Update to vocab metadata to pass SHACL validation 
    - creator & pubisher URIs for GSQ, not text