### PR TITLE
update purpose to align with migration requirements

### DIFF
--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -98,12 +98,6 @@ bhpur:non-industry a skos:Concept ;
     skos:prefLabel "Non-Industry"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
-bhpur:stratigraphic a skos:Concept ;
-    skos:broader bhpur:non-industry ;
-    skos:definition "Non-industry wells and bores drilled to establish the stratigraphic units present at a site"@en ;
-    skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
-    skos:prefLabel "Stratigraphic"@en .
-
 bhpur:oil-shale a skos:Concept ;
     skos:definition "Wells and bores drilled to facilitate the mining of oil shale under permits governed by the Queensland Mineral Resources Act (1989)"@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;

--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -8,14 +8,14 @@
 <http://linked.data.gov.au/def/borehole-purpose> a owl:Ontology , skos:ConceptScheme ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2020-01-21T13:24:10"^^xsd:dateTime ;
+    dcterms:modified "2020-06-17T11:30:10"^^xsd:dateTime ;
     dcterms:created "2020-01-21T09:40:39"^^xsd:dateTime ;
     dcterms:source "Compiled by the Geological Survey of Queensland" ;
     skos:definition "The primary purpose of a borehole based on the legislative State Act and/or the resources industry sector."@en ;
     skos:hasTopConcept bhpur:coal,
         bhpur:geothermal,
         bhpur:greenhouse-gas-storage,
-        bhpur:minerals,
+        bhpur:mineral,
         bhpur:non-industry,
         bhpur:oil-shale,
         bhpur:petroleum,
@@ -86,10 +86,10 @@ bhpur:geothermal a skos:Concept ;
     skos:prefLabel "Geothermal"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
-bhpur:minerals a skos:Concept ;
+bhpur:mineral a skos:Concept ;
     skos:definition "Wells and bores drilled to facilitate the mining of minerals, excluding coal and oil shale, under permits governed by the Queensland Mineral Resources Act (1989)"@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
-    skos:prefLabel "Minerals"@en ;
+    skos:prefLabel "Mineral"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
 bhpur:non-industry a skos:Concept ;
@@ -97,6 +97,12 @@ bhpur:non-industry a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
     skos:prefLabel "Non-Industry"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
+
+bhpur:stratigraphic a skos:Concept ;
+    skos:broader bhpur:stratigraphic ;
+    skos:definition "Non-industry wells and bores drilled to establish the stratigraphic units present at a site"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
+    skos:prefLabel "Stratigraphic"@en .
 
 bhpur:oil-shale a skos:Concept ;
     skos:definition "Wells and bores drilled to facilitate the mining of oil shale under permits governed by the Queensland Mineral Resources Act (1989)"@en ;

--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -130,7 +130,6 @@ bhpur:coal a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
 bhpur:petroleum a skos:Concept ;
-    skos:altLabel "Coal Seam Gas"@en ;
     skos:definition "Wells and bores drilled under permits governed by the Queensland Petroleum Act (1923)"@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
     skos:prefLabel "Petroleum"@en ;

--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -99,7 +99,7 @@ bhpur:non-industry a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
 bhpur:stratigraphic a skos:Concept ;
-    skos:broader bhpur:stratigraphic ;
+    skos:broader bhpur:non-industry ;
     skos:definition "Non-industry wells and bores drilled to establish the stratigraphic units present at a site"@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
     skos:prefLabel "Stratigraphic"@en .


### PR DESCRIPTION
added 'stratigraphic' as a concept under non-industry. 
removed the 's' from 'minerals' to align with the source in merlin

These concepts are needed to address migration errors where some purposes weren't coming across. This PR will partly resolve [JIRA ticket  #GDT-286](https://sra-it.atlassian.net/projects/GDT/issues/GDT-286)

@KellyVance pls review as the author and merge when approved
@LizDerrington pls review as the vocab owner
@LukeHauck tech check pls
@lisa-woody fyi 