### PR TITLE
Update georesources-report-types.ttl

### DIFF
--- a/vocabularies/georesources-report-types.ttl
+++ b/vocabularies/georesources-report-types.ttl
@@ -242,50 +242,56 @@ grt:mine-plan-lodgement a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-annual a skos:Concept ;
-    skos:altLabel "Annual Resource Authority Report"@en ;
+    skos:altLabel "Annual Resource Authority Report"@en,
+        "Permit Report - Annual"@en ;
     skos:definition "A report that is required to be lodged annually as a part of the obligations of holding tenure over a resource permit."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "ANNUAL" ;
-    skos:prefLabel "Permit Report - Annual"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Annual"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-final a skos:Concept ;
-    skos:altLabel "Final or End of Tenure Report"@en ;
+    skos:altLabel "Final or End of Tenure Report"@en,
+        "Permit Report - Final"@en ;
     skos:definition "A report that is required to be lodged when the tenure over a resource permit ends, detailing the work undertaken on the permit throughout the life of tenure."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "FINAL" ;
-    skos:prefLabel "Permit Report - Final"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Final"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-final-relinquishment a skos:Concept ;
-    skos:altLabel "Final Relinquishment (MDL)"@en ;
+    skos:altLabel "Final Relinquishment (MDL)"@en,
+        "Permit Report - Final Relinquishment"@en ;
     skos:definition "A report that is required to be lodged when the tenure over a Mineral Development License ends, detailing the work undertaken on the permit throughout the life of tenure."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "FINREQ" ;
-    skos:prefLabel "Permit Report - Final Relinquishment"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Final Relinquishment (MDL)"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-other a skos:Concept ;
-    skos:altLabel "Any Other Resource Authority Report"@en ;
+    skos:altLabel "Any Other Resource Authority Report"@en,
+        "Permit Report - Other"@en ;
     skos:definition "A report that does not fall under any other category of permit reports."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
-    skos:prefLabel "Permit Report - Other"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Other"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-partial-relinquishment a skos:Concept ;
-    skos:altLabel "Partial Relinquishment Report"@en ;
+    skos:altLabel "Partial Relinquishment Report"@en,
+        "Permit Report - Partial Relinquishment"@en ;
     skos:definition "A report detailing all the activities a holder has undertaken on a specific region of an exploration permit that has been relinquished. As required by the Mineral Resources Act and as defined by the Reporting Guidelines."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "RELINQ" ;
-    skos:prefLabel "Permit Report - Partial Relinquishment"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Partial Relinquishment"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-mineral-associated-water a skos:Concept ;
-    skos:altLabel "Mineral Associated Water"@en ;
+    skos:altLabel "Mineral Associated Water"@en,
+        "Permit Report - Mineral Associated Water"@en ;
     skos:definition "A report detailing the total water produced from a Mining Lease, defined as per the Mineral Resources Act."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "MINAW" ;
-    skos:prefLabel "Permit Report - Mineral Associated Water"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Mineral Associated Water"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-six-month a skos:Concept ;
@@ -297,11 +303,12 @@ grt:permit-report-six-month a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-surrender a skos:Concept ;
-    skos:altLabel "Surrender Report"@en ;
+    skos:altLabel "Surrender Report"@en,
+        "Permit Report - Surrender"@en ;
     skos:definition "A report that is required to be lodged as a part of the obligations of surrendering tenure over a Coal or Oil Shale Mining Lease. Defined in detail as a part of the Reporting Guidelines."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "SURR" ;
-    skos:prefLabel "Permit Report - Surrender"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Surrender"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:petroleum-report-cumulative-water-production a skos:Concept ;


### PR DESCRIPTION
closes #235 

Systematic Changes to Permit Report Labels to enhance lodgement portal user experience
**SMEs/Authors of issue** @SalEdwards01 @MicaelaPreda 
**Vocab owner** @GSQ-AI 
**Product owner** @LukeHauck 
**Business Systems Rep** @AdrianStead 
**Tech Check** @DavidCrosswellGSQ 

FYI - UAT Coordinator @lisa-woody 

Moved existing Preferred Labels to Alternate Labels
And duplicated as preferred labels with prefix "Coal or Mineral"
e.g.

Original

```
grt:permit-report-annual a skos:Concept ;
    skos:altLabel "Annual Resource Authority Report"@en ;
    skos:definition "A report that is required to be lodged annually as a part of the obligations of holding tenure over a resource permit."@en ;
    skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
    skos:notation "ANNUAL" ;
    skos:prefLabel "Permit Report - Annual"@en ;
    skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
```

to

```
grt:permit-report-annual a skos:Concept ;
    skos:altLabel "Annual Resource Authority Report"@en,
        "Permit Report - Annual"@en ;
    skos:definition "A report that is required to be lodged annually as a part of the obligations of holding tenure over a resource permit."@en ;
    skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
    skos:notation "ANNUAL" ;
    skos:prefLabel "Coal or Mineral Permit Report - Annual"@en ;
    skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
```