### PR TITLE
Update geologic-feature-types.ttl

### DIFF
--- a/vocabularies/geologic-feature-types.ttl
+++ b/vocabularies/geologic-feature-types.ttl
@@ -338,6 +338,13 @@ geof:Horst a skos:Concept ;
     skos:notation "gfhrt" ;
     skos:prefLabel "horst"@en .
 
+geof:IgneousAssociation a skos:Concept ;
+    skos:broader geof:TectonicEntity ;
+    skos:definition "An association of igneous rocks where their differentiation is uncertain, because the geodynamic environment of their magmatism is not well understood."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
+    skos:notation "gf???" ;
+    skos:prefLabel "igneous association"@en .
+
 geof:IgneousProvince a skos:Concept ;
     dcterms:source <http://www.glossaryofgeology.org> ;
     skos:broader geof:TectonicEntity ;
@@ -345,6 +352,13 @@ geof:IgneousProvince a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
     skos:notation "gfigp" ;
     skos:prefLabel "igneous province"@en .
+
+geof:IgneousSubprovince a skos:Concept ;
+    skos:broader geof:TectonicEntity ;
+    skos:definition "To be provided later, as there is a dliemma here with Igneous Associations and daughter subprovinces."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
+    skos:notation "gf???" ;
+    skos:prefLabel "igneous subprovince"@en .
 
 geof:Inlier a skos:Concept ;
     dcterms:source <http://www.glossaryofgeology.org> ;
@@ -528,6 +542,14 @@ geof:PresentContinent a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
     skos:prefLabel "present continent"@en .
 
+geof:Province a skos:Concept ;
+    skos:broader geof:TectonicEntity ;
+    skos:definition "A geologic province is a spatial entity with common geologic attributes, comprising a large area or region, which, considered as a whole, is characterised by similar geologic features or by a geologic history differing significantly from that of adjacent areas. (Modified from: Neuendorf et al. 2011; Geoscience Australia, USGS & Wikipedia, all accessed 13.05.2020)."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
+    skos:notation "gf???" ;
+    skos:prefLabel "Province"@en .
+    skos:scopeNote "A geologic province may include a single dominant tectonic/structural entity such as a sedimentary basin or an association of genetically-related basins, but otherwise craton (including shields and platforms) or orogen, as well as specified types of provinces (viz., mineral province, igneous province, large igneous province, tectonised/metamorphosed province, extended-crust province) that are individually defined by a complex history of tectonics, metamorphism, magmatism and/or metallogenesis. A province may be divided into two or more subprovinces that may be further divided into geologic domains."@en ;
+
 geof:RangeZone a skos:Concept ;
     dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
     skos:broader geof:BiostratigraphicUnit ;
@@ -560,6 +582,21 @@ geof:SeismicProvince a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
     skos:notation "gfssp" ;
     skos:prefLabel "seismic province"@en .
+
+geof:Subprovince a skos:Concept ;
+    skos:broader geof:TectonicEntity ;
+    skos:definition "One of two or more divisions of a province, based on differences in geological character."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
+    skos:notation "gf???" ;
+    skos:prefLabel "Subprovince"@en .
+
+geof:Superprovince a skos:Concept ;
+    skos:broader geof:TectonicEntity ;
+    skos:definition "A grouping of two or more like geologic provinces."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
+    skos:notation "gf???" ;
+    skos:prefLabel "Superprovince"@en .
+    skos:scopeNote "This highest-level root term was introduced by Mortimer et al. (2014), as the Austral Superprovince, to encompass all rocks of New Zealand’s Eastern Province and Western Province basement (providing a single stratigraphic search term for basement rocks in digital databases). In Queensland, for example, the term has application with the Tasmanides Orogenic Collage, the Great Australian Superbasin, and the Centralian Superbasin."@en ;
 
 geof:SequenceStratigraphicUnit a skos:Concept ;
     dcterms:source <https://doi.org/10.1080/11035897.2016.1178666>,

--- a/vocabularies/geologic-feature-types.ttl
+++ b/vocabularies/geologic-feature-types.ttl
@@ -342,7 +342,7 @@ geof:IgneousAssociation a skos:Concept ;
     skos:broader geof:TectonicEntity ;
     skos:definition "An association of igneous rocks where their differentiation is uncertain, because the geodynamic environment of their magmatism is not well understood."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
-    skos:notation "gf???" ;
+    skos:notation "gfiga" ;
     skos:prefLabel "igneous association"@en .
 
 geof:IgneousProvince a skos:Concept ;
