### PR TITLE
Update sample-material.ttl

### DIFF
--- a/vocabularies/sample-material.ttl
+++ b/vocabularies/sample-material.ttl
@@ -106,12 +106,11 @@ spmt:digital a skos:Concept ;
     skos:prefLabel "Digital"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
 
-spmt:drilling-fluid a skos:Concept ;
-    skos:broader spmt:fluid ;
-    skos:definition "Fluid used for drill bit lubrication and return of ground rock material from the drill bit, e.g. mud."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/drilling_fluid> ;
+spmt:aerated-mud a skos:Concept ;
+    skos:broader spmt:mud ;
+    skos:definition "Fluid consisting of a mud whose density has been decreased by the process of aeration. Typically used as a drilling fluid."@en ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Drilling Fluid"@en .
+    skos:prefLabel "Aerated Mud"@en .
 
 spmt:estuarine-water a skos:Concept ;
     skos:broader spmt:water ;
@@ -349,3 +348,13 @@ spmt:fluid a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Fluid"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+
+spmt:drilling-fluid a skos:Collection ;
+    skos:definition "Fluid used for drill bit lubrication and return of ground rock material from the drill bit, e.g. mud."@en ;
+    skos:member spmt:mud,
+        spmt:water,
+        spmt:aerated-mud,
+        spmt:foam,
+        spmt:mist,
+        spmt:air ;
+    skos:prefLabel "Drilling Fluid"@en .


### PR DESCRIPTION
Drill fluid removed as a concept and added as a collection of actual fluid types (mud, air, water, foam etc) i.e. drill fluid is not _really_ a fluid type in the sense of composition, it is just a functional category of certain fluids.
Addition of concept 'aerated mud' as type of fluid in alignment with possible values in P&G reporting templates