### PR TITLE
Update organisation-activity-status.ttl

### DIFF
--- a/vocabularies/organisation-activity-status.ttl
+++ b/vocabularies/organisation-activity-status.ttl
@@ -2,15 +2,18 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix oas: <http://linked.data.gov.au/def/organisation-activity-status/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdo: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://linked.data.gov.au/def/organisation-activity-status> a owl:Ontology,
         skos:ConceptScheme ;
     dcterms:created "2020-03-25"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2020-03-25"^^xsd:date ;
+    dcterms:modified "2020-08-21"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:source "Derived from Australian Standard AS4590.1:2017 and ASIC." ;
     skos:definition "Descriptions of the business activity of an organisation at a point in time."@en ;
@@ -25,20 +28,20 @@
     sdo:url <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq> .
 
 oas:strike-off-action-in-progress a skos:Concept ;
-    skos:definition "The organisation is being removed from the organisational register."@en ;
+    skos:definition "The organisation is being removed from the ASIC organisational register."@en ;
     skos:inScheme <http://linked.data.gov.au/def/organisation-activity-status> ;
     skos:notation "SOFF" ;
     skos:prefLabel "Strike off action in progress"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/organisation-activity-status> .
 
 oas:suspended-trading a skos:Concept ;
-    skos:definition "The organisation has suspended or has been suspended from trading on an exchange."@en ;
+    skos:definition "The organisation has suspended trading or has been suspended from trading on an exchange."@en ;
     skos:inScheme <http://linked.data.gov.au/def/organisation-activity-status> ;
     skos:prefLabel "Suspended Trading"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/organisation-activity-status> .
 
 oas:trading a skos:Concept ;
-    skos:definition "The organisation is being traded on an exchange."@en ;
+    skos:definition "The organisation is trading and carrying out business activities."@en ;
     skos:inScheme <http://linked.data.gov.au/def/organisation-activity-status> ;
     skos:prefLabel "Trading"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/organisation-activity-status> .


### PR DESCRIPTION
Fixed definitions to remove references to 'exchange' trading.
Covers non listed companies and orgs.