### PR TITLE
Revert "vocab should use / URI, not # (my original mistake)"

### DIFF
--- a/vocabularies/trs.ttl
+++ b/vocabularies/trs.ttl
@@ -2,7 +2,7 @@
 # imports: http://www.w3.org/2004/02/skos/core
 # imports: http://www.w3.org/2006/time
 
-@prefix trs: <http://linked.data.gov.au/def/trs/> .
+@prefix trs: <http://linked.data.gov.au/def/trs#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .


### PR DESCRIPTION
Reverts geological-survey-of-queensland/vocabularies#293