### PR TITLE
Update sample-type.ttl

### DIFF
--- a/vocabularies/sample-type.ttl
+++ b/vocabularies/sample-type.ttl
@@ -9,9 +9,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://linked.data.gov.au/def/sample-type> a owl:Ontology , skos:ConceptScheme ;
-    dct:created "2020-02-07T11:44:02"^^xsd:dateTime ;
-    dct:creator "Geological Survey of Queensland" ;
-    dct:modified "2020-02-08T09:59:08"^^xsd:dateTime ;
+    dct:created "2020-02-07"^^xsd:date ;
+    dct:creator <http://linked.data.gov.au/org/gsq> ;
+    dct:modified "2020-05-13"^^xsd:date ;
+    dct:publisher <http://linked.data.gov.au/org/gsq> ;
     dct:source "Compiled by the Geological Survey of Queensland" ;
     skos:definition "Types of sample used in Geoscience."@en ;
     skos:hasTopConcept sampty:blasted-sample,
@@ -22,6 +23,8 @@
         sampty:composited-cuttings,
         sampty:continuous-channel-sample,
         sampty:core,
+        sampty:core-plug,
+        sampty:crushed-rock,
         sampty:cuttings,
         sampty:deviation-log,
         sampty:drill-fluid,
@@ -40,6 +43,7 @@
         sampty:pan-concentrate,
         sampty:petrophysical-log,
         sampty:photograph,
+        sampty:polished-block,
         sampty:powdered-chip,
         sampty:random-dump-sample,
         sampty:random-sample,
@@ -122,6 +126,22 @@ sampty:core a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-type> ;
     skos:notation "CORE" ;
     skos:prefLabel "Core"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-type> .
+
+sampty:core-plug a skos:Concept ;
+    skos:definition "A plug, or sample, taken from a core sample for analysis."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-type> ;
+    skos:notation "PLUG" ;
+    skos:prefLabel "Core Plug"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-type> .
+
+sampty:crushed-rock a skos:Concept ;
+    skos:definition "A sample of rock that has been artificially crushed, milled, or ground."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-type> ;
+    skos:notation "CRUSH" ;
+    skos:altLabel "Milled rock"@en,
+        "Ground Rock"@en ;
+    skos:prefLabel "Crushed Rock"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-type> .
 
 sampty:cuttings a skos:Concept ;
@@ -228,6 +248,7 @@ sampty:oriented-sample a skos:Concept ;
     skos:definition "Sample collected with orientation recorded for detailed structural geology analysis"@en ;
     skos:inScheme <http://linked.data.gov.au/def/sample-type> ;
     skos:notation "OSAMP" ;
+    skos:altLabel "Oriented Section"@en ;
     skos:prefLabel "Oriented Sample"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-type> .
 
@@ -250,6 +271,13 @@ sampty:photograph a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-type> ;
     skos:notation "PHGR" ;
     skos:prefLabel "Photograph"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-type> .
+
+sampty:polished-block a skos:Concept ;
+    skos:definition "Rock samples that are bonded in epoxy and polished as small round blocks for reflected light microscopy."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-type> ;
+    skos:notation "PBLK" ;
+    skos:prefLabel "Polished Block"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-type> .
 
 sampty:powdered-chip a skos:Concept ;
@@ -391,4 +419,3 @@ sampty:petrophysical-log a skos:Concept ;
     skos:notation "PETL" ;
     skos:prefLabel "Petrophysical Log"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-type> .
-


### PR DESCRIPTION
closes #212 

core plug, crushed rock, and polished block added
oriented section added as an alias to oriented sample. 

The other relevant changes as follows

**core-plug**
definition "A plug, or sample, taken from a core sample for analysis."
 preferred name "Core Plug"

**crushed-rock**
definition: "A sample of rock that has been artificially crushed, milled, or ground."@en ;
aliases  "Milled rock", "Ground Rock"
 preferred name "Crushed Rock"

**polished-block**
 definition "Rock samples that are bonded in epoxy and polished as small round blocks for reflected light microscopy."
 preferred name"Polished Block"
