### PR TITLE
Update sample-relationship.ttl

### DIFF
--- a/vocabularies/sample-relationship.ttl
+++ b/vocabularies/sample-relationship.ttl
@@ -7,40 +7,38 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://linked.data.gov.au/def/sample-relationship> a owl:Ontology , skos:ConceptScheme ;
-    dcterms:created "2020-03-24T09:03:21"^^xsd:dateTime ;
+    dcterms:created "2020-03-24"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2020-03-24T09:03:21"^^xsd:dateTime ;
+    dcterms:modified "2020-06-23"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:source "Source information from https://www.w3.org/TR/vocab-ssn/#Sample_Relations and the SOSA Extensions ontology, modified by the Geological Survey of Queensland." ;
-    skos:definition """Relationships between Samples.
-
-This vocabulary is derived from the SOSA Ontology and the SOSA Extensions Ontology where the Samples are defined by the class sosa:Sample and the relationships are OWL objectProperties. It reuses the original ontology URIs directly and retains the relationship's non-SKSO properties too so it is a SKOS+ ontology (SKOS + other things)."""@en ;
+    skos:definition """Relationships between Samples. This vocabulary is derived from the SOSA Ontology and the SOSA Extensions Ontology where the Samples are defined by the class sosa:Sample and the relationships are OWL objectProperties. It reuses the original ontology URIs directly and retains the relationship's non-SKSO properties too so it is a SKOS+ ontology (SKOS + other things)."""@en ;
     skos:hasTopConcept
-        sosa:hasSample ,
+        #sosa:hasSample ,
         sosa:isSampleOf ,
         sosa:hasOriginalSample ;
-    skos:prefLabel "Sample Relationship"@en ;
-.
+    skos:prefLabel "Sample Relationship"@en .
 
-<http://linked.data.gov.au/org/gsq> a sdo:Organization ;
+<http://linked.data.gov.au/org/gsq>
+    a sdo:Organization ;
     sdo:name "Geological Survey of Queensland" ;
     sdo:url <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq> .
 
-sosa:hasSample
-    a owl:ObjectProperty , skos:Concept ;
-    skos:prefLabel "has sample"@en ;
-    skos:definition "Relation between a FeatureOfInterest and the Sample used to represent it."@en ;
-    sdo:domainIncludes sosa:FeatureOfInterest ;
-    sdo:rangeIncludes sosa:Sample ;
-    owl:inverseOf sosa:isSampleOf ;
-    rdfs:isDefinedBy sosa: ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-relationship> ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-relationship> .
+#sosa:hasSample
+#    a owl:ObjectProperty , skos:Concept ;
+#    skos:prefLabel "has sample"@en ;
+#    skos:definition "Relation between a subject and a sample dervied from it."@en ;
+#    sdo:domainIncludes sosa:FeatureOfInterest ;
+#    sdo:rangeIncludes sosa:Sample ;
+#    owl:inverseOf sosa:isSampleOf ;
+#    rdfs:isDefinedBy sosa: ;
+#    skos:inScheme <http://linked.data.gov.au/def/sample-relationship> ;
+#    skos:topConceptOf <http://linked.data.gov.au/def/sample-relationship> .
 
 sosa:isSampleOf
     a owl:ObjectProperty , skos:Concept ;
     skos:prefLabel "is sample of"@en ;
-    skos:definition "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of."@en ;
+    skos:definition "Relation from a Sample to the entity that it was dervied from."@en ;
     sdo:domainIncludes sosa:Sample ;
     sdo:rangeIncludes sosa:FeatureOfInterest ;
     owl:inverseOf sosa:hasSample ;
@@ -53,15 +51,9 @@ sosa:hasOriginalSample
     skos:prefLabel "has original sample"@en ;
     sdo:domainIncludes sosa:Sample ;
     sdo:rangeIncludes sosa:Sample ;
-    skos:definition "A Link to the original sample that is related to the context sample through a chain of isSampleOf relations."@en ;
+    skos:definition "A link from the subject sample to the original sample of interest through a chain of isSampleOf relations."@en ;
     rdfs:domain sosa:Sample ;
     rdfs:range sosa:Sample ;
     skos:inScheme <http://linked.data.gov.au/def/sample-relationship> ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-relationship> .
 
-
-<http://linked.data.gov.au/org/gsq>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Queensland" ;
-    sdo:url <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq> ;
-.


### PR DESCRIPTION
Have commented out hasSample so we define where samples were derived from, and just infer the inverse.
Tidied up definitions to reference where samples are derived from rather than the [w3 definitions](https://www.w3.org/TR/vocab-ssn/#Sampling-specification) so we make no claims as to the representativeness of our samples, only their provenance. 
Have added skos:inscheme to concepts to ensure they render in VocPrez.

Further work may be needed to expand this in future.