@@ -941,4 +941,3 @@ geof:StructuralFeature a skos:Concept ;
         [ ] ;
     prof:isProfileOf <http://sweetontology.net/realmGeol> ;
     sdo:codeRepository <https://github.com/geological-survey-of-queensland/geologic-features-ont> .
-

--- a/vocabularies/geologic-feature-types.ttl
+++ b/vocabularies/geologic-feature-types.ttl
@@ -594,7 +594,7 @@ geof:Superprovince a skos:Concept ;
     skos:broader geof:TectonicEntity ;
     skos:definition "A grouping of two or more like geologic provinces."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
-    skos:notation "gf???" ;
+    skos:notation "gfspp" ;
     skos:prefLabel "Superprovince"@en .
     skos:scopeNote "This highest-level root term was introduced by Mortimer et al. (2014), as the Austral Superprovince, to encompass all rocks of New Zealand’s Eastern Province and Western Province basement (providing a single stratigraphic search term for basement rocks in digital databases). In Queensland, for example, the term has application with the Tasmanides Orogenic Collage, the Great Australian Superbasin, and the Centralian Superbasin."@en ;
 

--- a/vocabularies/geologic-feature-types.ttl
+++ b/vocabularies/geologic-feature-types.ttl
@@ -587,7 +587,7 @@ geof:Subprovince a skos:Concept ;
     skos:broader geof:TectonicEntity ;
     skos:definition "One of two or more divisions of a province, based on differences in geological character."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
-    skos:notation "gf???" ;
+    skos:notation "gfsbp" ;
     skos:prefLabel "Subprovince"@en .
 
 geof:Superprovince a skos:Concept ;

--- a/vocabularies/geologic-feature-types.ttl
+++ b/vocabularies/geologic-feature-types.ttl
@@ -546,7 +546,7 @@ geof:Province a skos:Concept ;
     skos:broader geof:TectonicEntity ;
     skos:definition "A geologic province is a spatial entity with common geologic attributes, comprising a large area or region, which, considered as a whole, is characterised by similar geologic features or by a geologic history differing significantly from that of adjacent areas. (Modified from: Neuendorf et al. 2011; Geoscience Australia, USGS & Wikipedia, all accessed 13.05.2020)."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
-    skos:notation "gf???" ;
+    skos:notation "gfprv" ;
     skos:prefLabel "Province"@en .
     skos:scopeNote "A geologic province may include a single dominant tectonic/structural entity such as a sedimentary basin or an association of genetically-related basins, but otherwise craton (including shields and platforms) or orogen, as well as specified types of provinces (viz., mineral province, igneous province, large igneous province, tectonised/metamorphosed province, extended-crust province) that are individually defined by a complex history of tectonics, metamorphism, magmatism and/or metallogenesis. A province may be divided into two or more subprovinces that may be further divided into geologic domains."@en ;
 

--- a/vocabularies/geologic-feature-types.ttl
+++ b/vocabularies/geologic-feature-types.ttl
@@ -357,7 +357,7 @@ geof:IgneousSubprovince a skos:Concept ;
     skos:broader geof:TectonicEntity ;
     skos:definition "To be provided later, as there is a dliemma here with Igneous Associations and daughter subprovinces."@en ;
     skos:inScheme <http://linked.data.gov.au/def/geofeatures> ;
-    skos:notation "gf???" ;
+    skos:notation "gfisp" ;
     skos:prefLabel "igneous subprovince"@en .
 
 geof:Inlier a skos:Concept ;


### PR DESCRIPTION
I hope that these changes suffice.
Note:
1. I have not inserted skos notations
2. The definition of an igneous subprovince is outstanding (i.e. none provided, not otherwise)
3. Ridge was included previously (see definition), but I am thinking that ridge refers to a basement ridge and should be modified accordingly. Advice please.
4. I have not included:

•	OBSOLETE (MERLIN)
Obsolete
Structural unit terms that are considered to be obsolete and have been superceded by other terms.
Scope:Note: It has never been possible to delete records/terms from authority tables, and flagging a term as being obsolete is necessary. Care should be taken in deleting a record because it may have been linked to in Surface Geology.

•	MISC (MERLIN)
Not to be used. Do not include in ttl.
Terms in MERLIN that fell here (only three) have been now flagged as MISC (by Ian).

•	NOTQLD (MERLIN)
Forget for the moment: Not in Qld.
Comment from Ian: What is not obvious is why they are in the table at all. There are 11 of these, and include things like Otway basin, Bonaparte basin, Canning Basin etc. All are petroleum basins and possibly were in the codes that came across to CPF_STRUCTURAL_UNITS from the old QPED database that was migrated to BOREHOLE. Check if they are needed in BOREHOLE and if not delete them and the code.

 Should I do so??