### PR TITLE
Filesize fix, warnings for auth and problematic graphs

### DIFF
--- a/scripts/config-template-production.py
+++ b/scripts/config-template-production.py
@@ -10,3 +10,4 @@ GITHUB_RAW_URI_BASE = 'https://raw.githubusercontent.com/geological-survey-of-qu
 
 GITHUB_USR = 'github_username'  # or any valid GitHub account
 GITHUB_PWD = 'github_password'  # for the valid GitHub account
+GITHUB_TOKEN = 'github_personal_access_token' # recommended for use from 2020, not user/pass

--- a/scripts/vocabs_load.py
+++ b/scripts/vocabs_load.py
@@ -136,7 +136,11 @@ def load_all_vocabs_details_from_github():
     """
     print('Loading all vocabs from GitHub')
     print("Vocabs to be uploaded:")
-    gh = Github(config.GITHUB_USR, config.GITHUB_PWD)
+    if config.GITHUB_USR:
+        print("Using passwords will be deprecated in Nov 2020, try to use a personal token instead")
+        gh = Github(config.GITHUB_USR, config.GITHUB_PWD)
+    else:
+        gh = Github(config.GITHUB_TOKEN)
     repo = gh.get_repo("geological-survey-of-queensland/vocabularies")
     contents = repo.get_contents("vocabularies")
     c = 0

--- a/scripts/vocabs_load.py
+++ b/scripts/vocabs_load.py
@@ -175,6 +175,10 @@ def load_all_vocabs_details_from_github():
                         skos:prefLabel ?pl .
                 }
             '''
+            if not g.query(q):
+                print("There was an error parsing or querying the graph. " 
+                      "Ensure it contains 'a owl:Ontology' and 'skos:prefLabel'")
+
             for r in g.query(q):
                 vocabs[fn] = {
                     "context_uri": str(r["uri"]),


### PR DESCRIPTION
Fixes for the 1MB filesize limit, so minerals.ttl will work.
Added a warning when a graph is not being imported due to missing values.
Added warning for using user/pass instead of token authentication.