### PR TITLE
Remove grt:survey-plan from lodgement portal collection

### DIFF
--- a/vocabularies/georesources-report-types.ttl
+++ b/vocabularies/georesources-report-types.ttl
@@ -776,7 +776,6 @@ grt:water-reports a skos:Collection ;
         grt:greenhouse-gas-report-storage-capacity,
         grt:greenhouse-gas-report-storage-injection,
         grt:mine-plan-lodgement,
-        grt:survey-plan,
         grt:permit-report-mineral-associated-water,
         grt:petroleum-report-cumulative-water-production,
         grt:petroleum-report-field-information,


### PR DESCRIPTION
There needs to be changes to this report before it can be used in Lodgement Portal (allow user to add multiple boreholes).

Turning off display of this in Lodgement Portal until this fix is deployed.