### PR TITLE
Addition of Country Vocabulary

### DIFF
--- a/vocabularies/countries.ttl
+++ b/vocabularies/countries.ttl
@@ -1,0 +1,8532 @@
+@prefix : <http://dd.eionet.europa.eu/property/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcmit: <http://purl.org/dc/dcmitype/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AD> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Andorra>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/AND>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AD>,
+        <http://publications.europa.eu/resource/authority/country/AND>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/AD>,
+        <http://rod.eionet.europa.eu/spatial/96>,
+        <http://sws.geonames.org/3041565/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AD" ;
+    skos:prefLabel "Andorra",
+        "Андора"@bg,
+        "Andorra"@cs,
+        "Andorra"@da,
+        "Andorra"@de,
+        "Ανδόρα"@el,
+        "Andorra"@en,
+        "Andorra"@es,
+        "Andorra"@et,
+        "Andorra"@fi,
+        "Andorre (l’)"@fr,
+        "Andóra"@ga,
+        "Andora"@hr,
+        "Andorra"@hu,
+        "Andorra"@it,
+        "Andora"@lt,
+        "Andora"@lv,
+        "Andorra"@mt,
+        "Andorra"@nl,
+        "Andora"@pl,
+        "Andorra"@pt,
+        "Andorra"@ro,
+        "Andorra"@sk,
+        "Andora"@sl,
+        "Andorra"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AE>,
+        <http://publications.europa.eu/resource/authority/country/ARE>,
+        <http://sws.geonames.org/290557/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AE" ;
+    skos:prefLabel "United Arab Emirates",
+        "Обединени арабски емирства"@bg,
+        "Spojené arabské emiráty"@cs,
+        "Forenede Arabiske Emirater, De"@da,
+        "die Vereinigten Arabischen Emirate"@de,
+        "Ενωμένα Αραβικά Εμιράτα"@el,
+        "United Arab Emirates"@en,
+        "Emiratos Árabes Unidos"@es,
+        "Araabia Ühendemiraadid"@et,
+        "Arabiemiirikunnat"@fi,
+        "Émirats arabes unis (les)"@fr,
+        "Aontas na nÉimíríochtaí Arabacha"@ga,
+        "Ujedinjeni Arapski Emirati"@hr,
+        "Egyesült Arab Emírségek"@hu,
+        "Emirati arabi uniti"@it,
+        "Jungtiniai Arabų Emyratai"@lt,
+        "Apvienotie Arābu Emirāti"@lv,
+        "l-Emirati Għarab Magħquda"@mt,
+        "Verenigde Arabische Emiraten"@nl,
+        "Zjednoczone Emiraty Arabskie"@pl,
+        "Emirados Árabes Unidos"@pt,
+        "Emiratele Arabe Unite"@ro,
+        "Spojené arabské emiráty"@sk,
+        "Združeni arabski emirati"@sl,
+        "Förenade Arabemiraten"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AF>,
+        <http://publications.europa.eu/resource/authority/country/AFG>,
+        <http://sws.geonames.org/1149361/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AF" ;
+    skos:prefLabel "Afghanistan",
+        "Афганистан"@bg,
+        "Afghánistán"@cs,
+        "Afghanistan"@da,
+        "Afghanistan"@de,
+        "Αφγανιστάν"@el,
+        "Afghanistan"@en,
+        "Afganistán"@es,
+        "Afganistan"@et,
+        "Afganistan"@fi,
+        "Afghanistan (l’)"@fr,
+        "an Afganastáin"@ga,
+        "Afganistan"@hr,
+        "Afganisztán"@hu,
+        "Afghanistan"@it,
+        "Afganistanas"@lt,
+        "Afganistāna"@lv,
+        "l-Afganistan"@mt,
+        "Afghanistan"@nl,
+        "Afganistan"@pl,
+        "Afeganistão"@pt,
+        "Afganistan"@ro,
+        "Afganistan"@sk,
+        "Afganistan"@sl,
+        "Afghanistan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AG>,
+        <http://publications.europa.eu/resource/authority/country/ATG>,
+        <http://sws.geonames.org/3576396/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AG" ;
+    skos:prefLabel "Antigua and Barbuda",
+        "Антигуа и Барбуда"@bg,
+        "Antigua a Barbuda"@cs,
+        "Antigua og Barbuda"@da,
+        "Antigua und Barbuda"@de,
+        "Αντίγκουα και Μπαρμπούντα"@el,
+        "Antigua and Barbuda"@en,
+        "Antigua y Barbuda"@es,
+        "Antigua ja Barbuda"@et,
+        "Antigua ja Barbuda"@fi,
+        "Antigua-et-Barbuda"@fr,
+        "Antigua agus Barbúda"@ga,
+        "Antigva i Barbuda"@hr,
+        "Antigua és Barbuda"@hu,
+        "Antigua e Barbuda"@it,
+        "Antigva ir Barbuda"@lt,
+        "Antigva un Barbuda"@lv,
+        "Antigwa u Barbuda"@mt,
+        "Antigua en Barbuda"@nl,
+        "Antigua i Barbuda"@pl,
+        "Antígua e Barbuda"@pt,
+        "Antigua și Barbuda"@ro,
+        "Antigua a Barbuda"@sk,
+        "Antigva in Barbuda"@sl,
+        "Antigua och"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AI> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/AIA>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AI>,
+        <http://publications.europa.eu/resource/authority/country/AIA>,
+        <http://sws.geonames.org/3573511/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AI" ;
+    skos:prefLabel "Anguilla",
+        "Ангила"@bg,
+        "Anguilla"@cs,
+        "Anguilla"@da,
+        "Anguilla"@de,
+        "Ανγκουίλα"@el,
+        "Anguilla"@en,
+        "Anguila"@es,
+        "Anguilla"@et,
+        "Anguilla"@fi,
+        "Anguilla"@fr,
+        "Anguilla"@ga,
+        "Angvila"@hr,
+        "Anguilla"@hu,
+        "Anguilla"@it,
+        "Angilija"@lt,
+        "Angilja"@lv,
+        "Angwilla"@mt,
+        "Anguilla"@nl,
+        "Anguilla"@pl,
+        "Anguila"@pt,
+        "Anguilla"@ro,
+        "Anguilla"@sk,
+        "Angvila"@sl,
+        "Anguilla"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AL> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Albania>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ALB>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AL>,
+        <http://publications.europa.eu/resource/authority/country/ALB>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/AL>,
+        <http://rod.eionet.europa.eu/spatial/2>,
+        <http://sws.geonames.org/783754/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AL" ;
+    skos:prefLabel "Albania",
+        "Албания"@bg,
+        "Albánie"@cs,
+        "Albanien"@da,
+        "Albanien"@de,
+        "Αλβανία"@el,
+        "Albania"@en,
+        "Albania"@es,
+        "Albaania"@et,
+        "Albania"@fi,
+        "Albanie (l’)"@fr,
+        "an Albáin"@ga,
+        "Albanija"@hr,
+        "Albánia"@hu,
+        "Albania"@it,
+        "Albanija"@lt,
+        "Albānija"@lv,
+        "l-Albanija"@mt,
+        "Albanië"@nl,
+        "Albania"@pl,
+        "Albânia"@pt,
+        "Albania"@ro,
+        "Albánsko"@sk,
+        "Albanija"@sl,
+        "Albanien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AM> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Armenia>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ARM>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AM>,
+        <http://publications.europa.eu/resource/authority/country/ARM>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/AM>,
+        <http://rod.eionet.europa.eu/spatial/97>,
+        <http://sws.geonames.org/174982/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AM" ;
+    skos:prefLabel "Armenia",
+        "Армения"@bg,
+        "Arménie"@cs,
+        "Armenien"@da,
+        "Armenien"@de,
+        "Αρμενία"@el,
+        "Armenia"@en,
+        "Armenia"@es,
+        "Armeenia"@et,
+        "Armenia"@fi,
+        "Arménie (l’)"@fr,
+        "an Airméin"@ga,
+        "Armenija"@hr,
+        "Örményország"@hu,
+        "Armenia"@it,
+        "Armėnija"@lt,
+        "Armēnija"@lv,
+        "l-Armenja"@mt,
+        "Armenië"@nl,
+        "Armenia"@pl,
+        "Arménia"@pt,
+        "Armenia"@ro,
+        "Arménsko"@sk,
+        "Armenija"@sl,
+        "Armenien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ANT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AN>,
+        <http://publications.europa.eu/resource/authority/country/ANT> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AN" ;
+    skos:prefLabel "Netherlands Antilles" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/invalid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AO>,
+        <http://publications.europa.eu/resource/authority/country/AGO>,
+        <http://sws.geonames.org/3351879/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AO" ;
+    skos:prefLabel "Angola",
+        "Ангола"@bg,
+        "Angola"@cs,
+        "Angola"@da,
+        "Angola"@de,
+        "Ανγκόλα"@el,
+        "Angola"@en,
+        "Angola"@es,
+        "Angola"@et,
+        "Angola"@fi,
+        "Angola (l’)"@fr,
+        "Angóla"@ga,
+        "Angola"@hr,
+        "Angola"@hu,
+        "Angola"@it,
+        "Angola"@lt,
+        "Angola"@lv,
+        "l-Angola"@mt,
+        "Angola"@nl,
+        "Angola"@pl,
+        "Angola"@pt,
+        "Angola"@ro,
+        "Angola"@sk,
+        "Angola"@sl,
+        "Angola"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AQ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AQ>,
+        <http://publications.europa.eu/resource/authority/country/ATA>,
+        <http://sws.geonames.org/6697173/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AQ" ;
+    skos:prefLabel "Antarctica",
+        "Антарктика"@bg,
+        "Antarktida"@cs,
+        "Antarktis"@da,
+        "die Antarktis"@de,
+        "Ανταρκτική"@el,
+        "Antarctica"@en,
+        "Antártida"@es,
+        "Antarktis"@et,
+        "Antarktis"@fi,
+        "Antarctique (l’)"@fr,
+        "Antartaice"@ga,
+        "Antarktika"@hr,
+        "Antarktisz"@hu,
+        "Antartide (l’)"@it,
+        "Antarktis"@lt,
+        "Antarktika"@lv,
+        "l-Antartika"@mt,
+        "Antarctica"@nl,
+        "Antarktyda"@pl,
+        "Antártida"@pt,
+        "Antarctica"@ro,
+        "Antarktída"@sk,
+        "Antarktika"@sl,
+        "Antarktis"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AR>,
+        <http://publications.europa.eu/resource/authority/country/ARG>,
+        <http://sws.geonames.org/3865483/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AR" ;
+    skos:prefLabel "Argentina",
+        "Аржентина"@bg,
+        "Argentina"@cs,
+        "Argentina"@da,
+        "Argentinien"@de,
+        "Αργεντινή"@el,
+        "Argentina"@en,
+        "Argentina"@es,
+        "Argentina"@et,
+        "Argentiina"@fi,
+        "Argentine (l’)"@fr,
+        "an Airgintín"@ga,
+        "Argentina"@hr,
+        "Argentína"@hu,
+        "Argentina"@it,
+        "Argentina"@lt,
+        "Argentīna"@lv,
+        "l-Arġentina"@mt,
+        "Argentinië"@nl,
+        "Argentyna"@pl,
+        "Argentina"@pt,
+        "Argentina"@ro,
+        "Argentína"@sk,
+        "Argentina"@sl,
+        "Argentina"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AS> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AS>,
+        <http://publications.europa.eu/resource/authority/country/ASM>,
+        <http://sws.geonames.org/5880801/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AS" ;
+    skos:prefLabel "American Samoa",
+        "Американска Самоа"@bg,
+        "Americká Samoa"@cs,
+        "Amerikansk Samoa"@da,
+        "Amerikanisch-Samoa"@de,
+        "Αμερικανική Σαμόα"@el,
+        "American Samoa"@en,
+        "Samoa Americana"@es,
+        "Ameerika Samoa"@et,
+        "Amerikan Samoa"@fi,
+        "Samoa américaines (les)"@fr,
+        "Samó Mheiriceá"@ga,
+        "Američka Samoa"@hr,
+        "Amerikai Szamoa"@hu,
+        "Samoa americane (le)"@it,
+        "Amerikos Samoa"@lt,
+        "ASV Samoa"@lv,
+        "is-Samoa Amerikana"@mt,
+        "Amerikaans-Samoa"@nl,
+        "Samoa Amerykańskie"@pl,
+        "Samoa Americana"@pt,
+        "Samoa Americană"@ro,
+        "Americká Samoa"@sk,
+        "Ameriška Samoa"@sl,
+        "Amerikanska Samoa"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AT> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Austria>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/AT>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/AT>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/AUT>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/AT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/AT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AT>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/AT>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/AT>,
+        <http://publications.europa.eu/resource/authority/country/AUT>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/AT>,
+        <http://rod.eionet.europa.eu/spatial/3>,
+        <http://sws.geonames.org/2782113/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AT" ;
+    skos:prefLabel "Austria",
+        "Австрия"@bg,
+        "Rakousko"@cs,
+        "Østrig"@da,
+        "Österreich"@de,
+        "Αυστρία"@el,
+        "Austria"@en,
+        "Austria"@es,
+        "Austria"@et,
+        "Itävalta"@fi,
+        "Autriche (l’)"@fr,
+        "an Ostair"@ga,
+        "Austrija"@hr,
+        "Ausztria"@hu,
+        "Austria"@it,
+        "Austrija"@lt,
+        "Austrija"@lv,
+        "l-Awstrija"@mt,
+        "Oostenrijk"@nl,
+        "Austria"@pl,
+        "Áustria"@pt,
+        "Austria"@ro,
+        "Rakúsko"@sk,
+        "Avstrija"@sl,
+        "Österrike"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AU> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Australia>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AU>,
+        <http://publications.europa.eu/resource/authority/country/AUS>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/AU>,
+        <http://sws.geonames.org/2077456/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AU" ;
+    skos:prefLabel "Australia",
+        "Австралия"@bg,
+        "Austrálie"@cs,
+        "Australien"@da,
+        "Australien"@de,
+        "Αυστραλία"@el,
+        "Australia"@en,
+        "Australia"@es,
+        "Austraalia"@et,
+        "Australia"@fi,
+        "Australie (l’)"@fr,
+        "an Astráil"@ga,
+        "Australija"@hr,
+        "Ausztrália"@hu,
+        "Australia"@it,
+        "Australija"@lt,
+        "Austrālija"@lv,
+        "l-Awstralja"@mt,
+        "Australië"@nl,
+        "Australia"@pl,
+        "Austrália"@pt,
+        "Australia"@ro,
+        "Austrália"@sk,
+        "Avstralija"@sl,
+        "Australien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ABW>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AW>,
+        <http://publications.europa.eu/resource/authority/country/ABW>,
+        <http://sws.geonames.org/3577279/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AW" ;
+    skos:prefLabel "Aruba",
+        "Аруба"@bg,
+        "Aruba"@cs,
+        "Aruba"@da,
+        "Aruba"@de,
+        "Αρούμπα"@el,
+        "Aruba"@en,
+        "Aruba"@es,
+        "Aruba"@et,
+        "Aruba"@fi,
+        "Aruba"@fr,
+        "Arúba"@ga,
+        "Aruba"@hr,
+        "Aruba"@hu,
+        "Aruba"@it,
+        "Aruba"@lt,
+        "Aruba"@lv,
+        "Aruba"@mt,
+        "Aruba"@nl,
+        "Aruba"@pl,
+        "Aruba"@pt,
+        "Aruba"@ro,
+        "Aruba"@sk,
+        "Aruba"@sl,
+        "Aruba"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AX> a skos:Concept ;
+    skos:exactMatch <http://publications.europa.eu/resource/authority/country/ALA>,
+        <http://sws.geonames.org/661882/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AX" ;
+    skos:prefLabel "Åland",
+        "Oстрови Оланд"@bg,
+        "Alandy"@cs,
+        "Åland"@da,
+        "Ålandinseln"@de,
+        "Νήσοι Όλαντ"@el,
+        "Åland Islands"@en,
+        "Islas Åland"@es,
+        "Ahvenamaa"@et,
+        "Ahvenanmaa"@fi,
+        "Îles Åland (les)"@fr,
+        "Oileáin Åland"@ga,
+        "Olandski Otoci"@hr,
+        "Åland-szigetek"@hu,
+        "Isole Åland"@it,
+        "Alandai"@lt,
+        "Ālandu Salas"@lv,
+        "il-Gżejjer Åland"@mt,
+        "Åland"@nl,
+        "Wyspy Alandzkie"@pl,
+        "Alanda"@pt,
+        "Insulele Åland"@ro,
+        "Alandy"@sk,
+        "Ålandski otoki"@sl,
+        "Åland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/AZ> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Azerbaijan>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/AZE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/AZ>,
+        <http://publications.europa.eu/resource/authority/country/AZE>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/AZ>,
+        <http://rod.eionet.europa.eu/spatial/98>,
+        <http://sws.geonames.org/587116/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "AZ" ;
+    skos:prefLabel "Azerbaijan",
+        "Азербайджан"@bg,
+        "Ázerbájdžán"@cs,
+        "Aserbajdsjan"@da,
+        "Aserbaidschan"@de,
+        "Αζερμπαϊτζάν"@el,
+        "Azerbaijan"@en,
+        "Azerbaiyán"@es,
+        "Aserbaidžaan"@et,
+        "Azerbaidžan"@fi,
+        "Azerbaïdjan (l’)"@fr,
+        "an Asarbaiseáin"@ga,
+        "Azerbajdžan"@hr,
+        "Azerbajdzsán"@hu,
+        "Azerbaigian"@it,
+        "Azerbaidžanas"@lt,
+        "Azerbaidžāna"@lv,
+        "l-Azerbajġan"@mt,
+        "Azerbeidzjan"@nl,
+        "Azerbejdżan"@pl,
+        "Azerbaijão"@pt,
+        "Azerbaidjan"@ro,
+        "Azerbajdžan"@sk,
+        "Azerbajdžan"@sl,
+        "Azerbajdzjan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BA> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Bosnia_and_Herzegovina>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/BIH>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BA>,
+        <http://publications.europa.eu/resource/authority/country/BIH>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/BA>,
+        <http://rod.eionet.europa.eu/spatial/6>,
+        <http://sws.geonames.org/3277605/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BA" ;
+    skos:prefLabel "Bosnia and Herzegovina",
+        "Босна и Херцеговина"@bg,
+        "Bosna a Hercegovina"@cs,
+        "Bosnien-Hercegovina"@da,
+        "Bosnien und Herzegowina"@de,
+        "Βοσνία-Ερζεγοβίνη"@el,
+        "Bosnia and Herzegovina"@en,
+        "Bosnia y Herzegovina"@es,
+        "Bosnia ja Hertsegoviina"@et,
+        "Bosnia ja Hertsegovina"@fi,
+        "Bosnie-Herzégovine (la)"@fr,
+        "an Bhoisnia agus an Heirseagaivéin"@ga,
+        "Bosna i Hercegovina"@hr,
+        "Bosznia-Hercegovina"@hu,
+        "Bosnia-Erzegovina"@it,
+        "Bosnija ir Hercegovina"@lt,
+        "Bosnija un Hercegovina"@lv,
+        "il-Bosnja-Ħerzegovina"@mt,
+        "Bosnië en Herzegovina"@nl,
+        "Bośnia i Hercegowina"@pl,
+        "Bósnia-Herzegovina"@pt,
+        "Bosnia și Herțegovina"@ro,
+        "Bosna a Hercegovina"@sk,
+        "Bosna in Hercegovina"@sl,
+        "Bosnien och Hercegovina"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BB> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BB>,
+        <http://publications.europa.eu/resource/authority/country/BRB>,
+        <http://sws.geonames.org/3374084/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BB" ;
+    skos:prefLabel "Barbados",
+        "Барбадос"@bg,
+        "Barbados"@cs,
+        "Barbados"@da,
+        "Barbados"@de,
+        "Μπαρμπάντος (τα)"@el,
+        "Barbados"@en,
+        "Barbados"@es,
+        "Barbados"@et,
+        "Barbados"@fi,
+        "Barbade (la)"@fr,
+        "Barbadós"@ga,
+        "Barbados"@hr,
+        "Barbados"@hu,
+        "Barbados"@it,
+        "Barbadosas"@lt,
+        "Barbadosa"@lv,
+        "il-Barbados"@mt,
+        "Barbados"@nl,
+        "Barbados"@pl,
+        "Barbados"@pt,
+        "Barbados"@ro,
+        "Barbados"@sk,
+        "Barbados"@sl,
+        "Barbados"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BD> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BD>,
+        <http://publications.europa.eu/resource/authority/country/BGD>,
+        <http://sws.geonames.org/1210997/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BD" ;
+    skos:prefLabel "Bangladesh",
+        "Бангладеш"@bg,
+        "Bangladéš"@cs,
+        "Bangladesh"@da,
+        "Bangladesch"@de,
+        "Μπανγκλαντές"@el,
+        "Bangladesh"@en,
+        "Bangladés"@es,
+        "Bangladesh"@et,
+        "Bangladesh"@fi,
+        "Bangladesh (le)"@fr,
+        "an Bhanglaidéis"@ga,
+        "Bangladeš"@hr,
+        "Banglades"@hu,
+        "Bangladesh"@it,
+        "Bangladešas"@lt,
+        "Bangladeša"@lv,
+        "il-Bangladexx"@mt,
+        "Bangladesh"@nl,
+        "Bangladesz"@pl,
+        "Bangladeche"@pt,
+        "Bangladesh"@ro,
+        "Bangladéš"@sk,
+        "Bangladeš"@sl,
+        "Bangladesh"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BE> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Belgium>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/BE>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/BE>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/BEL>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/BE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/BE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BE>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/BE>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/BE>,
+        <http://publications.europa.eu/resource/authority/country/BEL>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/BE>,
+        <http://rod.eionet.europa.eu/spatial/5>,
+        <http://sws.geonames.org/2802361/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BE" ;
+    skos:prefLabel "Belgium",
+        "Белгия"@bg,
+        "Belgie"@cs,
+        "Belgien"@da,
+        "Belgien"@de,
+        "Βέλγιο"@el,
+        "Belgium"@en,
+        "Bélgica"@es,
+        "Belgia"@et,
+        "Belgia"@fi,
+        "Belgique (la)"@fr,
+        "an Bheilg"@ga,
+        "Belgija"@hr,
+        "Belgium"@hu,
+        "Belgio"@it,
+        "Belgija"@lt,
+        "Beļģija"@lv,
+        "il-Belġju"@mt,
+        "België"@nl,
+        "Belgia"@pl,
+        "Bélgica"@pt,
+        "Belgia"@ro,
+        "Belgicko"@sk,
+        "Belgija"@sl,
+        "Belgien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BF>,
+        <http://publications.europa.eu/resource/authority/country/BFA>,
+        <http://sws.geonames.org/2361809/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BF" ;
+    skos:prefLabel "Burkina Faso",
+        "Буркина Фасо"@bg,
+        "Burkina Faso"@cs,
+        "Burkina Faso"@da,
+        "Burkina Faso"@de,
+        "Μπουρκίνα (η)"@el,
+        "Burkina Faso"@en,
+        "Burkina Faso"@es,
+        "Burkina Faso"@et,
+        "Burkina"@fi,
+        "Burkina (le)"@fr,
+        "Buircíne Fasó"@ga,
+        "Burkina Faso"@hr,
+        "Burkina Faso"@hu,
+        "Burkina Faso"@it,
+        "Burkina Fasas"@lt,
+        "Burkinafaso"@lv,
+        "il-Burkina Faso"@mt,
+        "Burkina Faso"@nl,
+        "Burkina Faso"@pl,
+        "Burquina Faso"@pt,
+        "Burkina Faso"@ro,
+        "Burkina"@sk,
+        "Burkina Faso"@sl,
+        "Burkina Faso"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BG> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Bulgaria>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/BG>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/BGR>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/BG>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/BG>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BG>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/BG>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/BG>,
+        <http://publications.europa.eu/resource/authority/country/BGR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/BG>,
+        <http://rod.eionet.europa.eu/spatial/7>,
+        <http://sws.geonames.org/732800/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BG" ;
+    skos:prefLabel "Bulgaria",
+        "България"@bg,
+        "Bulharsko"@cs,
+        "Bulgarien"@da,
+        "Bulgarien"@de,
+        "Βουλγαρία"@el,
+        "Bulgaria"@en,
+        "Bulgaria"@es,
+        "Bulgaaria"@et,
+        "Bulgaria"@fi,
+        "Bulgarie (la)"@fr,
+        "an Bhulgáir"@ga,
+        "Bugarska"@hr,
+        "Bulgária"@hu,
+        "Bulgaria"@it,
+        "Bulgarija"@lt,
+        "Bulgārija"@lv,
+        "il-Bulgarija"@mt,
+        "Bulgarije"@nl,
+        "Bułgaria"@pl,
+        "Bulgária"@pt,
+        "Bulgaria"@ro,
+        "Bulharsko"@sk,
+        "Bolgarija"@sl,
+        "Bulgarien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BH>,
+        <http://publications.europa.eu/resource/authority/country/BHR>,
+        <http://sws.geonames.org/290291/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BH" ;
+    skos:prefLabel "Bahrain",
+        "Бахрейн"@bg,
+        "Bahrajn"@cs,
+        "Bahrain"@da,
+        "Bahrain"@de,
+        "Μπαχρέιν"@el,
+        "Bahrain"@en,
+        "Baréin"@es,
+        "Bahrein"@et,
+        "Bahrain"@fi,
+        "Bahreïn"@fr,
+        "Bairéin"@ga,
+        "Bahrein"@hr,
+        "Bahrein"@hu,
+        "Bahrein"@it,
+        "Bahreinas"@lt,
+        "Bahreina"@lv,
+        "il-Baħrejn"@mt,
+        "Bahrein"@nl,
+        "Bahrajn"@pl,
+        "Barém"@pt,
+        "Bahrain"@ro,
+        "Bahrajn"@sk,
+        "Bahrajn"@sl,
+        "Bahrain"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BI> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BI>,
+        <http://publications.europa.eu/resource/authority/country/BDI>,
+        <http://sws.geonames.org/433561/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BI" ;
+    skos:prefLabel "Burundi",
+        "Бурунди"@bg,
+        "Burundi"@cs,
+        "Burundi"@da,
+        "Burundi"@de,
+        "Μπουρούντι"@el,
+        "Burundi"@en,
+        "Burundi"@es,
+        "Burundi"@et,
+        "Burundi"@fi,
+        "Burundi (le)"@fr,
+        "an Bhurúin"@ga,
+        "Burundi"@hr,
+        "Burundi"@hu,
+        "Burundi"@it,
+        "Burundis"@lt,
+        "Burundi"@lv,
+        "il-Burundi"@mt,
+        "Burundi"@nl,
+        "Burundi"@pl,
+        "Burundi"@pt,
+        "Burundi"@ro,
+        "Burundi"@sk,
+        "Burundi"@sl,
+        "Burundi"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BJ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BJ>,
+        <http://publications.europa.eu/resource/authority/country/BEN>,
+        <http://sws.geonames.org/2395170/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BJ" ;
+    skos:prefLabel "Benin",
+        "Бенин"@bg,
+        "Benin"@cs,
+        "Benin"@da,
+        "Benin"@de,
+        "Μπενίν"@el,
+        "Benin"@en,
+        "Benín"@es,
+        "Benin"@et,
+        "Benin"@fi,
+        "Bénin (le)"@fr,
+        "Beinin"@ga,
+        "Benin"@hr,
+        "Benin"@hu,
+        "Benin"@it,
+        "Beninas"@lt,
+        "Benina"@lv,
+        "il-Benin"@mt,
+        "Benin"@nl,
+        "Benin"@pl,
+        "Benim"@pt,
+        "Benin"@ro,
+        "Benin"@sk,
+        "Benin"@sl,
+        "Benin"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BL> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/BLM>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BL>,
+        <http://publications.europa.eu/resource/authority/country/BLM>,
+        <http://sws.geonames.org/3578476/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BL" ;
+    skos:prefLabel "Saint Barthélemy",
+        "Сен Бартелеми"@bg,
+        "Svatý Bartoloměj"@cs,
+        "Saint-Barthélemy"@da,
+        "St. Barthélemy"@de,
+        "Άγιος Βαρθολομαίος"@el,
+        "Saint Barthélemy"@en,
+        "San Bartolomé"@es,
+        "Saint-Barthélemy"@et,
+        "Saint-Barthélemy"@fi,
+        "Saint-Barthélemy"@fr,
+        "Saint-Barthélemy"@ga,
+        "Saint Barthélemy"@hr,
+        "Saint-Barthélemy"@hu,
+        "Saint-Barthélemy"@it,
+        "Sen Bartelemi"@lt,
+        "Senbartelmī"@lv,
+        "Saint Barthélemy"@mt,
+        "Saint-Barthélemy"@nl,
+        "Saint-Barthélemy"@pl,
+        "São Bartolomeu"@pt,
+        "Saint-Barthélemy"@ro,
+        "Svätý Bartolomej"@sk,
+        "Saint-Barthélemy"@sl,
+        "Saint-Barthélemy"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/BMU>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BM>,
+        <http://publications.europa.eu/resource/authority/country/BMU>,
+        <http://sws.geonames.org/3573345/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BM" ;
+    skos:prefLabel "Bermuda",
+        "Бермуда"@bg,
+        "Bermudy"@cs,
+        "Bermuda"@da,
+        "Bermuda"@de,
+        "Βερμούδες"@el,
+        "Bermuda"@en,
+        "Bermudas"@es,
+        "Bermuda"@et,
+        "Bermuda"@fi,
+        "Bermudes (les)"@fr,
+        "Beirmiúda"@ga,
+        "Bermudski Otoci"@hr,
+        "Bermuda"@hu,
+        "Bermuda"@it,
+        "Bermuda"@lt,
+        "Bermudu Salas"@lv,
+        "il-Bermuda"@mt,
+        "Bermuda"@nl,
+        "Bermudy"@pl,
+        "Bermudas"@pt,
+        "Bermuda"@ro,
+        "Bermudy"@sk,
+        "Bermudi"@sl,
+        "Bermuda"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BN>,
+        <http://publications.europa.eu/resource/authority/country/BRN>,
+        <http://sws.geonames.org/1820814/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BN" ;
+    skos:prefLabel "Brunei Darussalam",
+        "Бруней"@bg,
+        "Brunej"@cs,
+        "Brunei"@da,
+        "Brunei Darussalam"@de,
+        "Μπρουνέι"@el,
+        "Brunei"@en,
+        "Brunéi"@es,
+        "Brunei"@et,
+        "Brunei"@fi,
+        "Brunei (le)"@fr,
+        "Brúiné"@ga,
+        "Brunej"@hr,
+        "Brunei"@hu,
+        "Brunei"@it,
+        "Brunėjus"@lt,
+        "Bruneja"@lv,
+        "il-Brunej"@mt,
+        "Brunei"@nl,
+        "Brunei"@pl,
+        "Brunei"@pt,
+        "Brunei"@ro,
+        "Brunej"@sk,
+        "Brunej"@sl,
+        "Brunei"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BO>,
+        <http://publications.europa.eu/resource/authority/country/BOL>,
+        <http://sws.geonames.org/3923057/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BO" ;
+    skos:prefLabel "Bolivia",
+        "Боливия"@bg,
+        "Bolívie"@cs,
+        "Bolivia"@da,
+        "Bolivien"@de,
+        "Βολιβία"@el,
+        "Bolivia"@en,
+        "Bolivia"@es,
+        "Boliivia"@et,
+        "Bolivia"@fi,
+        "Bolivie (la)"@fr,
+        "an Bholaiv"@ga,
+        "Bolivija"@hr,
+        "Bolívia"@hu,
+        "Bolivia"@it,
+        "Bolivija"@lt,
+        "Bolīvija"@lv,
+        "il-Bolivja"@mt,
+        "Bolivia"@nl,
+        "Boliwia"@pl,
+        "Bolívia"@pt,
+        "Bolivia"@ro,
+        "Bolívia"@sk,
+        "Bolivija"@sl,
+        "Bolivia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BQ> a skos:Concept ;
+    skos:definition "Caribbean Netherlands" ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BQ>,
+        <http://publications.europa.eu/resource/authority/country/BES> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BQ" ;
+    skos:prefLabel "Bonaire, Saint Eustatius and Saba" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BR>,
+        <http://publications.europa.eu/resource/authority/country/BRA>,
+        <http://sws.geonames.org/3469034/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BR" ;
+    skos:prefLabel "Brazil",
+        "Бразилия"@bg,
+        "Brazílie"@cs,
+        "Brasilien"@da,
+        "Brasilien"@de,
+        "Βραζιλία"@el,
+        "Brazil"@en,
+        "Brasil"@es,
+        "Brasiilia"@et,
+        "Brasilia"@fi,
+        "Brésil (le)"@fr,
+        "an Bhrasaíl"@ga,
+        "Brazil"@hr,
+        "Brazília"@hu,
+        "Brasile"@it,
+        "Brazilija"@lt,
+        "Brazīlija"@lv,
+        "il-Brażil"@mt,
+        "Brazilië"@nl,
+        "Brazylia"@pl,
+        "Brasil"@pt,
+        "Brazilia"@ro,
+        "Brazília"@sk,
+        "Brazilija"@sl,
+        "Brasilien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BS> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BS>,
+        <http://publications.europa.eu/resource/authority/country/BHS>,
+        <http://sws.geonames.org/3572887/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BS" ;
+    skos:prefLabel "Bahamas",
+        "Бахамски острови"@bg,
+        "Bahamy"@cs,
+        "Bahamas"@da,
+        "Bahamas"@de,
+        "Μπαχάμες"@el,
+        "Bahamas"@en,
+        "Bahamas"@es,
+        "Bahama"@et,
+        "Bahama"@fi,
+        "Bahamas (les)"@fr,
+        "na Bahámaí"@ga,
+        "Bahami"@hr,
+        "Bahama-szigetek"@hu,
+        "Bahamas"@it,
+        "Bahamos"@lt,
+        "Bahamu Salas"@lv,
+        "il-Baħamas"@mt,
+        "Bahama’s"@nl,
+        "Bahamy"@pl,
+        "Baamas"@pt,
+        "Bahamas"@ro,
+        "Bahamy"@sk,
+        "Bahami"@sl,
+        "Bahamas"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BT> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BT>,
+        <http://publications.europa.eu/resource/authority/country/BTN>,
+        <http://sws.geonames.org/1252634/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BT" ;
+    skos:prefLabel "Bhutan",
+        "Бутан"@bg,
+        "Bhútán"@cs,
+        "Bhutan"@da,
+        "Bhutan"@de,
+        "Μπουτάν"@el,
+        "Bhutan"@en,
+        "Bután"@es,
+        "Bhutan"@et,
+        "Bhutan"@fi,
+        "Bhoutan (le)"@fr,
+        "an Bhútáin"@ga,
+        "Butan"@hr,
+        "Bhután"@hu,
+        "Bhutan"@it,
+        "Butanas"@lt,
+        "Butāna"@lv,
+        "il-Butan"@mt,
+        "Bhutan"@nl,
+        "Bhutan"@pl,
+        "Butão"@pt,
+        "Bhutan"@ro,
+        "Bhután"@sk,
+        "Butan"@sl,
+        "Bhutan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BV> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/BVT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BV>,
+        <http://publications.europa.eu/resource/authority/country/BVT>,
+        <http://sws.geonames.org/3371123/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BV" ;
+    skos:prefLabel "Bouvet Island",
+        "Oстров Буве"@bg,
+        "Bouvetův ostrov"@cs,
+        "Bouvetøen"@da,
+        "die Bouvetinsel"@de,
+        "Νήσος Μπουβέ"@el,
+        "Bouvet Island"@en,
+        "Isla Bouvet"@es,
+        "Bouvet’ saar"@et,
+        "Bouvet’nsaari"@fi,
+        "Île Bouvet (l’)"@fr,
+        "Oileán Bouvet"@ga,
+        "Otok Bouvet"@hr,
+        "Bouvet-sziget"@hu,
+        "Isola di Bouvet (l’)"@it,
+        "Buvė"@lt,
+        "Buvē Sala"@lv,
+        "il-Gżira ta’ Bouvet"@mt,
+        "Bouveteiland"@nl,
+        "Wyspa Bouveta"@pl,
+        "Ilha Bouvet"@pt,
+        "Insula Bouvet"@ro,
+        "Bouvetov ostrov"@sk,
+        "Bouvetov otok"@sl,
+        "Bouvetön"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BW>,
+        <http://publications.europa.eu/resource/authority/country/BWA>,
+        <http://sws.geonames.org/933860/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BW" ;
+    skos:prefLabel "Botswana",
+        "Ботсуана"@bg,
+        "Botswana"@cs,
+        "Botswana"@da,
+        "Botsuana"@de,
+        "Μποτσουάνα"@el,
+        "Botswana"@en,
+        "Botsuana"@es,
+        "Botswana"@et,
+        "Botswana"@fi,
+        "Botswana (le)"@fr,
+        "an Bhotsuáin"@ga,
+        "Bocvana"@hr,
+        "Botswana"@hu,
+        "Botswana"@it,
+        "Botsvana"@lt,
+        "Botsvāna"@lv,
+        "il-Botswana"@mt,
+        "Botswana"@nl,
+        "Botswana"@pl,
+        "Botsuana"@pt,
+        "Botswana"@ro,
+        "Botswana"@sk,
+        "Bocvana"@sl,
+        "Botswana"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BY> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Belarus>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/BLR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BY>,
+        <http://publications.europa.eu/resource/authority/country/BLR>,
+        <http://publications.europa.eu/resource/authority/country/BYS>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/BY>,
+        <http://rod.eionet.europa.eu/spatial/4>,
+        <http://sws.geonames.org/630336/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BY" ;
+    skos:prefLabel "Belarus",
+        "Беларус"@bg,
+        "Bělorusko"@cs,
+        "Hviderusland"@da,
+        "Belarus"@de,
+        "Λευκορωσία"@el,
+        "Belarus"@en,
+        "Bielorrusia"@es,
+        "Valgevene"@et,
+        "Valko-Venäjä"@fi,
+        "Biélorussie (la)"@fr,
+        "an Bhealarúis"@ga,
+        "Bjelorusija"@hr,
+        "Belarusz"@hu,
+        "Bielorussia"@it,
+        "Baltarusija"@lt,
+        "Baltkrievija"@lv,
+        "il-Bjelorussja"@mt,
+        "Belarus"@nl,
+        "Białoruś"@pl,
+        "Bielorrússia"@pt,
+        "Belarus"@ro,
+        "Bielorusko"@sk,
+        "Belorusija"@sl,
+        "Vitryssland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/BZ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/BZ>,
+        <http://publications.europa.eu/resource/authority/country/BLZ>,
+        <http://sws.geonames.org/3582678/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "BZ" ;
+    skos:prefLabel "Belize",
+        "Белиз"@bg,
+        "Belize"@cs,
+        "Belize"@da,
+        "Belize"@de,
+        "Μπελίζε (η)"@el,
+        "Belize"@en,
+        "Belice"@es,
+        "Belize"@et,
+        "Belize"@fi,
+        "Belize (le)"@fr,
+        "an Bheilís"@ga,
+        "Belize"@hr,
+        "Belize"@hu,
+        "Belize"@it,
+        "Belizas"@lt,
+        "Beliza"@lv,
+        "il-Beliże"@mt,
+        "Belize"@nl,
+        "Belize"@pl,
+        "Belize"@pt,
+        "Belize"@ro,
+        "Belize"@sk,
+        "Belize"@sl,
+        "Belize"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CA> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Canada>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CA>,
+        <http://publications.europa.eu/resource/authority/country/CAN>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/CA>,
+        <http://sws.geonames.org/6251999/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CA" ;
+    skos:prefLabel "Canada",
+        "Канада"@bg,
+        "Kanada"@cs,
+        "Canada"@da,
+        "Kanada"@de,
+        "Καναδάς"@el,
+        "Canada"@en,
+        "Canadá"@es,
+        "Kanada"@et,
+        "Kanada"@fi,
+        "Canada (le)"@fr,
+        "Ceanada"@ga,
+        "Kanada"@hr,
+        "Kanada"@hu,
+        "Canada"@it,
+        "Kanada"@lt,
+        "Kanāda"@lv,
+        "il-Kanada"@mt,
+        "Canada"@nl,
+        "Kanada"@pl,
+        "Canadá"@pt,
+        "Canada"@ro,
+        "Kanada"@sk,
+        "Kanada"@sl,
+        "Kanada"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CC> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CC>,
+        <http://publications.europa.eu/resource/authority/country/CCK>,
+        <http://sws.geonames.org/1547376/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CC" ;
+    skos:prefLabel "Cocos (Keeling) Islands",
+        "Кокосови острови"@bg,
+        "Kokosové (Keelingovy) ostrovy"@cs,
+        "Cocosøerne"@da,
+        "die Kokosinseln"@de,
+        "Νήσοι Κόκος (Κίλινγκ)"@el,
+        "Cocos (Keeling) Islands"@en,
+        "Islas Cocos"@es,
+        "Kookossaared"@et,
+        "Kookossaaret"@fi,
+        "Îles Cocos (les)"@fr,
+        "Oileáin Cocos (Keeling)"@ga,
+        "Kokosovi (Keelingovi) Otoci"@hr,
+        "Kókusz-szigetek"@hu,
+        "Isole Cocos (le)"@it,
+        "Kokosų (Kilingo) Salos"@lt,
+        "Kokosu (Kīlinga) Salas"@lv,
+        "il-Gżejjer Kokos (Keeling)"@mt,
+        "Cocoseilanden"@nl,
+        "Wyspy Kokosowe"@pl,
+        "Ilhas dos Cocos"@pt,
+        "Insulele Cocos (Keeling)"@ro,
+        "Kokosové ostrovy"@sk,
+        "Kokosovi otoki"@sl,
+        "Kokosöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CD> a skos:Concept ;
+    skos:altLabel "Congo (Kinshasa)"@en ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CD>,
+        <http://publications.europa.eu/resource/authority/country/COD>,
+        <http://sws.geonames.org/203312/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CD" ;
+    skos:prefLabel "Democratic Republic of the Congo",
+        "Демократична република Конго"@bg,
+        "Demokratická republika Kongo"@cs,
+        "Demokratiske Republik Congo, Den"@da,
+        "die Demokratische Republik Kongo"@de,
+        "Λαϊκή Δημοκρατία του Κονγκό"@el,
+        "Democratic Republic of the Congo"@en,
+        "República Democrática del Congo"@es,
+        "Kongo Demokraatlik Vabariik"@et,
+        "Kongon demokraattinen tasavalta"@fi,
+        "République démocratique du Congo (la)"@fr,
+        "Poblacht Dhaonlathach an Chongó"@ga,
+        "Demokratska Republika Kongo"@hr,
+        "Kongói Demokratikus Köztársaság"@hu,
+        "Repubblica democratica del Congo"@it,
+        "Kongo Demokratinė Respublika"@lt,
+        "Kongo Demokrātiskā Republika"@lv,
+        "ir-Repubblika Demokratika tal-Kongo"@mt,
+        "Democratische Republiek Congo"@nl,
+        "Demokratyczna Republika Konga"@pl,
+        "República Democrática do Congo"@pt,
+        "Republica Democratică Congo"@ro,
+        "Konžská demokratická republika"@sk,
+        "Demokratična republika Kongo"@sl,
+        "Demokratiska republiken Kongo"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CF>,
+        <http://publications.europa.eu/resource/authority/country/CAF>,
+        <http://sws.geonames.org/239880/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CF" ;
+    skos:prefLabel "Central African Republic",
+        "Централноафриканска република"@bg,
+        "Středoafrická republika"@cs,
+        "Centralafrikanske Republik, Den"@da,
+        "die Zentralafrikanische Republik"@de,
+        "Κεντροαφρικανική Δημοκρατία"@el,
+        "Central African Republic"@en,
+        "República Centroafricana"@es,
+        "Kesk-Aafrika Vabariik"@et,
+        "Keski-Afrikan tasavalta"@fi,
+        "République"@fr,
+        "Poblacht na hAfraice Láir"@ga,
+        "Srednjoafrička Republika"@hr,
+        "Közép-afrikai Köztársaság"@hu,
+        "Repubblica centrafricana"@it,
+        "Centrinės Afrikos Respublika"@lt,
+        "Centrālāfrikas Republika"@lv,
+        "ir-Repubblika Ċentru-Afrikana"@mt,
+        "Centraal-Afrikaanse Republiek"@nl,
+        "Republika Środkowo-"@pl,
+        "República Centro-Africana"@pt,
+        "Republica Centrafricană"@ro,
+        "Stredoafrická republika"@sk,
+        "Srednjeafriška republika"@sl,
+        "Centralafrikanska republiken"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CG> a skos:Concept ;
+    skos:altLabel "Congo (Brazzaville)"@en ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CG>,
+        <http://publications.europa.eu/resource/authority/country/COG>,
+        <http://sws.geonames.org/2260494/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CG" ;
+    skos:prefLabel "Congo",
+        "Конго"@bg,
+        "Kongo"@cs,
+        "Congo"@da,
+        "Kongo"@de,
+        "Κονγκό"@el,
+        "Congo"@en,
+        "Congo"@es,
+        "Kongo"@et,
+        "Kongo"@fi,
+        "Congo (le)"@fr,
+        "an Congó"@ga,
+        "Kongo"@hr,
+        "Kongó"@hu,
+        "Congo"@it,
+        "Kongas"@lt,
+        "Kongo"@lv,
+        "il-Kongo"@mt,
+        "Congo"@nl,
+        "Kongo"@pl,
+        "Congo"@pt,
+        "Congo"@ro,
+        "Kongo"@sk,
+        "Kongo"@sl,
+        "Kongo"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CH> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Switzerland>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/CHE>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/CH>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/CH>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CH>,
+        <http://publications.europa.eu/resource/authority/country/CHE>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/CH>,
+        <http://rod.eionet.europa.eu/spatial/37>,
+        <http://sws.geonames.org/2658434/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CH" ;
+    skos:prefLabel "Switzerland",
+        "Швейцария"@bg,
+        "Švýcarsko"@cs,
+        "Schweiz"@da,
+        "die Schweiz"@de,
+        "Ελβετία"@el,
+        "Switzerland"@en,
+        "Suiza"@es,
+        "Šveits"@et,
+        "Sveitsi"@fi,
+        "Suisse (la)"@fr,
+        "an Eilvéis"@ga,
+        "Švicarska"@hr,
+        "Svájc"@hu,
+        "Svizzera"@it,
+        "Šveicarija"@lt,
+        "Šveice"@lv,
+        "l-Isvizzera"@mt,
+        "Zwitserland"@nl,
+        "Szwajcaria"@pl,
+        "Suíça"@pt,
+        "Elveția"@ro,
+        "Švajčiarsko"@sk,
+        "Švica"@sl,
+        "Schweiz"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CI> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CI>,
+        <http://publications.europa.eu/resource/authority/country/CIV>,
+        <http://sws.geonames.org/2287781/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CI" ;
+    skos:prefLabel "Côte d'Ivoire",
+        "Кот д’Ивоар"@bg,
+        "Pobřeží slonoviny"@cs,
+        "Elfenbenskysten"@da,
+        "Côte d’Ivoire"@de,
+        "Ακτή Ελεφαντοστού"@el,
+        "Côte d’Ivoire"@en,
+        "Costa de Marfil"@es,
+        "Côte d’Ivoire"@et,
+        "Norsunluurannikko"@fi,
+        "Côte d’Ivoire (la)"@fr,
+        "an Cósta Eabhair"@ga,
+        "Obala Bjelokosti"@hr,
+        "Elefántcsontpart"@hu,
+        "Costa d’Avorio"@it,
+        "Dramblio Kaulo Krantas"@lt,
+        "Kotdivuāra"@lv,
+        "il-Côte d’Ivoire"@mt,
+        "Ivoorkust"@nl,
+        "Wybrzeże Kości Słoniowej"@pl,
+        "Costa do Marfim"@pt,
+        "Côte d’Ivoire"@ro,
+        "Pobrežie Slonoviny"@sk,
+        "Slonokoščena obala"@sl,
+        "Elfenbenskusten"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CK> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CK>,
+        <http://publications.europa.eu/resource/authority/country/COK>,
+        <http://sws.geonames.org/1899402/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CK" ;
+    skos:prefLabel "Cook Islands",
+        "Oстрови Кук"@bg,
+        "Cookovy ostrovy"@cs,
+        "Cookøerne"@da,
+        "die Cookinseln"@de,
+        "Νήσοι Κουκ"@el,
+        "Cook Islands"@en,
+        "Islas Cook"@es,
+        "Cooki saared"@et,
+        "Cookinsaaret"@fi,
+        "Îles Cook (les)"@fr,
+        "Oileáin Cook"@ga,
+        "Cookovi Otoci"@hr,
+        "Cook-szigetek"@hu,
+        "Isole Cook"@it,
+        "Kuko Salos"@lt,
+        "Kuka Salas"@lv,
+        "il-Gżejjer Cook"@mt,
+        "Cookeilanden"@nl,
+        "Wyspy Cooka"@pl,
+        "Ilhas Cook"@pt,
+        "Insulele Cook"@ro,
+        "Cookove ostrovy"@sk,
+        "Cookovi otoki"@sl,
+        "Cooköarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CL> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CL>,
+        <http://publications.europa.eu/resource/authority/country/CHL>,
+        <http://sws.geonames.org/3895114/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CL" ;
+    skos:prefLabel "Chile",
+        "Чили"@bg,
+        "Chile"@cs,
+        "Chile"@da,
+        "Chile"@de,
+        "Χιλή"@el,
+        "Chile"@en,
+        "Chile"@es,
+        "Tšiili"@et,
+        "Chile"@fi,
+        "Chili (le)"@fr,
+        "an tSile"@ga,
+        "Čile"@hr,
+        "Chile"@hu,
+        "Cile"@it,
+        "Čilė"@lt,
+        "Čīle"@lv,
+        "iċ-Ċilì"@mt,
+        "Chili"@nl,
+        "Chile"@pl,
+        "Chile"@pt,
+        "Chile"@ro,
+        "Čile"@sk,
+        "Čile"@sl,
+        "Chile"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CM>,
+        <http://publications.europa.eu/resource/authority/country/CMR>,
+        <http://sws.geonames.org/2233387/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CM" ;
+    skos:prefLabel "Cameroon",
+        "Камерун"@bg,
+        "Kamerun"@cs,
+        "Cameroun"@da,
+        "Kamerun"@de,
+        "Καμερούν"@el,
+        "Cameroon"@en,
+        "Camerún"@es,
+        "Kamerun"@et,
+        "Kamerun"@fi,
+        "Cameroun (le)"@fr,
+        "Camarún"@ga,
+        "Kamerun"@hr,
+        "Kamerun"@hu,
+        "Camerun"@it,
+        "Kamerūnas"@lt,
+        "Kamerūna"@lv,
+        "il-Kamerun"@mt,
+        "Kameroen"@nl,
+        "Kamerun"@pl,
+        "Camarões"@pt,
+        "Camerun"@ro,
+        "Kamerun"@sk,
+        "Kamerun"@sl,
+        "Kamerun"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CN>,
+        <http://publications.europa.eu/resource/authority/country/CHN>,
+        <http://sws.geonames.org/1814991/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CN" ;
+    skos:prefLabel "China",
+        "Китай"@bg,
+        "Čína"@cs,
+        "Kina"@da,
+        "China"@de,
+        "Κίνα"@el,
+        "China"@en,
+        "China"@es,
+        "Hiina"@et,
+        "Kiina"@fi,
+        "Chine (la)"@fr,
+        "an tSín"@ga,
+        "Kina"@hr,
+        "Kína"@hu,
+        "Cina"@it,
+        "Kinija"@lt,
+        "Ķīna"@lv,
+        "iċ-Ċina"@mt,
+        "China"@nl,
+        "Chiny"@pl,
+        "China"@pt,
+        "China"@ro,
+        "Čína"@sk,
+        "Kitajska"@sl,
+        "Kina"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CO>,
+        <http://publications.europa.eu/resource/authority/country/COL>,
+        <http://sws.geonames.org/3686110/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CO" ;
+    skos:prefLabel "Colombia",
+        "Колумбия"@bg,
+        "Kolumbie"@cs,
+        "Colombia"@da,
+        "Kolumbien"@de,
+        "Κολομβία"@el,
+        "Colombia"@en,
+        "Colombia"@es,
+        "Colombia"@et,
+        "Kolumbia"@fi,
+        "Colombie (la)"@fr,
+        "an Cholóim"@ga,
+        "Kolumbija"@hr,
+        "Kolumbia"@hu,
+        "Colombia"@it,
+        "Kolumbija"@lt,
+        "Kolumbija"@lv,
+        "il-Kolombja"@mt,
+        "Colombia"@nl,
+        "Kolumbia"@pl,
+        "Colômbia"@pt,
+        "Columbia"@ro,
+        "Kolumbia"@sk,
+        "Kolumbija"@sl,
+        "Colombia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CR>,
+        <http://publications.europa.eu/resource/authority/country/CRI>,
+        <http://sws.geonames.org/3624060/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CR" ;
+    skos:prefLabel "Costa Rica",
+        "Коста Рика"@bg,
+        "Kostarika"@cs,
+        "Costa Rica"@da,
+        "Costa Rica"@de,
+        "Κόστα Ρίκα"@el,
+        "Costa Rica"@en,
+        "Costa Rica"@es,
+        "Costa Rica"@et,
+        "Costa Rica"@fi,
+        "Costa Rica (le)"@fr,
+        "Cósta Ríce"@ga,
+        "Kostarik"@hr,
+        "Costa Rica"@hu,
+        "Costa Rica"@it,
+        "Kosta Rika"@lt,
+        "Kostarika"@lv,
+        "il-Kosta Rika"@mt,
+        "Costa Rica"@nl,
+        "Kostaryka"@pl,
+        "Costa Rica"@pt,
+        "Costa Rica"@ro,
+        "Kostarika"@sk,
+        "Kostarika"@sl,
+        "Costa Rica"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CU> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CU>,
+        <http://publications.europa.eu/resource/authority/country/CUB>,
+        <http://sws.geonames.org/3562981/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CU" ;
+    skos:prefLabel "Cuba",
+        "Куба"@bg,
+        "Kuba"@cs,
+        "Cuba"@da,
+        "Kuba"@de,
+        "Κούβα"@el,
+        "Cuba"@en,
+        "Cuba"@es,
+        "Kuuba"@et,
+        "Kuuba"@fi,
+        "Cuba"@fr,
+        "Cúba"@ga,
+        "Kuba"@hr,
+        "Kuba"@hu,
+        "Cuba"@it,
+        "Kuba"@lt,
+        "Kuba"@lv,
+        "Kuba"@mt,
+        "Cuba"@nl,
+        "Kuba"@pl,
+        "Cuba"@pt,
+        "Cuba"@ro,
+        "Kuba"@sk,
+        "Kuba"@sl,
+        "Kuba"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CV> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CV>,
+        <http://publications.europa.eu/resource/authority/country/CPV>,
+        <http://sws.geonames.org/3374766/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CV" ;
+    skos:prefLabel "Cape Verde",
+        "Кабо Верде"@bg,
+        "Kapverdy"@cs,
+        "Kap Verde"@da,
+        "Kap Verde"@de,
+        "Πράσινο Ακρωτήριο"@el,
+        "Cape Verde"@en,
+        "Cabo Verde"@es,
+        "Roheneemesaared"@et,
+        "Kap Verde"@fi,
+        "Cap-Vert (le)"@fr,
+        "Rinn Verde"@ga,
+        "Zelenortska Republika"@hr,
+        "Zöld-foki-szigetek"@hu,
+        "Capo Verde"@it,
+        "Žaliasis Kyšulys"@lt,
+        "Kaboverde"@lv,
+        "il-Kap Verde"@mt,
+        "Kaapverdië"@nl,
+        "Republika Zielonego Przylądka"@pl,
+        "Cabo Verde"@pt,
+        "Capul Verde"@ro,
+        "Kapverdy"@sk,
+        "Zelenortski otoki"@sl,
+        "Kap Verde"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CW>,
+        <http://publications.europa.eu/resource/authority/country/CUW> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CW" ;
+    skos:prefLabel "Curaçao" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CX> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CX>,
+        <http://publications.europa.eu/resource/authority/country/CXR>,
+        <http://sws.geonames.org/2078138/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CX" ;
+    skos:prefLabel "Christmas Island",
+        "Oстров Рождество"@bg,
+        "Vánoční ostrov"@cs,
+        "Christmas Island"@da,
+        "die Weihnachtsinsel"@de,
+        "Νήσος των Χριστουγέννων"@el,
+        "Christmas Island"@en,
+        "Isla Christmas"@es,
+        "Jõulusaar"@et,
+        "Joulusaari"@fi,
+        "Île Christmas (l’)"@fr,
+        "Oileán na Nollag"@ga,
+        "Božićni Otok"@hr,
+        "Karácsony-sziget"@hu,
+        "Isola Christmas (l’)"@it,
+        "Kalėdų Sala"@lt,
+        "Ziemsvētku Sala"@lv,
+        "il-Gżira Christmas"@mt,
+        "Christmaseiland"@nl,
+        "Wyspa Bożego Narodzenia"@pl,
+        "Ilha do Natal"@pt,
+        "Insula Christmas"@ro,
+        "Vianočný ostrov"@sk,
+        "Božični otok"@sl,
+        "Julön"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CY> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Cyprus>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/CY>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/CY>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/CYP>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/CY>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/CY>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CY>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/CY>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/CY>,
+        <http://publications.europa.eu/resource/authority/country/CYP>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/CY>,
+        <http://rod.eionet.europa.eu/spatial/9>,
+        <http://sws.geonames.org/146669/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CY" ;
+    skos:prefLabel "Cyprus",
+        "Кипър"@bg,
+        "Kypr"@cs,
+        "Cypern"@da,
+        "Zypern"@de,
+        "Κύπρος"@el,
+        "Cyprus"@en,
+        "Chipre"@es,
+        "Küpros"@et,
+        "Kypros"@fi,
+        "Chypre"@fr,
+        "an Chipir"@ga,
+        "Cipar"@hr,
+        "Ciprus"@hu,
+        "Cipro"@it,
+        "Kipras"@lt,
+        "Kipra"@lv,
+        "Ċipru"@mt,
+        "Cyprus"@nl,
+        "Cypr"@pl,
+        "Chipre"@pt,
+        "Cipru"@ro,
+        "Cyprus"@sk,
+        "Ciper"@sl,
+        "Cypern"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/CZ> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Czech_Republic>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/CZ>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/CZ>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/CZE>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/CZ>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/CZ>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/CZ>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/CZ>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/CZ>,
+        <http://publications.europa.eu/resource/authority/country/CZE>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/CZ>,
+        <http://rod.eionet.europa.eu/spatial/10>,
+        <http://sws.geonames.org/3077311/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "CZ" ;
+    skos:prefLabel "Czechia",
+        "Чешка република"@bg,
+        "Česká republika"@cs,
+        "Tjekkiet"@da,
+        "die Tschechische Republik"@de,
+        "Τσεχική Δημοκρατία"@el,
+        "Czech Republic"@en,
+        "Chequia"@es,
+        "Tšehhi Vabariik"@et,
+        "Tšekki"@fi,
+        "République tchèque (la)"@fr,
+        "Poblacht na Seice"@ga,
+        "Češka Republika"@hr,
+        "Cseh Köztársaság"@hu,
+        "Repubblica ceca"@it,
+        "Čekija"@lt,
+        "Čehijas Republika"@lv,
+        "ir-Repubblika Ċeka"@mt,
+        "Tsjechië"@nl,
+        "Republika Czeska"@pl,
+        "República Checa"@pt,
+        "Republica Cehă"@ro,
+        "Česká republika"@sk,
+        "Češka"@sl,
+        "Tjeckien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/DE> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Germany>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/DE>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/DE>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/DEU>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/DE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/DE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/DE>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/DE>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/DE>,
+        <http://publications.europa.eu/resource/authority/country/DEU>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/DE>,
+        <http://rod.eionet.europa.eu/spatial/15>,
+        <http://sws.geonames.org/2921044/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "DE" ;
+    skos:prefLabel "Germany",
+        "Германия"@bg,
+        "Německo"@cs,
+        "Tyskland"@da,
+        "Deutschland"@de,
+        "Γερμανία"@el,
+        "Germany"@en,
+        "Alemania"@es,
+        "Saksamaa"@et,
+        "Saksa"@fi,
+        "Allemagne (l’)"@fr,
+        "an Ghearmáin"@ga,
+        "Njemačka"@hr,
+        "Németország"@hu,
+        "Germania"@it,
+        "Vokietija"@lt,
+        "Vācija"@lv,
+        "il-Ġermanja"@mt,
+        "Duitsland"@nl,
+        "Niemcy"@pl,
+        "Alemanha"@pt,
+        "Germania"@ro,
+        "Nemecko"@sk,
+        "Nemčija"@sl,
+        "Tyskland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/DJ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/DJ>,
+        <http://publications.europa.eu/resource/authority/country/DJI>,
+        <http://sws.geonames.org/223816/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "DJ" ;
+    skos:prefLabel "Djibouti",
+        "Джибути"@bg,
+        "Džibutsko"@cs,
+        "Djibouti"@da,
+        "Dschibuti"@de,
+        "Τζιμπουτί"@el,
+        "Djibouti"@en,
+        "Yibuti"@es,
+        "Djibouti"@et,
+        "Djibouti"@fi,
+        "Djibouti"@fr,
+        "Djibouti"@ga,
+        "Džibuti"@hr,
+        "Dzsibuti"@hu,
+        "Gibuti"@it,
+        "Džibutis"@lt,
+        "Džibutija"@lv,
+        "Ġibuti"@mt,
+        "Djibouti"@nl,
+        "Dżibuti"@pl,
+        "Jibuti"@pt,
+        "Djibouti"@ro,
+        "Džibutsko"@sk,
+        "Džibuti"@sl,
+        "Djibouti"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/DK> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Denmark>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/DK>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/DK>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/DNK>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/DK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/DK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/DK>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/DK>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/DK>,
+        <http://publications.europa.eu/resource/authority/country/DNK>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/DK>,
+        <http://rod.eionet.europa.eu/spatial/11>,
+        <http://sws.geonames.org/2623032/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "DK" ;
+    skos:prefLabel "Denmark",
+        "Дания"@bg,
+        "Dánsko"@cs,
+        "Danmark"@da,
+        "Dänemark"@de,
+        "Δανία"@el,
+        "Denmark"@en,
+        "Dinamarca"@es,
+        "Taani"@et,
+        "Tanska"@fi,
+        "Danemark (le)"@fr,
+        "an Danmhairg"@ga,
+        "Danska"@hr,
+        "Dánia"@hu,
+        "Danimarca"@it,
+        "Danija"@lt,
+        "Dānija"@lv,
+        "id-Danimarka"@mt,
+        "Denemarken"@nl,
+        "Dania"@pl,
+        "Dinamarca"@pt,
+        "Danemarca"@ro,
+        "Dánsko"@sk,
+        "Danska"@sl,
+        "Danmark"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/DM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/DM>,
+        <http://publications.europa.eu/resource/authority/country/DMA>,
+        <http://sws.geonames.org/3575830/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "DM" ;
+    skos:prefLabel "Dominica",
+        "Доминика"@bg,
+        "Dominika"@cs,
+        "Dominica"@da,
+        "Dominica"@de,
+        "Ντομίνικα"@el,
+        "Dominica"@en,
+        "Dominica"@es,
+        "Dominica"@et,
+        "Dominica"@fi,
+        "Dominique (la)"@fr,
+        "Doiminice"@ga,
+        "Dominika"@hr,
+        "Dominika"@hu,
+        "Dominica"@it,
+        "Dominika"@lt,
+        "Dominika"@lv,
+        "Dominika"@mt,
+        "Dominica"@nl,
+        "Dominika"@pl,
+        "Domínica"@pt,
+        "Dominica"@ro,
+        "Dominika"@sk,
+        "Dominika"@sl,
+        "Dominica"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/DO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/DO>,
+        <http://publications.europa.eu/resource/authority/country/DOM>,
+        <http://sws.geonames.org/3508796/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "DO" ;
+    skos:prefLabel "Dominican Republic",
+        "Доминиканска република"@bg,
+        "Dominikánská republika"@cs,
+        "Dominikanske Republik, Den"@da,
+        "die Dominikanische Republik"@de,
+        "Δομινικανή Δημοκρατία"@el,
+        "Dominican Republic"@en,
+        "República Dominicana"@es,
+        "Dominikaani Vabariik"@et,
+        "Dominikaaninen tasavalta"@fi,
+        "République dominicaine (la)"@fr,
+        "an Phoblacht Dhoiminiceach"@ga,
+        "Dominikanska Republika"@hr,
+        "Dominikai Köztársaság"@hu,
+        "Repubblica dominicana"@it,
+        "Dominikos Respublika"@lt,
+        "Dominikāna"@lv,
+        "ir-Repubblika Dominikana"@mt,
+        "Dominicaanse Republiek"@nl,
+        "Dominikana"@pl,
+        "República Dominicana"@pt,
+        "Republica Dominicană"@ro,
+        "Dominikánska republika"@sk,
+        "Dominikanska republika"@sl,
+        "Dominikanska republiken"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/DZ> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Algeria>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/DZA>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/DZ>,
+        <http://publications.europa.eu/resource/authority/country/DZA>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/DZ>,
+        <http://rod.eionet.europa.eu/spatial/110>,
+        <http://sws.geonames.org/2589581/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "DZ" ;
+    skos:prefLabel "Algeria",
+        "Алжир"@bg,
+        "Alžírsko"@cs,
+        "Algeriet"@da,
+        "Algerien"@de,
+        "Αλγερία"@el,
+        "Algeria"@en,
+        "Argelia"@es,
+        "Alžeeria"@et,
+        "Algeria"@fi,
+        "Algérie (l’)"@fr,
+        "an Ailgéir"@ga,
+        "Alžir"@hr,
+        "Algéria"@hu,
+        "Algeria"@it,
+        "Alžyras"@lt,
+        "Alžīrija"@lv,
+        "l-Alġerija"@mt,
+        "Algerije"@nl,
+        "Algieria"@pl,
+        "Argélia"@pt,
+        "Algeria"@ro,
+        "Alžírsko"@sk,
+        "Alžirija"@sl,
+        "Algeriet"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/EC> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/EC>,
+        <http://publications.europa.eu/resource/authority/country/ECU>,
+        <http://sws.geonames.org/3658394/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "EC" ;
+    skos:prefLabel "Ecuador",
+        "Еквадор"@bg,
+        "Ekvádor"@cs,
+        "Ecuador"@da,
+        "Ecuador"@de,
+        "Ισημερινός"@el,
+        "Ecuador"@en,
+        "Ecuador"@es,
+        "Ecuador"@et,
+        "Ecuador"@fi,
+        "Équateur (l’)"@fr,
+        "Eacuadór"@ga,
+        "Ekvador"@hr,
+        "Ecuador"@hu,
+        "Ecuador"@it,
+        "Ekvadoras"@lt,
+        "Ekvadora"@lv,
+        "l-Ekwador"@mt,
+        "Ecuador"@nl,
+        "Ekwador"@pl,
+        "Equador"@pt,
+        "Ecuador"@ro,
+        "Ekvádor"@sk,
+        "Ekvador"@sl,
+        "Ecuador"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/EE> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Estonia>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/EE>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/EE>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/EST>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/EE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/EE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/EE>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/EE>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/EE>,
+        <http://publications.europa.eu/resource/authority/country/EST>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/EE>,
+        <http://rod.eionet.europa.eu/spatial/12>,
+        <http://sws.geonames.org/453733/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "EE" ;
+    skos:prefLabel "Estonia",
+        "Естония"@bg,
+        "Estonsko"@cs,
+        "Estland"@da,
+        "Estland"@de,
+        "Εσθονία"@el,
+        "Estonia"@en,
+        "Estonia"@es,
+        "Eesti"@et,
+        "Viro"@fi,
+        "Estonie (l’)"@fr,
+        "an Eastóin"@ga,
+        "Estonija"@hr,
+        "Észtország"@hu,
+        "Estonia"@it,
+        "Estija"@lt,
+        "Igaunija"@lv,
+        "l-Estonja"@mt,
+        "Estland"@nl,
+        "Estonia"@pl,
+        "Estónia"@pt,
+        "Estonia"@ro,
+        "Estónsko"@sk,
+        "Estonija"@sl,
+        "Estland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/EG> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Egypt>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/EGY>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/EG>,
+        <http://publications.europa.eu/resource/authority/country/EGY>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/EG>,
+        <http://rod.eionet.europa.eu/spatial/109>,
+        <http://sws.geonames.org/357994/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "EG" ;
+    skos:prefLabel "Egypt",
+        "Египет"@bg,
+        "Egypt"@cs,
+        "Egypten"@da,
+        "Ägypten"@de,
+        "Αίγυπτος"@el,
+        "Egypt"@en,
+        "Egipto"@es,
+        "Egiptus"@et,
+        "Egypti"@fi,
+        "Égypte (l’)"@fr,
+        "an Éigipt"@ga,
+        "Egipat"@hr,
+        "Egyiptom"@hu,
+        "Egitto"@it,
+        "Egiptas"@lt,
+        "Ēģipte"@lv,
+        "l-Eġittu"@mt,
+        "Egypte"@nl,
+        "Egipt"@pl,
+        "Egito"@pt,
+        "Egipt"@ro,
+        "Egypt"@sk,
+        "Egipt"@sl,
+        "Egypten"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/EH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/EH>,
+        <http://publications.europa.eu/resource/authority/country/ESH>,
+        <http://sws.geonames.org/2461445/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "EH" ;
+    skos:prefLabel "Western Sahara",
+        "Западна Сахара"@bg,
+        "Západní Sahara"@cs,
+        "Vestsahara"@da,
+        "Westsahara"@de,
+        "Δυτική Σαχάρα"@el,
+        "Western Sahara"@en,
+        "Sáhara Occidental"@es,
+        "Lääne-Sahara"@et,
+        "Länsi-Sahara"@fi,
+        "Sahara occidental (le)"@fr,
+        "an Sahára Thiar"@ga,
+        "Zapadna Sahara"@hr,
+        "Nyugat-Szahara"@hu,
+        "Sahara occidentale (il)"@it,
+        "Vakarų Sachara"@lt,
+        "Rietumsahāra"@lv,
+        "is-Saħara tal-Punent"@mt,
+        "Westelijke Sahara"@nl,
+        "Sahara Zachodnia"@pl,
+        "Sara Ocidental"@pt,
+        "Sahara Occidentală"@ro,
+        "Západná Sahara"@sk,
+        "Zahodna Sahara"@sl,
+        "Västsahara"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ER> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ER>,
+        <http://publications.europa.eu/resource/authority/country/ERI>,
+        <http://sws.geonames.org/338010/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ER" ;
+    skos:prefLabel "Eritrea",
+        "Еритрея"@bg,
+        "Eritrea"@cs,
+        "Eritrea"@da,
+        "Eritrea"@de,
+        "Ερυθραία"@el,
+        "Eritrea"@en,
+        "Eritrea"@es,
+        "Eritrea"@et,
+        "Eritrea"@fi,
+        "Érythrée (l’)"@fr,
+        "an Eiritré"@ga,
+        "Eritreja"@hr,
+        "Eritrea"@hu,
+        "Eritrea"@it,
+        "Eritrėja"@lt,
+        "Eritreja"@lv,
+        "l-Eritrea"@mt,
+        "Eritrea"@nl,
+        "Erytrea"@pl,
+        "Eritreia"@pt,
+        "Eritreea"@ro,
+        "Eritrea"@sk,
+        "Eritreja"@sl,
+        "Eritrea"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ES> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Spain>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/ES>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/ES>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ESP>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/ES>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/ES>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ES>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/ES>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/ES>,
+        <http://publications.europa.eu/resource/authority/country/ESP>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/ES>,
+        <http://rod.eionet.europa.eu/spatial/35>,
+        <http://sws.geonames.org/2510769/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ES" ;
+    skos:prefLabel "Spain",
+        "Испания"@bg,
+        "Španělsko"@cs,
+        "Spanien"@da,
+        "Spanien"@de,
+        "Ισπανία"@el,
+        "Spain"@en,
+        "España"@es,
+        "Hispaania"@et,
+        "Espanja"@fi,
+        "Espagne (l’)"@fr,
+        "an Spáinn"@ga,
+        "Španjolska"@hr,
+        "Spanyolország"@hu,
+        "Spagna"@it,
+        "Ispanija"@lt,
+        "Spānija"@lv,
+        "Spanja"@mt,
+        "Spanje"@nl,
+        "Hiszpania"@pl,
+        "Espanha"@pt,
+        "Spania"@ro,
+        "Španielsko"@sk,
+        "Španija"@sl,
+        "Spanien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ET> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ET>,
+        <http://publications.europa.eu/resource/authority/country/ETH>,
+        <http://sws.geonames.org/337996/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ET" ;
+    skos:prefLabel "Ethiopia",
+        "Етиопия"@bg,
+        "Etiopie"@cs,
+        "Etiopien"@da,
+        "Äthiopien"@de,
+        "Αιθιοπία"@el,
+        "Ethiopia"@en,
+        "Etiopía"@es,
+        "Etioopia"@et,
+        "Etiopia"@fi,
+        "Éthiopie (l’)"@fr,
+        "an Aetóip"@ga,
+        "Etiopija"@hr,
+        "Etiópia"@hu,
+        "Etiopia"@it,
+        "Etiopija"@lt,
+        "Etiopija"@lv,
+        "l-Etjopja"@mt,
+        "Ethiopië"@nl,
+        "Etiopia"@pl,
+        "Etiópia"@pt,
+        "Etiopia"@ro,
+        "Etiópia"@sk,
+        "Etiopija"@sl,
+        "Etiopien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/FI> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Finland>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/FI>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/FI>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/FIN>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/FI>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/FI>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/FI>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/FI>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/FI>,
+        <http://publications.europa.eu/resource/authority/country/FIN>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/FI>,
+        <http://rod.eionet.europa.eu/spatial/13>,
+        <http://sws.geonames.org/660013/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "FI" ;
+    skos:prefLabel "Finland",
+        "Финландия"@bg,
+        "Finsko"@cs,
+        "Finland"@da,
+        "Finnland"@de,
+        "Φινλανδία"@el,
+        "Finland"@en,
+        "Finlandia"@es,
+        "Soome"@et,
+        "Suomi"@fi,
+        "Finlande (la)"@fr,
+        "an Fhionlainn"@ga,
+        "Finska"@hr,
+        "Finnország"@hu,
+        "Finlandia"@it,
+        "Suomija"@lt,
+        "Somija"@lv,
+        "il-Finlandja"@mt,
+        "Finland"@nl,
+        "Finlandia"@pl,
+        "Finlândia"@pt,
+        "Finlanda"@ro,
+        "Fínsko"@sk,
+        "Finska"@sl,
+        "Finland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/FJ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/FJ>,
+        <http://publications.europa.eu/resource/authority/country/FJI>,
+        <http://sws.geonames.org/2205218/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "FJ" ;
+    skos:prefLabel "Fiji",
+        "Фиджи"@bg,
+        "Fidži"@cs,
+        "Fiji"@da,
+        "Fidschi"@de,
+        "Φίτζι"@el,
+        "Fiji"@en,
+        "Fiyi"@es,
+        "Fidži"@et,
+        "Fidži"@fi,
+        "Fidji (les)"@fr,
+        "Fidsí"@ga,
+        "Fidži"@hr,
+        "Fidzsi"@hu,
+        "Figi"@it,
+        "Fidžis"@lt,
+        "Fidži"@lv,
+        "Fiġi"@mt,
+        "Fiji"@nl,
+        "Fidżi"@pl,
+        "Fiji"@pt,
+        "Fiji"@ro,
+        "Fidži"@sk,
+        "Fidži"@sl,
+        "Fiji"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/FK> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/FLK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/FK>,
+        <http://publications.europa.eu/resource/authority/country/FLK>,
+        <http://sws.geonames.org/3474414/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "FK" ;
+    skos:prefLabel "Falkland Islands",
+        "Фолкландски острови"@bg,
+        "Falklandské ostrovy"@cs,
+        "Falklandsøerne"@da,
+        "die Falklandinseln (Malwinen)"@de,
+        "Νήσοι Φόκλαντ"@el,
+        "Falkland Islands"@en,
+        "Islas Malvinas"@es,
+        "Falklandi saared"@et,
+        "Falklandinsaaret"@fi,
+        "Îles Falkland (les)"@fr,
+        "Oileáin Fháclainne"@ga,
+        "Falklandski Otoci"@hr,
+        "Falkland-szigetek"@hu,
+        "Isole Falkland (le)"@it,
+        "Folklandas"@lt,
+        "Folklenda (Malvinu) Salas"@lv,
+        "il-Gżejjer Falkland"@mt,
+        "Falklandeilanden"@nl,
+        "Falklandy"@pl,
+        "Ilhas Falkland"@pt,
+        "Insulele Falkland"@ro,
+        "Falklandy"@sk,
+        "Falklandski otoki"@sl,
+        "Falklandsöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/FM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/FM>,
+        <http://publications.europa.eu/resource/authority/country/FSM>,
+        <http://sws.geonames.org/2081918/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "FM" ;
+    skos:prefLabel "Micronesia",
+        "Микронезия"@bg,
+        "Mikronésie"@cs,
+        "Mikronesien"@da,
+        "Mikronesien"@de,
+        "Μικρονησία"@el,
+        "Micronesia"@en,
+        "Micronesia"@es,
+        "Mikroneesia"@et,
+        "Mikronesia"@fi,
+        "Micronésie (la)"@fr,
+        "an Mhicrinéis"@ga,
+        "Mikronezija"@hr,
+        "Mikronézia"@hu,
+        "Micronesia"@it,
+        "Mikronezija"@lt,
+        "Mikronēzija"@lv,
+        "il-Mikroneżja"@mt,
+        "Micronesia"@nl,
+        "Mikronezja"@pl,
+        "Micronésia"@pt,
+        "Micronezia"@ro,
+        "Mikronézia"@sk,
+        "Mikronezija"@sl,
+        "Mikronesien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/FO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/FRO>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/FO>,
+        <http://publications.europa.eu/resource/authority/country/FRO>,
+        <http://sws.geonames.org/2622320/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "FO" ;
+    skos:prefLabel "Faroe Islands",
+        "Фарьорски острови"@bg,
+        "Faerské ostrovy"@cs,
+        "Færøerne"@da,
+        "die Färöer"@de,
+        "Φερόες Νήσοι"@el,
+        "Faeroe Islands"@en,
+        "Islas Feroe"@es,
+        "Fääri saared"@et,
+        "Färsaaret"@fi,
+        "Féroé (les)"@fr,
+        "Oileáin Fharó"@ga,
+        "Francuska"@hr,
+        "Feröer szigetek"@hu,
+        "Fær Øer (le)"@it,
+        "Farerai"@lt,
+        "Fēru Salas"@lv,
+        "il-Gżejjer Faeroe"@mt,
+        "Faeröer"@nl,
+        "Wyspy Owcze"@pl,
+        "Faroé"@pt,
+        "Insulele Feroe"@ro,
+        "Faerské ostrovy"@sk,
+        "Ferski otoki"@sl,
+        "Färöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/FR> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/France>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/FR>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/FR>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/FRA>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/FR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/FR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/FR>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/FR>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/FR>,
+        <http://publications.europa.eu/resource/authority/country/FRA>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/FR>,
+        <http://rod.eionet.europa.eu/spatial/14>,
+        <http://sws.geonames.org/3017382/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "FR" ;
+    skos:prefLabel "France",
+        "Франция"@bg,
+        "Francie"@cs,
+        "Frankrig"@da,
+        "Frankreich"@de,
+        "Γαλλία"@el,
+        "France"@en,
+        "Francia"@es,
+        "Prantsusmaa"@et,
+        "Ranska"@fi,
+        "France (la)"@fr,
+        "an Fhrainc"@ga,
+        "Gabon"@hr,
+        "Franciaország"@hu,
+        "Francia"@it,
+        "Prancūzija"@lt,
+        "Francija"@lv,
+        "Franza"@mt,
+        "Frankrijk"@nl,
+        "Francja"@pl,
+        "França"@pt,
+        "Franța"@ro,
+        "Francúzsko"@sk,
+        "Francija"@sl,
+        "Frankrike"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GA> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GA>,
+        <http://publications.europa.eu/resource/authority/country/GAB>,
+        <http://sws.geonames.org/2400553/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GA" ;
+    skos:prefLabel "Gabon",
+        "Габон"@bg,
+        "Gabon"@cs,
+        "Gabon"@da,
+        "Gabun"@de,
+        "Γκαμπόν"@el,
+        "Gabon"@en,
+        "Gabón"@es,
+        "Gabon"@et,
+        "Gabon"@fi,
+        "Gabon (le)"@fr,
+        "an Ghabúin"@ga,
+        "Grenada"@hr,
+        "Gabon"@hu,
+        "Gabon"@it,
+        "Gabonas"@lt,
+        "Gabona"@lv,
+        "il-Gabon"@mt,
+        "Gabon"@nl,
+        "Gabon"@pl,
+        "Gabão"@pt,
+        "Gabon"@ro,
+        "Gabon"@sk,
+        "Gabon"@sl,
+        "Gabon"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GB> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/United_Kingdom>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/UK>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/UK>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/GBR>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/UK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/UK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/UK>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/UK>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/UK>,
+        <http://publications.europa.eu/resource/authority/country/GBR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/GB>,
+        <http://rod.eionet.europa.eu/spatial/40>,
+        <http://sws.geonames.org/2635167/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GB" ;
+    skos:prefLabel "United Kingdom",
+        "Обединено кралство"@bg,
+        "Spojené království"@cs,
+        "Forenede Kongerige, Det"@da,
+        "das Vereinigte Königreich"@de,
+        "Ηνωμένο Βασίλειο"@el,
+        "United Kingdom"@en,
+        "Reino Unido"@es,
+        "Ühendkuningriik"@et,
+        "Yhdistynyt kuningaskunta"@fi,
+        "Royaume-Uni (le)"@fr,
+        "an Ríocht Aontaithe"@ga,
+        "Ujedinjena Kraljevina"@hr,
+        "Egyesült Királyság"@hu,
+        "Regno Unito"@it,
+        "Jungtinė Karalystė"@lt,
+        "Apvienotā Karaliste"@lv,
+        "ir-Renju Unit"@mt,
+        "Verenigd Koninkrijk"@nl,
+        "Zjednoczone Królestwo"@pl,
+        "Reino Unido"@pt,
+        "Regatul Unit"@ro,
+        "Spojené kráľovstvo"@sk,
+        "Združeno kraljestvo"@sl,
+        "Förenade kungariket"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GD> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GD>,
+        <http://publications.europa.eu/resource/authority/country/GRD>,
+        <http://sws.geonames.org/3580239/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GD" ;
+    skos:prefLabel "Grenada",
+        "Гренада"@bg,
+        "Grenada"@cs,
+        "Grenada"@da,
+        "Grenada"@de,
+        "Γρενάδα"@el,
+        "Grenada"@en,
+        "Granada"@es,
+        "Grenada"@et,
+        "Grenada"@fi,
+        "Grenade (la)"@fr,
+        "Greanáda"@ga,
+        "Grenada"@hr,
+        "Grenada"@hu,
+        "Grenada"@it,
+        "Grenada"@lt,
+        "Grenāda"@lv,
+        "Grenada"@mt,
+        "Grenada"@nl,
+        "Grenada"@pl,
+        "Granada"@pt,
+        "Grenada"@ro,
+        "Grenada"@sk,
+        "Grenada"@sl,
+        "Grenada"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GE> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Georgia>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/GEO>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GE>,
+        <http://publications.europa.eu/resource/authority/country/GEO>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/GE>,
+        <http://rod.eionet.europa.eu/spatial/99>,
+        <http://sws.geonames.org/614540/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GE" ;
+    skos:prefLabel "Georgia",
+        "Грузия"@bg,
+        "Gruzie"@cs,
+        "Georgien"@da,
+        "Georgien"@de,
+        "Γεωργία"@el,
+        "Georgia"@en,
+        "Georgia"@es,
+        "Gruusia"@et,
+        "Georgia"@fi,
+        "Géorgie (la)"@fr,
+        "an tSeoirsia"@ga,
+        "Gruzija"@hr,
+        "Grúzia"@hu,
+        "Georgia"@it,
+        "Gruzija"@lt,
+        "Gruzija"@lv,
+        "il-Ġeorġja"@mt,
+        "Georgië"@nl,
+        "Gruzja"@pl,
+        "Geórgia"@pt,
+        "Georgia"@ro,
+        "Gruzínsko"@sk,
+        "Gruzija"@sl,
+        "Georgien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/GUF>,
+        <http://publications.europa.eu/resource/authority/country/GUF>,
+        <http://sws.geonames.org/3381670/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GF" ;
+    skos:prefLabel "French Guiana",
+        "Френска Гвиана"@bg,
+        "Francouzská Guyana"@cs,
+        "Fransk Guyana"@da,
+        "Französisch-Guayana"@de,
+        "Γουιάνα"@el,
+        "French Guiana"@en,
+        "Guayana Francesa"@es,
+        "Prantsuse Guajaana"@et,
+        "Ranskan Guayana"@fi,
+        "Guyane (la)"@fr,
+        "Guáin na Fraince"@ga,
+        "Francuska Gijana"@hr,
+        "Francia Guyana"@hu,
+        "Guyana francese (la)"@it,
+        "Prancūzijos Gviana"@lt,
+        "Francijas Gviāna"@lv,
+        "il-Gujana Franċiża"@mt,
+        "Frans-Guyana"@nl,
+        "Gujana Francuska"@pl,
+        "Guiana Francesa"@pt,
+        "Guyana Franceză"@ro,
+        "Francúzska Guyana"@sk,
+        "Francoska Gvajana"@sl,
+        "Franska Guyana"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GG>,
+        <http://publications.europa.eu/resource/authority/country/GGY>,
+        <http://sws.geonames.org/3042362/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GG" ;
+    skos:prefLabel "Guernsey",
+        "Гърнзи"@bg,
+        "Guernsey"@cs,
+        "Guernsey"@da,
+        "Guernsey"@de,
+        "Γκέρνζι"@el,
+        "Guernsey"@en,
+        "Guernesey"@es,
+        "Guernsey"@et,
+        "Guernsey"@fi,
+        "Guernesey"@fr,
+        "Geansaí"@ga,
+        "Guernsey"@hr,
+        "Guernsey"@hu,
+        "Guernsey"@it,
+        "Gernsis"@lt,
+        "Gērnsija"@lv,
+        "Guernsey"@mt,
+        "Guernsey"@nl,
+        "Guernsey"@pl,
+        "Guernesey"@pt,
+        "Guernsey"@ro,
+        "Guernsey"@sk,
+        "Guernsey"@sl,
+        "Guernsey"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GH>,
+        <http://publications.europa.eu/resource/authority/country/GHA>,
+        <http://sws.geonames.org/2300660/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GH" ;
+    skos:prefLabel "Ghana",
+        "Гана"@bg,
+        "Ghana"@cs,
+        "Ghana"@da,
+        "Ghana"@de,
+        "Γκάνα"@el,
+        "Ghana"@en,
+        "Ghana"@es,
+        "Ghana"@et,
+        "Ghana"@fi,
+        "Ghana (le)"@fr,
+        "Gána"@ga,
+        "Gana"@hr,
+        "Ghána"@hu,
+        "Ghana"@it,
+        "Gana"@lt,
+        "Gana"@lv,
+        "il-Gana"@mt,
+        "Ghana"@nl,
+        "Ghana"@pl,
+        "Gana"@pt,
+        "Ghana"@ro,
+        "Ghana"@sk,
+        "Gana"@sl,
+        "Ghana"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GI> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Gibraltar>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/GIB>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GI>,
+        <http://publications.europa.eu/resource/authority/country/GIB>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/GI>,
+        <http://rod.eionet.europa.eu/spatial/114>,
+        <http://sws.geonames.org/2411586/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GI" ;
+    skos:prefLabel "Gibraltar",
+        "Гибралтар"@bg,
+        "Gibraltar"@cs,
+        "Gibraltar"@da,
+        "Gibraltar"@de,
+        "Γιβραλτάρ"@el,
+        "Gibraltar"@en,
+        "Gibraltar"@es,
+        "Gibraltar"@et,
+        "Gibraltar"@fi,
+        "Gibraltar"@fr,
+        "Giobráltar"@ga,
+        "Gibraltar"@hr,
+        "Gibraltár"@hu,
+        "Gibilterra"@it,
+        "Gibraltaras"@lt,
+        "Gibraltārs"@lv,
+        "Ġibiltà"@mt,
+        "Gibraltar"@nl,
+        "Gibraltar"@pl,
+        "Gibraltar"@pt,
+        "Gibraltar"@ro,
+        "Gibraltár"@sk,
+        "Gibraltar"@sl,
+        "Gibraltar"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GL> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Greenland>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/GRL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GL>,
+        <http://publications.europa.eu/resource/authority/country/GRL>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/GL>,
+        <http://rod.eionet.europa.eu/spatial/120>,
+        <http://sws.geonames.org/3425505/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GL" ;
+    skos:prefLabel "Greenland",
+        "Гренландия"@bg,
+        "Grónsko"@cs,
+        "Grønland"@da,
+        "Grönland"@de,
+        "Γροιλανδία"@el,
+        "Greenland"@en,
+        "Groenlandia"@es,
+        "Gröönimaa"@et,
+        "Grönlanti"@fi,
+        "Groenland (le)"@fr,
+        "an Ghraonlainn"@ga,
+        "Grenland"@hr,
+        "Grönland"@hu,
+        "Groenlandia (la)"@it,
+        "Grenlandija"@lt,
+        "Grenlande"@lv,
+        "il-Groenlandja"@mt,
+        "Groenland"@nl,
+        "Grenlandia"@pl,
+        "Gronelândia"@pt,
+        "Groenlanda"@ro,
+        "Grónsko"@sk,
+        "Grenlandija"@sl,
+        "Grönland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GM>,
+        <http://publications.europa.eu/resource/authority/country/GMB>,
+        <http://sws.geonames.org/2413451/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GM" ;
+    skos:prefLabel "Gambia",
+        "Gambija"@bg,
+        "Gambie"@cs,
+        "Gambia"@da,
+        "Gambia"@de,
+        "Γκάμπια"@el,
+        "Gambia, The"@en,
+        "Gambia"@es,
+        "Gambia"@et,
+        "Gambia"@fi,
+        "Gambie (la)"@fr,
+        "an Ghaimbia"@ga,
+        "Gambia"@hu,
+        "Gambia"@it,
+        "Gambija"@lt,
+        "Gambija"@lv,
+        "il-Gambja"@mt,
+        "Gambia"@nl,
+        "Gambia"@pl,
+        "Gâmbia"@pt,
+        "Gambia"@ro,
+        "Gambia"@sk,
+        "Gambija"@sl,
+        "Gambia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GN>,
+        <http://publications.europa.eu/resource/authority/country/GIN>,
+        <http://sws.geonames.org/2420477/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GN" ;
+    skos:prefLabel "Guinea",
+        "Гвинея"@bg,
+        "Guinea"@cs,
+        "Guinea"@da,
+        "Guinea"@de,
+        "Γουινέα"@el,
+        "Guinea"@en,
+        "Guinea"@es,
+        "Guinea"@et,
+        "Guinea"@fi,
+        "Guinée (la)"@fr,
+        "an Ghuine"@ga,
+        "Gvineja"@hr,
+        "Guinea"@hu,
+        "Guinea"@it,
+        "Gvinėja"@lt,
+        "Gvineja"@lv,
+        "il-Ginea"@mt,
+        "Guinee"@nl,
+        "Gwinea"@pl,
+        "Guiné"@pt,
+        "Guineea"@ro,
+        "Guinea"@sk,
+        "Gvineja"@sl,
+        "Guinea"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GP> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/GLP>,
+        <http://publications.europa.eu/resource/authority/country/GLP>,
+        <http://sws.geonames.org/3579143/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GP" ;
+    skos:prefLabel "Guadeloupe",
+        "Гваделупа"@bg,
+        "Guadeloupe"@cs,
+        "Guadeloupe"@da,
+        "Guadeloupe"@de,
+        "Γουαδελούπη"@el,
+        "Guadeloupe"@en,
+        "Guadalupe"@es,
+        "Guadeloupe"@et,
+        "Guadeloupe"@fi,
+        "Guadeloupe (la)"@fr,
+        "Guadalúip"@ga,
+        "Guadalupa"@hr,
+        "Guadeloupe"@hu,
+        "Guadalupa (la)"@it,
+        "Gvadelupa"@lt,
+        "Gvadelupa"@lv,
+        "il-Gwadelup"@mt,
+        "Guadeloupe"@nl,
+        "Gwadelupa"@pl,
+        "Guadalupe"@pt,
+        "Guadelupa"@ro,
+        "Guadeloupe"@sk,
+        "Guadeloupe"@sl,
+        "Guadeloupe"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GQ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GQ>,
+        <http://publications.europa.eu/resource/authority/country/GNQ>,
+        <http://sws.geonames.org/2309096/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GQ" ;
+    skos:prefLabel "Equatorial Guinea",
+        "Екваториална Гвинея"@bg,
+        "Rovníková Guinea"@cs,
+        "Ækvatorialguinea"@da,
+        "Äquatorialguinea"@de,
+        "Ισημερινή Γουινέα"@el,
+        "Equatorial Guinea"@en,
+        "Guinea Ecuatorial"@es,
+        "Ekvatoriaal-Guinea"@et,
+        "Päiväntasaajan Guinea"@fi,
+        "Guinée équatoriale (la)"@fr,
+        "an Ghuine Mheánchiorclach"@ga,
+        "Ekvatorska Gvineja"@hr,
+        "Egyenlítői-Guinea"@hu,
+        "Guinea equatoriale"@it,
+        "Pusiaujo Gvinėja"@lt,
+        "Ekvatoriālā Gvineja"@lv,
+        "il-Ginea Ekwatorjali"@mt,
+        "Equatoriaal-Guinea"@nl,
+        "Gwinea Równikowa"@pl,
+        "Guiné Equatorial"@pt,
+        "Guineea Ecuatorială"@ro,
+        "Rovníková Guinea"@sk,
+        "Ekvatorialna Gvineja"@sl,
+        "Ekvatorialguinea"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GR> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Greece>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/GR>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/GR>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/GRC>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/EL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/EL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/EL>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/EL>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/GR>,
+        <http://publications.europa.eu/resource/authority/country/GRC>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/GR>,
+        <http://rod.eionet.europa.eu/spatial/16>,
+        <http://sws.geonames.org/390903/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GR" ;
+    skos:prefLabel "Greece",
+        "Гърция"@bg,
+        "Řecko"@cs,
+        "Grækenland"@da,
+        "Griechenland"@de,
+        "Ελλάδα"@el,
+        "Greece"@en,
+        "Grecia"@es,
+        "Kreeka"@et,
+        "Kreikka"@fi,
+        "Grèce (la)"@fr,
+        "an Ghréig"@ga,
+        "Grčka"@hr,
+        "Görögország"@hu,
+        "Grecia"@it,
+        "Graikija"@lt,
+        "Grieķija"@lv,
+        "il-Greċja"@mt,
+        "Griekenland"@nl,
+        "Grecja"@pl,
+        "Grécia"@pt,
+        "Grecia"@ro,
+        "Grécko"@sk,
+        "Grčija"@sl,
+        "Grekland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GS> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SGS>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GS>,
+        <http://publications.europa.eu/resource/authority/country/SGS>,
+        <http://sws.geonames.org/3474415/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GS" ;
+    skos:prefLabel "South Georgia and South Sandwich Islands",
+        "Южна Джорджия и Южни Сандвичеви острови"@bg,
+        "Jižní Georgie a Jižní Sandwichovy ostrovy"@cs,
+        "Sydgeorgien og Sydsandwichøerne"@da,
+        "Südgeorgien und die Südlichen Sandwichinseln"@de,
+        "Νήσοι Νότια Γεωργία και Νότιες Σάντουιτς"@el,
+        "South Georgia and the South Sandwich Islands"@en,
+        "Georgia del Sur e Islas Sandwich del Sur"@es,
+        "Lõuna-Georgia ja Lõuna-Sandwichi saared"@et,
+        "Etelä-Georgia ja Eteläiset Sandwichsaaret"@fi,
+        "Îles Géorgie du Sud"@fr,
+        "an tSeoirsia Theas agus Oileáin Sandwich Theas"@ga,
+        "Južna Georgija i Južni Sendvički Otoci"@hr,
+        "Déli-Georgia és Déli-Sandwich-szigetek"@hu,
+        "Georgia del sud e Sandwich australi"@it,
+        "Pietų Džordžija ir Pietų Sandvičas"@lt,
+        "Dienviddžordžija un"@lv,
+        "il-Ġeorġja tan-Nofsinhar u l-Gżejjer Sandwich tan-Nofsinhar"@mt,
+        "Zuid-Georgia en de Zuidelijke Sandwicheilanden"@nl,
+        "Georgia Południowa i Sandwich Południowy"@pl,
+        "Ilhas Geórgia do Sul e Sandwich do Sul"@pt,
+        "Georgia de Sud și Insulele Sandwich de Sud"@ro,
+        "Južná Georgia a Južné Sandwichove ostrovy"@sk,
+        "Južna Georgia in Južni Sandwichevi otoki"@sl,
+        "Sydgeorgien och Sydsandwichöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GT> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GT>,
+        <http://publications.europa.eu/resource/authority/country/GTM>,
+        <http://sws.geonames.org/3595528/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GT" ;
+    skos:prefLabel "Guatemala",
+        "Гватемала"@bg,
+        "Guatemala"@cs,
+        "Guatemala"@da,
+        "Guatemala"@de,
+        "Γουατεμάλα"@el,
+        "Guatemala"@en,
+        "Guatemala"@es,
+        "Guatemala"@et,
+        "Guatemala"@fi,
+        "Guatemala (le)"@fr,
+        "Guatamala"@ga,
+        "Gvatemala"@hr,
+        "Guatemala"@hu,
+        "Guatemala"@it,
+        "Gvatemala"@lt,
+        "Gvatemala"@lv,
+        "il-Gwatemala"@mt,
+        "Guatemala"@nl,
+        "Gwatemala"@pl,
+        "Guatemala"@pt,
+        "Guatemala"@ro,
+        "Guatemala"@sk,
+        "Gvatemala"@sl,
+        "Guatemala"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GU> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GU>,
+        <http://publications.europa.eu/resource/authority/country/GUM>,
+        <http://sws.geonames.org/4043988/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GU" ;
+    skos:prefLabel "Guam",
+        "Гуам"@bg,
+        "Guam"@cs,
+        "Guam"@da,
+        "Guam"@de,
+        "Γκουάμ"@el,
+        "Guam"@en,
+        "Guam"@es,
+        "Guam"@et,
+        "Guam"@fi,
+        "Guam"@fr,
+        "Guam"@ga,
+        "Guam"@hr,
+        "Guam"@hu,
+        "Guam"@it,
+        "Guamas"@lt,
+        "Guama"@lv,
+        "Gwam"@mt,
+        "Guam"@nl,
+        "Guam"@pl,
+        "Guame"@pt,
+        "Guam"@ro,
+        "Guam"@sk,
+        "Guam"@sl,
+        "Guam"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GW>,
+        <http://publications.europa.eu/resource/authority/country/GNB>,
+        <http://sws.geonames.org/2372248/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GW" ;
+    skos:prefLabel "Guinea-Bissau",
+        "Гвинея Бисау"@bg,
+        "Guinea-Bissau"@cs,
+        "Guinea-Bissau"@da,
+        "Guinea-Bissau"@de,
+        "Γουινέα Μπισάου"@el,
+        "Guinea-Bissau"@en,
+        "Guinea-Bisáu"@es,
+        "Guinea-Bissau"@et,
+        "Guinea-Bissau"@fi,
+        "Guinée-Bissau (la)"@fr,
+        "Guine Bissau"@ga,
+        "Gvineja Bisau"@hr,
+        "Bissau-Guinea"@hu,
+        "Guinea-Bissau"@it,
+        "Bisau Gvinėja"@lt,
+        "Gvineja-Bisava"@lv,
+        "il-Ginea Bissaw"@mt,
+        "Guinee-Bissau"@nl,
+        "Gwinea Bissau"@pl,
+        "Guiné-Bissau"@pt,
+        "Guineea-Bissau"@ro,
+        "Guinea-Bissau"@sk,
+        "Gvineja Bissau"@sl,
+        "Guinea-Bissau"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/GY> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/GY>,
+        <http://publications.europa.eu/resource/authority/country/GUY>,
+        <http://sws.geonames.org/3378535/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "GY" ;
+    skos:prefLabel "Guyana",
+        "Гвиана"@bg,
+        "Guyana"@cs,
+        "Guyana"@da,
+        "Guyana"@de,
+        "Γουιάνα"@el,
+        "Guyana"@en,
+        "Guyana"@es,
+        "Guyana"@et,
+        "Guyana"@fi,
+        "Guyana (le)"@fr,
+        "an Ghuáin"@ga,
+        "Gvajana"@hr,
+        "Guyana"@hu,
+        "Guyana"@it,
+        "Gajana"@lt,
+        "Gajāna"@lv,
+        "il-Gujana"@mt,
+        "Guyana"@nl,
+        "Gujana"@pl,
+        "Guiana"@pt,
+        "Guyana"@ro,
+        "Guyana"@sk,
+        "Gvajana"@sl,
+        "Guyana"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/HK> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/HK>,
+        <http://publications.europa.eu/resource/authority/country/HKG>,
+        <http://sws.geonames.org/1819730/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "HK" ;
+    skos:prefLabel "Hong Kong",
+        "Хонконг"@bg,
+        "Hongkong"@cs,
+        "Hongkong"@da,
+        "Hongkong"@de,
+        "Χονγκ Κονγκ"@el,
+        "Hong Kong"@en,
+        "Hong Kong"@es,
+        "Hongkong"@et,
+        "Hongkong"@fi,
+        "Hong Kong"@fr,
+        "Hong Cong"@ga,
+        "Hong Kong"@hr,
+        "Hongkong"@hu,
+        "Hong Kong"@it,
+        "Honkongas"@lt,
+        "Honkonga"@lv,
+        "Ħong Kong"@mt,
+        "Hongkong"@nl,
+        "Hongkong"@pl,
+        "Hong Kong"@pt,
+        "Hong Kong"@ro,
+        "Hongkong"@sk,
+        "Hongkong"@sl,
+        "Hongkong"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/HM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/HM>,
+        <http://publications.europa.eu/resource/authority/country/HMD>,
+        <http://sws.geonames.org/1547314/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "HM" ;
+    skos:prefLabel "Heard Island and McDonald Islands" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/HN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/HN>,
+        <http://publications.europa.eu/resource/authority/country/HND>,
+        <http://sws.geonames.org/3608932/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "HN" ;
+    skos:prefLabel "Honduras" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/HR> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Croatia>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/HRV>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/HR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/HR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/HR>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/HR>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/HR>,
+        <http://publications.europa.eu/resource/authority/country/HRV>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/HR>,
+        <http://rod.eionet.europa.eu/spatial/8>,
+        <http://sws.geonames.org/3202326/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "HR" ;
+    skos:prefLabel "Croatia",
+        "Хърватия"@bg,
+        "Chorvatsko"@cs,
+        "Kroatien"@da,
+        "Kroatien"@de,
+        "Κροατία"@el,
+        "Croatia"@en,
+        "Croacia"@es,
+        "Horvaatia"@et,
+        "Kroatia"@fi,
+        "Croatie (la)"@fr,
+        "an Chróit"@ga,
+        "Hrvatska"@hr,
+        "Horvátország"@hu,
+        "Croazia"@it,
+        "Kroatija"@lt,
+        "Horvātija"@lv,
+        "il-Kroazja"@mt,
+        "Kroatië"@nl,
+        "Chorwacja"@pl,
+        "Croácia"@pt,
+        "Croația"@ro,
+        "Chorvátsko"@sk,
+        "Hrvaška"@sl,
+        "Kroatien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/HT> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/HT>,
+        <http://publications.europa.eu/resource/authority/country/HTI>,
+        <http://sws.geonames.org/3723988/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "HT" ;
+    skos:prefLabel "Haiti",
+        "Хаити"@bg,
+        "Haiti"@cs,
+        "Haiti"@da,
+        "Haiti"@de,
+        "Αϊτή"@el,
+        "Haiti"@en,
+        "Haití"@es,
+        "Haiti"@et,
+        "Haiti"@fi,
+        "Haïti"@fr,
+        "Háítí"@ga,
+        "Haiti"@hr,
+        "Haiti"@hu,
+        "Haiti"@it,
+        "Haitis"@lt,
+        "Haiti"@lv,
+        "Ħaiti"@mt,
+        "Haïti"@nl,
+        "Haiti"@pl,
+        "Haiti"@pt,
+        "Haiti"@ro,
+        "Haiti"@sk,
+        "Haiti"@sl,
+        "Haiti"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/HU> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Hungary>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/HU>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/HU>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/HUN>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/HU>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/HU>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/HU>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/HU>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/HU>,
+        <http://publications.europa.eu/resource/authority/country/HUN>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/HU>,
+        <http://rod.eionet.europa.eu/spatial/17>,
+        <http://sws.geonames.org/719819/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "HU" ;
+    skos:prefLabel "Hungary",
+        "Унгария"@bg,
+        "Maďarsko"@cs,
+        "Ungarn"@da,
+        "Ungarn"@de,
+        "Ουγγαρία"@el,
+        "Hungary"@en,
+        "Hungría"@es,
+        "Ungari"@et,
+        "Unkari"@fi,
+        "Hongrie (la)"@fr,
+        "an Ungáir"@ga,
+        "Mađarska"@hr,
+        "Magyarország"@hu,
+        "Ungheria"@it,
+        "Vengrija"@lt,
+        "Ungārija"@lv,
+        "l-Ungerija"@mt,
+        "Hongarije"@nl,
+        "Węgry"@pl,
+        "Hungria"@pt,
+        "Ungaria"@ro,
+        "Maďarsko"@sk,
+        "Madžarska"@sl,
+        "Ungern"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ID> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ID>,
+        <http://publications.europa.eu/resource/authority/country/IDN>,
+        <http://sws.geonames.org/1643084/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ID" ;
+    skos:prefLabel "Indonesia",
+        "Индонезия"@bg,
+        "Indonésie"@cs,
+        "Indonesien"@da,
+        "Indonesien"@de,
+        "Ινδονησία"@el,
+        "Indonesia"@en,
+        "Indonesia"@es,
+        "Indoneesia"@et,
+        "Indonesia"@fi,
+        "Indonésie (l’)"@fr,
+        "an Indinéis"@ga,
+        "Indonezija"@hr,
+        "Indonézia"@hu,
+        "Indonesia"@it,
+        "Indonezija"@lt,
+        "Indonēzija"@lv,
+        "l-Indoneżja"@mt,
+        "Indonesië"@nl,
+        "Indonezja"@pl,
+        "Indonésia"@pt,
+        "Indonezia"@ro,
+        "Indonézia"@sk,
+        "Indonezija"@sl,
+        "Indonesien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IE> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Ireland>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/IE>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/IE>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/IRL>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/IE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/IE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IE>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/IE>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/IE>,
+        <http://publications.europa.eu/resource/authority/country/IRL>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/IE>,
+        <http://rod.eionet.europa.eu/spatial/20>,
+        <http://sws.geonames.org/2963597/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IE" ;
+    skos:prefLabel "Ireland",
+        "Ирландия"@bg,
+        "Irsko"@cs,
+        "Irland"@da,
+        "Irland"@de,
+        "Ιρλανδία"@el,
+        "Ireland"@en,
+        "Irlanda"@es,
+        "Iirimaa"@et,
+        "Irlanti"@fi,
+        "Irlande (l’)"@fr,
+        "Éire"@ga,
+        "Irska"@hr,
+        "Írország"@hu,
+        "Irlanda"@it,
+        "Airija"@lt,
+        "Īrija"@lv,
+        "l-Irlanda"@mt,
+        "Ierland"@nl,
+        "Irlandia"@pl,
+        "Irlanda"@pt,
+        "Irlanda"@ro,
+        "Írsko"@sk,
+        "Irska"@sl,
+        "Irland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IL> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Israel>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IL>,
+        <http://publications.europa.eu/resource/authority/country/ISR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/IL>,
+        <http://rod.eionet.europa.eu/spatial/116>,
+        <http://sws.geonames.org/294640/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IL" ;
+    skos:prefLabel "Israel",
+        "Израел"@bg,
+        "Izrael"@cs,
+        "Israel"@da,
+        "Israel"@de,
+        "Ισραήλ"@el,
+        "Israel"@en,
+        "Israel"@es,
+        "Iisrael"@et,
+        "Israel"@fi,
+        "Israël"@fr,
+        "Iosrael"@ga,
+        "Izrael"@hr,
+        "Izrael"@hu,
+        "Israele"@it,
+        "Izraelis"@lt,
+        "Izraēla"@lv,
+        "l-Iżrael"@mt,
+        "Israël"@nl,
+        "Izrael"@pl,
+        "Israel"@pt,
+        "Israel"@ro,
+        "Izrael"@sk,
+        "Izrael"@sl,
+        "Israel"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IM>,
+        <http://publications.europa.eu/resource/authority/country/IMN>,
+        <http://sws.geonames.org/3042225/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IM" ;
+    skos:prefLabel "Isle of Man",
+        "Остров Ман"@bg,
+        "Ostrov Man"@cs,
+        "Isle of Man"@da,
+        "Insel Man"@de,
+        "Νήσος του Μαν"@el,
+        "Isle of Man"@en,
+        "Isla de Man"@es,
+        "Mani saar"@et,
+        "Mansaari"@fi,
+        "Île de Man (l’)"@fr,
+        "Manainn"@ga,
+        "Otok Man"@hr,
+        "Man-sziget"@hu,
+        "Isola di Man"@it,
+        "Menas"@lt,
+        "Menas Sala"@lv,
+        "il-Gżira ta’ Man"@mt,
+        "Eiland Man"@nl,
+        "Wyspa Man"@pl,
+        "Ilha de Man"@pt,
+        "Insula Man"@ro,
+        "Ostrov Man"@sk,
+        "Otok Man"@sl,
+        "Isle of Man"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IN>,
+        <http://publications.europa.eu/resource/authority/country/IND>,
+        <http://sws.geonames.org/1269750/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IN" ;
+    skos:prefLabel "India",
+        "Индия"@bg,
+        "Indie"@cs,
+        "Indien"@da,
+        "Indien"@de,
+        "Ινδία"@el,
+        "India"@en,
+        "India"@es,
+        "India"@et,
+        "Intia"@fi,
+        "Inde (l’)"@fr,
+        "an India"@ga,
+        "Indija"@hr,
+        "India"@hu,
+        "India"@it,
+        "Indija"@lt,
+        "Indija"@lv,
+        "l-Indja"@mt,
+        "India"@nl,
+        "Indie"@pl,
+        "Índia"@pt,
+        "India"@ro,
+        "India"@sk,
+        "Indija"@sl,
+        "Indien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/IOT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IO>,
+        <http://publications.europa.eu/resource/authority/country/IOT>,
+        <http://sws.geonames.org/1282588/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IO" ;
+    skos:prefLabel "British Indian Ocean Territory",
+        "Британски територии в Индийския океан"@bg,
+        "Britské indickooceánské území"@cs,
+        "britiske territorium i Det Indiske Ocean, det"@da,
+        "das Britische Territorium im Indischen Ozean"@de,
+        "Βρετανικό Έδαφος του Ινδικού Ωκεανού"@el,
+        "British Indian Ocean Territory"@en,
+        "Territorio Británico del Océano Índico"@es,
+        "Briti India ookeani ala"@et,
+        "Brittiläinen Intian valtameren alue"@fi,
+        "Territoire britannique de l’océan Indien (le)"@fr,
+        "Críoch Aigéan Indiach na Breataine"@ga,
+        "Britanski Indijskooceanski Teritorij"@hr,
+        "Brit Indiai-óceáni"@hu,
+        "Territorio britannico dell’Oceano Indiano (il)"@it,
+        "Indijos Vandenyno Britų Sritis"@lt,
+        "Britu Indijas Okeāna Teritorija"@lv,
+        "it-Territorju Brittaniku tal-Oċean Indjan"@mt,
+        "Brits Indische Oceaanterritorium"@nl,
+        "Brytyjskie Terytorium Oceanu Indyjskiego"@pl,
+        "Território Britânico do Oceano Índico"@pt,
+        "Teritoriul Britanic din Oceanul Indian"@ro,
+        "Britské indickooceánske územie"@sk,
+        "Britansko ozemlje v Indijskem oceanu"@sl,
+        "Brittiska territoriet i Indiska oceanen"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IQ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IQ>,
+        <http://publications.europa.eu/resource/authority/country/IRQ>,
+        <http://sws.geonames.org/99237/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IQ" ;
+    skos:prefLabel "Iraq",
+        "Ирак"@bg,
+        "Irák"@cs,
+        "Irak"@da,
+        "Irak"@de,
+        "Ιράκ"@el,
+        "Iraq"@en,
+        "Irak"@es,
+        "Iraak"@et,
+        "Irak"@fi,
+        "Iraq (l’)"@fr,
+        "an Iaráic"@ga,
+        "Irak"@hr,
+        "Irak"@hu,
+        "Iraq"@it,
+        "Irakas"@lt,
+        "Irāka"@lv,
+        "l-Iraq"@mt,
+        "Irak"@nl,
+        "Irak"@pl,
+        "Iraque"@pt,
+        "Irak"@ro,
+        "Irak"@sk,
+        "Irak"@sl,
+        "Irak"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IR>,
+        <http://publications.europa.eu/resource/authority/country/IRN>,
+        <http://sws.geonames.org/130758/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IR" ;
+    skos:prefLabel "Iran",
+        "Иран"@bg,
+        "Írán"@cs,
+        "Iran"@da,
+        "Iran"@de,
+        "Ιράν"@el,
+        "Iran"@en,
+        "Irán"@es,
+        "Iraan"@et,
+        "Iran"@fi,
+        "Iran (l’)"@fr,
+        "an Iaráin"@ga,
+        "Iran"@hr,
+        "Irán"@hu,
+        "Iran"@it,
+        "Iranas"@lt,
+        "Irāna"@lv,
+        "l-Iran"@mt,
+        "Iran"@nl,
+        "Iran"@pl,
+        "Irão"@pt,
+        "Iran"@ro,
+        "Irán"@sk,
+        "Iran"@sl,
+        "Iran"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IS> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Iceland>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ISL>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/IS>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IS>,
+        <http://publications.europa.eu/resource/authority/country/ISL>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/IS>,
+        <http://rod.eionet.europa.eu/spatial/18>,
+        <http://sws.geonames.org/2629691/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IS" ;
+    skos:prefLabel "Iceland",
+        "Исландия"@bg,
+        "Island"@cs,
+        "Island"@da,
+        "Island"@de,
+        "Ισλανδία"@el,
+        "Iceland"@en,
+        "Islandia"@es,
+        "Island"@et,
+        "Islanti"@fi,
+        "Islande (l’)"@fr,
+        "an Íoslainn"@ga,
+        "Island"@hr,
+        "Izland"@hu,
+        "Islanda"@it,
+        "Islandija"@lt,
+        "Islande"@lv,
+        "l-Islanda"@mt,
+        "IJsland"@nl,
+        "Islandia"@pl,
+        "Islândia"@pt,
+        "Islanda"@ro,
+        "Island"@sk,
+        "Islandija"@sl,
+        "Island"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/IT> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Italy>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/IT>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/IT>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ITA>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/IT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/IT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/IT>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/IT>,
+        <http://publications.europa.eu/resource/authority/country/ITA>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/IT>,
+        <http://rod.eionet.europa.eu/spatial/19>,
+        <http://sws.geonames.org/3175395/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "IT" ;
+    skos:prefLabel "Italy",
+        "Италия"@bg,
+        "Itálie"@cs,
+        "Italien"@da,
+        "Italien"@de,
+        "Ιταλία"@el,
+        "Italy"@en,
+        "Italia"@es,
+        "Itaalia"@et,
+        "Italia"@fi,
+        "Italie (l’)"@fr,
+        "an Iodáil"@ga,
+        "Italija"@hr,
+        "Olaszország"@hu,
+        "Italia"@it,
+        "Italija"@lt,
+        "Itālija"@lv,
+        "l-Italja"@mt,
+        "Italië"@nl,
+        "Włochy"@pl,
+        "Itália"@pt,
+        "Italia"@ro,
+        "Taliansko"@sk,
+        "Italija"@sl,
+        "Italien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/JE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/JE>,
+        <http://publications.europa.eu/resource/authority/country/JEY>,
+        <http://sws.geonames.org/3042142/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "JE" ;
+    skos:prefLabel "Jersey",
+        "Джърси"@bg,
+        "Jersey"@cs,
+        "Jersey"@da,
+        "Jersey"@de,
+        "Τζέρζι"@el,
+        "Jersey"@en,
+        "Jersey"@es,
+        "Jersey"@et,
+        "Jersey"@fi,
+        "Jersey"@fr,
+        "Geirsí"@ga,
+        "Jersey"@hr,
+        "Jersey"@hu,
+        "Jersey"@it,
+        "Džersis"@lt,
+        "Džērsija"@lv,
+        "Jersey"@mt,
+        "Jersey"@nl,
+        "Jersey"@pl,
+        "Jersey"@pt,
+        "Jersey"@ro,
+        "Jersey"@sk,
+        "Jersey"@sl,
+        "Jersey"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/JM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/JM>,
+        <http://publications.europa.eu/resource/authority/country/JAM>,
+        <http://sws.geonames.org/3489940/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "JM" ;
+    skos:prefLabel "Jamaica",
+        "Ямайка"@bg,
+        "Jamajka"@cs,
+        "Jamaica"@da,
+        "Jamaika"@de,
+        "Τζαμάικα"@el,
+        "Jamaica"@en,
+        "Jamaica"@es,
+        "Jamaica"@et,
+        "Jamaika"@fi,
+        "Jamaïque (la)"@fr,
+        "Iamáice"@ga,
+        "Jamajka"@hr,
+        "Jamaica"@hu,
+        "Giamaica"@it,
+        "Jamaika"@lt,
+        "Jamaika"@lv,
+        "il-Ġamajka"@mt,
+        "Jamaica"@nl,
+        "Jamajka"@pl,
+        "Jamaica"@pt,
+        "Jamaica"@ro,
+        "Jamajka"@sk,
+        "Jamajka"@sl,
+        "Jamaica"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/JO> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Jordan>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/JO>,
+        <http://publications.europa.eu/resource/authority/country/JOR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/JO>,
+        <http://rod.eionet.europa.eu/spatial/108>,
+        <http://sws.geonames.org/248816/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "JO" ;
+    skos:prefLabel "Jordan",
+        "Йордания"@bg,
+        "Jordánsko"@cs,
+        "Jordan"@da,
+        "Jordanien"@de,
+        "Ιορδανία"@el,
+        "Jordan"@en,
+        "Jordania"@es,
+        "Jordaania"@et,
+        "Jordania"@fi,
+        "Jordanie (la)"@fr,
+        "an Iordáin"@ga,
+        "Jordan"@hr,
+        "Jordánia"@hu,
+        "Giordania"@it,
+        "Jordanija"@lt,
+        "Jordānija"@lv,
+        "il-Ġordan"@mt,
+        "Jordanië"@nl,
+        "Jordania"@pl,
+        "Jordânia"@pt,
+        "Iordania"@ro,
+        "Jordánsko"@sk,
+        "Jordanija"@sl,
+        "Jordanien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/JP> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Japan>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/JP>,
+        <http://publications.europa.eu/resource/authority/country/JPN>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/JP>,
+        <http://sws.geonames.org/1861060/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "JP" ;
+    skos:prefLabel "Japan",
+        "Япония"@bg,
+        "Japonsko"@cs,
+        "Japan"@da,
+        "Japan"@de,
+        "Ιαπωνία"@el,
+        "Japan"@en,
+        "Japón"@es,
+        "Jaapan"@et,
+        "Japani"@fi,
+        "Japon (le)"@fr,
+        "an tSeapáin"@ga,
+        "Japan"@hr,
+        "Japán"@hu,
+        "Giappone"@it,
+        "Japonija"@lt,
+        "Japāna"@lv,
+        "il-Ġappun"@mt,
+        "Japan"@nl,
+        "Japonia"@pl,
+        "Japão"@pt,
+        "Japonia"@ro,
+        "Japonsko"@sk,
+        "Japonska"@sl,
+        "Japan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KE>,
+        <http://publications.europa.eu/resource/authority/country/KEN>,
+        <http://sws.geonames.org/192950/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KE" ;
+    skos:prefLabel "Kenya",
+        "Кения"@bg,
+        "Keňa"@cs,
+        "Kenya"@da,
+        "Kenia"@de,
+        "Κένυα"@el,
+        "Kenya"@en,
+        "Kenia"@es,
+        "Kenya"@et,
+        "Kenia"@fi,
+        "Kenya (le)"@fr,
+        "an Chéinia"@ga,
+        "Kenija"@hr,
+        "Kenya"@hu,
+        "Kenya"@it,
+        "Kenija"@lt,
+        "Kenija"@lv,
+        "il-Kenja"@mt,
+        "Kenia"@nl,
+        "Kenia"@pl,
+        "Quénia"@pt,
+        "Kenya"@ro,
+        "Keňa"@sk,
+        "Kenija"@sl,
+        "Kenya"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KG> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Kyrgyzstan>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/KGZ>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KG>,
+        <http://publications.europa.eu/resource/authority/country/KGZ>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/KG>,
+        <http://rod.eionet.europa.eu/spatial/101>,
+        <http://sws.geonames.org/1527747/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KG" ;
+    skos:prefLabel "Kyrgyzstan",
+        "Киргизстан"@bg,
+        "Kyrgyzstán"@cs,
+        "Kirgisistan"@da,
+        "Kirgisistan"@de,
+        "Κιργιζία"@el,
+        "Kyrgyzstan"@en,
+        "Kirguistán"@es,
+        "Kõrgõzstan"@et,
+        "Kirgisia"@fi,
+        "Kirghizstan (le)"@fr,
+        "an Chirgeastáin"@ga,
+        "Kirgistan"@hr,
+        "Kirgizisztán"@hu,
+        "Kirghizistan"@it,
+        "Kirgizija"@lt,
+        "Kirgizstāna"@lv,
+        "il-Kirgiżistan"@mt,
+        "Kirgizië"@nl,
+        "Kirgistan"@pl,
+        "Quirguistão"@pt,
+        "Kârgâzstan"@ro,
+        "Kirgizsko"@sk,
+        "Kirgizistan"@sl,
+        "Kirgizistan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KH>,
+        <http://publications.europa.eu/resource/authority/country/KHM>,
+        <http://sws.geonames.org/1831722/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KH" ;
+    skos:prefLabel "Cambodia",
+        "Камбоджа"@bg,
+        "Kambodža"@cs,
+        "Cambodja"@da,
+        "Kambodscha"@de,
+        "Καμπότζη"@el,
+        "Cambodia"@en,
+        "Camboya"@es,
+        "Kambodža"@et,
+        "Kambodža"@fi,
+        "Cambodge (le)"@fr,
+        "an Chambóid"@ga,
+        "Kambodža"@hr,
+        "Kambodzsa"@hu,
+        "Cambogia"@it,
+        "Kambodža"@lt,
+        "Kambodža"@lv,
+        "il-Kambodja"@mt,
+        "Cambodja"@nl,
+        "Kambodża"@pl,
+        "Camboja"@pt,
+        "Cambodgia"@ro,
+        "Kambodža"@sk,
+        "Kambodža"@sl,
+        "Kambodja"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KI> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KI>,
+        <http://publications.europa.eu/resource/authority/country/KIR>,
+        <http://sws.geonames.org/4030945/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KI" ;
+    skos:prefLabel "Kiribati",
+        "Кирибати"@bg,
+        "Kiribati"@cs,
+        "Kiribati"@da,
+        "Kiribati"@de,
+        "Κιριμπάτι"@el,
+        "Kiribati"@en,
+        "Kiribati"@es,
+        "Kiribati"@et,
+        "Kiribati"@fi,
+        "Kiribati"@fr,
+        "Cireabaití"@ga,
+        "Kiribati"@hr,
+        "Kiribati"@hu,
+        "Kiribati"@it,
+        "Kiribatis"@lt,
+        "Kiribati"@lv,
+        "Kiribati"@mt,
+        "Kiribati"@nl,
+        "Kiribati"@pl,
+        "Quiribáti"@pt,
+        "Kiribati"@ro,
+        "Kiribati"@sk,
+        "Kiribati"@sl,
+        "Kiribati"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KM>,
+        <http://publications.europa.eu/resource/authority/country/COM>,
+        <http://sws.geonames.org/921929/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KM" ;
+    skos:prefLabel "Comoros",
+        "Коморски острови"@bg,
+        "Komory"@cs,
+        "Comorerne"@da,
+        "Komoren"@de,
+        "Κομόρες"@el,
+        "Comoros"@en,
+        "Comoras"@es,
+        "Komoorid"@et,
+        "Komorit"@fi,
+        "Comores (les)"@fr,
+        "Oileáin Chomóra"@ga,
+        "Komori"@hr,
+        "Comore-szigetek"@hu,
+        "Comore"@it,
+        "Komorai"@lt,
+        "Komoru Salas"@lv,
+        "il-Komoros"@mt,
+        "Comoren"@nl,
+        "Komory"@pl,
+        "Comores"@pt,
+        "Comore"@ro,
+        "Komory"@sk,
+        "Komori"@sl,
+        "Komorerna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KN>,
+        <http://publications.europa.eu/resource/authority/country/KNA>,
+        <http://sws.geonames.org/3575174/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KN" ;
+    skos:prefLabel "Saint Kitts and Nevis",
+        "Сейнт Китс и Невис"@bg,
+        "Svatý Kryštof a Nevis"@cs,
+        "Saint Kitts og Nevis"@da,
+        "St. Kitts und Nevis"@de,
+        "Άγιος Χριστόφορος και Νέβις"@el,
+        "Saint Kitts and Nevis"@en,
+        "San Cristóbal y Nieves"@es,
+        "Saint Kitts ja Nevis"@et,
+        "Saint Kitts ja Nevis"@fi,
+        "Saint-Christophe-"@fr,
+        "San Críostóir-Nimheas"@ga,
+        "Sveti Kristofor i Nevis"@hr,
+        "Saint Kitts és Nevis"@hu,
+        "Saint Kitts e Nevis"@it,
+        "Sent Kitsas ir Nevis"@lt,
+        "Sentkitsa un Nevisa"@lv,
+        "Saint Kitts u Nevis"@mt,
+        "Saint Kitts en Nevis"@nl,
+        "Saint Kitts i Nevis"@pl,
+        "São Cristóvão e Neves"@pt,
+        "Saint Kitts și Nevis"@ro,
+        "Svätý Krištof a Nevis"@sk,
+        "Saint Kitts in Nevis"@sl,
+        "Saint Kitts och Nevis"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KP> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KP>,
+        <http://publications.europa.eu/resource/authority/country/PRK>,
+        <http://sws.geonames.org/1873107/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KP" ;
+    skos:prefLabel "Korea, North",
+        "Северна Корея"@bg,
+        "Severní Korea"@cs,
+        "Nordkorea"@da,
+        "Nordkorea"@de,
+        "Βόρεια Κορέα"@el,
+        "North Korea"@en,
+        "Corea del Norte"@es,
+        "Põhja-Korea"@et,
+        "Pohjois-Korea"@fi,
+        "Corée du Nord (la)"@fr,
+        "an Chóiré Thuaidh"@ga,
+        "Sjeverna Koreja"@hr,
+        "Észak-Korea"@hu,
+        "Corea del Nord"@it,
+        "Šiaurės Korėja"@lt,
+        "Ziemeļkoreja"@lv,
+        "il-Korea ta’ Fuq"@mt,
+        "Noord-Korea"@nl,
+        "Korea Północna"@pl,
+        "Coreia do Norte"@pt,
+        "Coreea de Nord"@ro,
+        "Severná Kórea"@sk,
+        "Severna Koreja"@sl,
+        "Nordkorea"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KR>,
+        <http://publications.europa.eu/resource/authority/country/KOR>,
+        <http://sws.geonames.org/1835841/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KR" ;
+    skos:prefLabel "Korea, South",
+        "Южна Корея"@bg,
+        "Jižní Korea"@cs,
+        "Sydkorea"@da,
+        "Südkorea"@de,
+        "Νότια Κορέα"@el,
+        "South Korea"@en,
+        "Corea del Sur"@es,
+        "Lõuna-Korea"@et,
+        "Etelä-Korea"@fi,
+        "Corée du Sud (la)"@fr,
+        "an Chóiré Theas"@ga,
+        "Južna Koreja"@hr,
+        "Dél-Korea"@hu,
+        "Corea del Sud"@it,
+        "Pietų Korėja"@lt,
+        "Dienvidkoreja"@lv,
+        "il-Korea t’Isfel"@mt,
+        "Zuid-Korea"@nl,
+        "Korea Południowa"@pl,
+        "Coreia do Sul"@pt,
+        "Coreea de Sud"@ro,
+        "Južná Kórea"@sk,
+        "Južna Koreja"@sl,
+        "Sydkorea"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KW>,
+        <http://publications.europa.eu/resource/authority/country/KWT>,
+        <http://sws.geonames.org/285570/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KW" ;
+    skos:prefLabel "Kuwait",
+        "Кувейт"@bg,
+        "Kuvajt"@cs,
+        "Kuwait"@da,
+        "Kuwait"@de,
+        "Κουβέιτ"@el,
+        "Kuwait"@en,
+        "Kuwait"@es,
+        "Kuveit"@et,
+        "Kuwait"@fi,
+        "Koweït (le)"@fr,
+        "Cuáit"@ga,
+        "Kuvajt"@hr,
+        "Kuvait"@hu,
+        "Kuwait"@it,
+        "Kuveitas"@lt,
+        "Kuveita"@lv,
+        "il-Kuwajt"@mt,
+        "Koeweit"@nl,
+        "Kuwejt"@pl,
+        "Koweit"@pt,
+        "Kuweit"@ro,
+        "Kuvajt"@sk,
+        "Kuvajt"@sl,
+        "Kuwait"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KY> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/CYM>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KY>,
+        <http://publications.europa.eu/resource/authority/country/CYM>,
+        <http://sws.geonames.org/3580718/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KY" ;
+    skos:prefLabel "Cayman Islands",
+        "Кайманови острови"@bg,
+        "Kajmanské ostrovy"@cs,
+        "Caymanøerne"@da,
+        "die Kaimaninseln"@de,
+        "Νήσοι Κάιμαν"@el,
+        "Cayman Islands"@en,
+        "Islas Caimán"@es,
+        "Kaimanisaared"@et,
+        "Caymansaaret"@fi,
+        "Îles Caïmans (les)"@fr,
+        "Oileáin Cayman"@ga,
+        "Kajmanski Otoci"@hr,
+        "Kajmán-szigetek"@hu,
+        "Isole Cayman (le)"@it,
+        "Kaimanai"@lt,
+        "Kaimanu Salas"@lv,
+        "il-Gżejjer Kajman"@mt,
+        "Kaaimaneilanden"@nl,
+        "Kajmany"@pl,
+        "Ilhas Caimão"@pt,
+        "Insulele Cayman"@ro,
+        "Kajmanie ostrovy"@sk,
+        "Kajmanski otoki"@sl,
+        "Caymanöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/KZ> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Kazakhstan>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/KAZ>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/KZ>,
+        <http://publications.europa.eu/resource/authority/country/KAZ>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/KZ>,
+        <http://rod.eionet.europa.eu/spatial/100>,
+        <http://sws.geonames.org/1522867/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "KZ" ;
+    skos:prefLabel "Kazakhstan",
+        "Казахстан"@bg,
+        "Kazachstán"@cs,
+        "Kasakhstan"@da,
+        "Kasachstan"@de,
+        "Καζαχστάν"@el,
+        "Kazakhstan"@en,
+        "Kazajistán"@es,
+        "Kasahstan"@et,
+        "Kazakstan"@fi,
+        "Kazakhstan (le)"@fr,
+        "an Chasacstáin"@ga,
+        "Kazahstan"@hr,
+        "Kazahsztán"@hu,
+        "Kazakhstan"@it,
+        "Kazachstanas"@lt,
+        "Kazahstāna"@lv,
+        "il-Kazakistan"@mt,
+        "Kazachstan"@nl,
+        "Kazachstan"@pl,
+        "Cazaquistão"@pt,
+        "Kazahstan"@ro,
+        "Kazachstan"@sk,
+        "Kazahstan"@sl,
+        "Kazakstan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LA> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LA>,
+        <http://publications.europa.eu/resource/authority/country/LAO>,
+        <http://sws.geonames.org/1655842/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LA" ;
+    skos:prefLabel "Laos",
+        "Лаос"@bg,
+        "Laos"@cs,
+        "Laos"@da,
+        "Laos"@de,
+        "Λάος"@el,
+        "Laos"@en,
+        "Laos"@es,
+        "Laos"@et,
+        "Laos"@fi,
+        "Laos (le)"@fr,
+        "Laos"@ga,
+        "Laos"@hr,
+        "Laosz"@hu,
+        "Laos"@it,
+        "Laosas"@lt,
+        "Laosa"@lv,
+        "il-Laos"@mt,
+        "Laos"@nl,
+        "Laos"@pl,
+        "Laos"@pt,
+        "Laos"@ro,
+        "Laos"@sk,
+        "Laos"@sl,
+        "Laos"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LB> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Lebanon>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LB>,
+        <http://publications.europa.eu/resource/authority/country/LBN>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/LB>,
+        <http://rod.eionet.europa.eu/spatial/117>,
+        <http://sws.geonames.org/272103/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LB" ;
+    skos:prefLabel "Lebanon",
+        "Ливан"@bg,
+        "Libanon"@cs,
+        "Libanon"@da,
+        "Libanon"@de,
+        "Λίβανος"@el,
+        "Lebanon"@en,
+        "Líbano"@es,
+        "Liibanon"@et,
+        "Libanon"@fi,
+        "Liban (le)"@fr,
+        "an Liobáin"@ga,
+        "Libanon"@hr,
+        "Libanon"@hu,
+        "Libano"@it,
+        "Libanas"@lt,
+        "Libāna"@lv,
+        "il-Libanu"@mt,
+        "Libanon"@nl,
+        "Liban"@pl,
+        "Líbano"@pt,
+        "Liban"@ro,
+        "Libanon"@sk,
+        "Libanon"@sl,
+        "Libanon"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LC> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LC>,
+        <http://publications.europa.eu/resource/authority/country/LCA>,
+        <http://sws.geonames.org/3576468/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LC" ;
+    skos:prefLabel "Saint Lucia",
+        "Сейнт Лусия"@bg,
+        "Svatá Lucie"@cs,
+        "Saint Lucia"@da,
+        "St. Lucia"@de,
+        "Αγία Λουκία"@el,
+        "Saint Lucia"@en,
+        "Santa Lucía"@es,
+        "Saint Lucia"@et,
+        "Saint Lucia"@fi,
+        "Sainte-Lucie"@fr,
+        "Saint Lucia"@ga,
+        "Sveta Lucija"@hr,
+        "Saint Lucia"@hu,
+        "Santa Lucia"@it,
+        "Sent Lusija"@lt,
+        "Sentlūsija"@lv,
+        "Santa Luċija"@mt,
+        "Saint Lucia"@nl,
+        "Saint Lucia"@pl,
+        "Santa Lúcia"@pt,
+        "Saint Lucia"@ro,
+        "Svätá Lucia"@sk,
+        "Sveta Lucija"@sl,
+        "Saint Lucia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LI> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Liechtenstein>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/LIE>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/LI>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LI>,
+        <http://publications.europa.eu/resource/authority/country/LIE>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/LI>,
+        <http://rod.eionet.europa.eu/spatial/102>,
+        <http://sws.geonames.org/3042058/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LI" ;
+    skos:prefLabel "Liechtenstein",
+        "Лихтенщайн"@bg,
+        "Lichtenštejnsko"@cs,
+        "Liechtenstein"@da,
+        "Liechtenstein"@de,
+        "Λιχτενστάιν"@el,
+        "Liechtenstein"@en,
+        "Liechtenstein"@es,
+        "Liechtenstein"@et,
+        "Liechtenstein"@fi,
+        "Liechtenstein (le)"@fr,
+        "Lichtinstéin"@ga,
+        "Lihtenštajn"@hr,
+        "Liechtenstein"@hu,
+        "Liechtenstein"@it,
+        "Lichtenšteinas"@lt,
+        "Lihtenšteina"@lv,
+        "il-Liechtenstein"@mt,
+        "Liechtenstein"@nl,
+        "Liechtenstein"@pl,
+        "Listenstaine"@pt,
+        "Liechtenstein"@ro,
+        "Lichtenštajnsko"@sk,
+        "Lihtenštajn"@sl,
+        "Liechtenstein"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LK> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LK>,
+        <http://publications.europa.eu/resource/authority/country/LKA>,
+        <http://sws.geonames.org/1227603/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LK" ;
+    skos:prefLabel "Sri Lanka",
+        "Шри Ланка"@bg,
+        "Šrí Lanka"@cs,
+        "Sri Lanka"@da,
+        "Sri Lanka"@de,
+        "Σρι Λάνκα"@el,
+        "Sri Lanka"@en,
+        "Sri Lanka"@es,
+        "Sri Lanka"@et,
+        "Sri Lanka"@fi,
+        "Sri Lanka"@fr,
+        "Srí Lanca"@ga,
+        "Šri Lanka"@hr,
+        "Srí Lanka"@hu,
+        "Sri Lanka"@it,
+        "Šri Lanka"@lt,
+        "Šrilanka"@lv,
+        "is-Sri Lanka"@mt,
+        "Sri Lanka"@nl,
+        "Sri Lanka"@pl,
+        "Sri Lanca"@pt,
+        "Sri Lanka"@ro,
+        "Srí Lanka"@sk,
+        "Šrilanka"@sl,
+        "Sri Lanka"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LR>,
+        <http://publications.europa.eu/resource/authority/country/LBR>,
+        <http://sws.geonames.org/2275384/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LR" ;
+    skos:prefLabel "Liberia",
+        "Либерия"@bg,
+        "Libérie"@cs,
+        "Liberia"@da,
+        "Liberia"@de,
+        "Λιβερία"@el,
+        "Liberia"@en,
+        "Liberia"@es,
+        "Libeeria"@et,
+        "Liberia"@fi,
+        "Liberia (le)"@fr,
+        "an Libéir"@ga,
+        "Liberija"@hr,
+        "Libéria"@hu,
+        "Liberia"@it,
+        "Liberija"@lt,
+        "Libērija"@lv,
+        "il-Liberja"@mt,
+        "Liberia"@nl,
+        "Liberia"@pl,
+        "Libéria"@pt,
+        "Liberia"@ro,
+        "Libéria"@sk,
+        "Liberija"@sl,
+        "Liberia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LS> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LS>,
+        <http://publications.europa.eu/resource/authority/country/LSO>,
+        <http://sws.geonames.org/932692/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LS" ;
+    skos:prefLabel "Lesotho",
+        "Лесото"@bg,
+        "Lesotho"@cs,
+        "Lesotho"@da,
+        "Lesotho"@de,
+        "Λεσόθο"@el,
+        "Lesotho"@en,
+        "Lesoto"@es,
+        "Lesotho"@et,
+        "Lesotho"@fi,
+        "Lesotho (le)"@fr,
+        "Leosóta"@ga,
+        "Lesoto"@hr,
+        "Lesotho"@hu,
+        "Lesotho"@it,
+        "Lesotas"@lt,
+        "Lesoto"@lv,
+        "il-Lesoto"@mt,
+        "Lesotho"@nl,
+        "Lesotho"@pl,
+        "Lesoto"@pt,
+        "Lesotho"@ro,
+        "Lesotho"@sk,
+        "Lesoto"@sl,
+        "Lesotho"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LT> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Lithuania>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/LT>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/LT>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/LTU>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/LT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/LT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LT>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/LT>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/LT>,
+        <http://publications.europa.eu/resource/authority/country/LTU>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/LT>,
+        <http://rod.eionet.europa.eu/spatial/22>,
+        <http://sws.geonames.org/597427/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LT" ;
+    skos:prefLabel "Lithuania",
+        "Литва"@bg,
+        "Litva"@cs,
+        "Litauen"@da,
+        "Litauen"@de,
+        "Λιθουανία"@el,
+        "Lithuania"@en,
+        "Lituania"@es,
+        "Leedu"@et,
+        "Liettua"@fi,
+        "Lituanie (la)"@fr,
+        "an Liotuáin"@ga,
+        "Litva"@hr,
+        "Litvánia"@hu,
+        "Lituania"@it,
+        "Lietuva"@lt,
+        "Lietuva"@lv,
+        "il-Litwanja"@mt,
+        "Litouwen"@nl,
+        "Litwa"@pl,
+        "Lituânia"@pt,
+        "Lituania"@ro,
+        "Litva"@sk,
+        "Litva"@sl,
+        "Litauen"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LU> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Luxembourg>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/LU>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/LU>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/LUX>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/LU>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/LU>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LU>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/LU>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/LU>,
+        <http://publications.europa.eu/resource/authority/country/LUX>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/LU>,
+        <http://rod.eionet.europa.eu/spatial/23>,
+        <http://sws.geonames.org/2960313/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LU" ;
+    skos:prefLabel "Luxembourg",
+        "Люксембург"@bg,
+        "Lucembursko"@cs,
+        "Luxembourg"@da,
+        "Luxemburg"@de,
+        "Λουξεμβούργο"@el,
+        "Luxembourg"@en,
+        "Luxemburgo"@es,
+        "Luksemburg"@et,
+        "Luxemburg"@fi,
+        "Luxembourg (le)"@fr,
+        "Lucsamburg"@ga,
+        "Luksemburg"@hr,
+        "Luxemburg"@hu,
+        "Lussemburgo"@it,
+        "Liuksemburgas"@lt,
+        "Luksemburga"@lv,
+        "il-Lussemburgu"@mt,
+        "Luxemburg"@nl,
+        "Luksemburg"@pl,
+        "Luxemburgo"@pt,
+        "Luxemburg"@ro,
+        "Luxembursko"@sk,
+        "Luksemburg"@sl,
+        "Luxemburg"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LV> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Latvia>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/LV>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/LV>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/LVA>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/LV>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/LV>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LV>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/LV>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/LV>,
+        <http://publications.europa.eu/resource/authority/country/LVA>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/LV>,
+        <http://rod.eionet.europa.eu/spatial/21>,
+        <http://sws.geonames.org/458258/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LV" ;
+    skos:prefLabel "Latvia",
+        "Латвия"@bg,
+        "Lotyšsko"@cs,
+        "Letland"@da,
+        "Lettland"@de,
+        "Λετονία"@el,
+        "Latvia"@en,
+        "Letonia"@es,
+        "Läti"@et,
+        "Latvia"@fi,
+        "Lettonie (la)"@fr,
+        "an Laitvia"@ga,
+        "Latvija"@hr,
+        "Lettország"@hu,
+        "Lettonia"@it,
+        "Latvija"@lt,
+        "Latvija"@lv,
+        "il-Latvja"@mt,
+        "Letland"@nl,
+        "Łotwa"@pl,
+        "Letónia"@pt,
+        "Letonia"@ro,
+        "Lotyšsko"@sk,
+        "Latvija"@sl,
+        "Lettland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/LY> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Libya>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/LBY>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/LY>,
+        <http://publications.europa.eu/resource/authority/country/LBY>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/LY>,
+        <http://rod.eionet.europa.eu/spatial/111>,
+        <http://sws.geonames.org/2215636/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "LY" ;
+    skos:prefLabel "Libya",
+        "Либия"@bg,
+        "Libye"@cs,
+        "Libyen"@da,
+        "Libyen"@de,
+        "Λιβύη"@el,
+        "Libya"@en,
+        "Libia"@es,
+        "Liibüa"@et,
+        "Libya"@fi,
+        "Libye (la)"@fr,
+        "an Libia"@ga,
+        "Libija"@hr,
+        "Líbia"@hu,
+        "Libia"@it,
+        "Libija"@lt,
+        "Lībija"@lv,
+        "il-Libja"@mt,
+        "Libië"@nl,
+        "Libia"@pl,
+        "Líbia"@pt,
+        "Libia"@ro,
+        "Líbya"@sk,
+        "Libija"@sl,
+        "Libyen"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MA> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Morocco>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MAR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MA>,
+        <http://publications.europa.eu/resource/authority/country/MAR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/MA>,
+        <http://rod.eionet.europa.eu/spatial/112>,
+        <http://sws.geonames.org/2542007/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MA" ;
+    skos:prefLabel "Morocco",
+        "Мароко"@bg,
+        "Maroko"@cs,
+        "Marokko"@da,
+        "Marokko"@de,
+        "Μαρόκο"@el,
+        "Morocco"@en,
+        "Marruecos"@es,
+        "Maroko"@et,
+        "Marokko"@fi,
+        "Maroc (le)"@fr,
+        "Maracó"@ga,
+        "Maroko"@hr,
+        "Marokkó"@hu,
+        "Marocco"@it,
+        "Marokas"@lt,
+        "Maroka"@lv,
+        "il-Marokk"@mt,
+        "Marokko"@nl,
+        "Maroko"@pl,
+        "Marrocos"@pt,
+        "Maroc"@ro,
+        "Maroko"@sk,
+        "Maroko"@sl,
+        "Marocko"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MC> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Monaco>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MCO>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MC>,
+        <http://publications.europa.eu/resource/authority/country/MCO>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/MC>,
+        <http://rod.eionet.europa.eu/spatial/103>,
+        <http://sws.geonames.org/2993457/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MC" ;
+    skos:prefLabel "Monaco",
+        "Монако"@bg,
+        "Monako"@cs,
+        "Monaco"@da,
+        "Monaco"@de,
+        "Μονακό"@el,
+        "Monaco"@en,
+        "Mónaco"@es,
+        "Monaco"@et,
+        "Monaco"@fi,
+        "Monaco"@fr,
+        "Monacó"@ga,
+        "Monako"@hr,
+        "Monaco"@hu,
+        "Monaco"@it,
+        "Monakas"@lt,
+        "Monako"@lv,
+        "Monako"@mt,
+        "Monaco"@nl,
+        "Monako"@pl,
+        "Mónaco"@pt,
+        "Monaco"@ro,
+        "Monako"@sk,
+        "Monako"@sl,
+        "Monaco"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MD> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Moldova>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MDA>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MD>,
+        <http://publications.europa.eu/resource/authority/country/MDA>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/MD>,
+        <http://rod.eionet.europa.eu/spatial/26>,
+        <http://sws.geonames.org/617790/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MD" ;
+    skos:prefLabel "Moldova",
+        "Молдова"@bg,
+        "Moldavsko"@cs,
+        "Moldova"@da,
+        "Moldau"@de,
+        "Μολδαβία"@el,
+        "Moldova"@en,
+        "Moldavia"@es,
+        "Moldova"@et,
+        "Moldova"@fi,
+        "Moldavie (la)"@fr,
+        "an Mholdóiv"@ga,
+        "Moldavija"@hr,
+        "Moldova"@hu,
+        "Moldova"@it,
+        "Moldova"@lt,
+        "Moldova"@lv,
+        "il-Moldova"@mt,
+        "Moldavië"@nl,
+        "Mołdawia"@pl,
+        "Moldávia"@pt,
+        "Moldova"@ro,
+        "Moldavsko"@sk,
+        "Moldavija"@sl,
+        "Moldavien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ME> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Montenegro>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MNE>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/ME>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ME>,
+        <http://dd.eionet.europa.eu/vocabulary/worldbank/country/ME>,
+        <http://publications.europa.eu/resource/authority/country/MNE>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/ME>,
+        <http://rod.eionet.europa.eu/spatial/115>,
+        <http://sws.geonames.org/3194884/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ME" ;
+    skos:prefLabel "Montenegro",
+        "Черна гора"@bg,
+        "Černá Hora"@cs,
+        "Montenegro"@da,
+        "Montenegro"@de,
+        "Μαυροβούνιο"@el,
+        "Montenegro"@en,
+        "Montenegro"@es,
+        "Montenegro"@et,
+        "Montenegro"@fi,
+        "Monténégro (le)"@fr,
+        "Montainéagró"@ga,
+        "Crna Gora"@hr,
+        "Montenegró"@hu,
+        "Montenegro"@it,
+        "Juodkalnija"@lt,
+        "Melnkalne"@lv,
+        "il-Montenegro"@mt,
+        "Montenegro"@nl,
+        "Czarnogóra"@pl,
+        "Montenegro"@pt,
+        "Muntenegru"@ro,
+        "Čierna Hora"@sk,
+        "Črna gora"@sl,
+        "Montenegro"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MAF>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MF>,
+        <http://publications.europa.eu/resource/authority/country/MAF>,
+        <http://sws.geonames.org/3578421/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MF" ;
+    skos:prefLabel "Saint Martin (French part)",
+        "Сен Мартен"@bg,
+        "Svatý Martin"@cs,
+        "Saint-Martin"@da,
+        "St. Martin"@de,
+        "Άγιος Μαρτίνος"@el,
+        "Saint Martin"@en,
+        "San Martín"@es,
+        "Saint-Martin"@et,
+        "Saint-Martin"@fi,
+        "Saint-Martin"@fr,
+        "Saint-Martin"@ga,
+        "Saint Martin"@hr,
+        "Saint-Martin"@hu,
+        "Saint-Martin"@it,
+        "Sen Martenas"@lt,
+        "Senmartēna"@lv,
+        "Saint Martin"@mt,
+        "Saint-Martin"@nl,
+        "Saint-Martin"@pl,
+        "São Martinho"@pt,
+        "Saint-Martin"@ro,
+        "Saint Martin"@sk,
+        "Saint-Martin"@sl,
+        "Saint-Martin"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MG>,
+        <http://publications.europa.eu/resource/authority/country/MDG>,
+        <http://sws.geonames.org/1062947/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MG" ;
+    skos:prefLabel "Madagascar",
+        "Мадагаскар"@bg,
+        "Madagaskar"@cs,
+        "Madagaskar"@da,
+        "Madagaskar"@de,
+        "Μαδαγασκάρη"@el,
+        "Madagascar"@en,
+        "Madagascar"@es,
+        "Madagaskar"@et,
+        "Madagaskar"@fi,
+        "Madagascar"@fr,
+        "Madagascar"@ga,
+        "Madagaskar"@hr,
+        "Madagaszkár"@hu,
+        "Madagascar"@it,
+        "Madagaskaras"@lt,
+        "Madagaskara"@lv,
+        "il-Madagaskar"@mt,
+        "Madagaskar"@nl,
+        "Madagaskar"@pl,
+        "Madagáscar"@pt,
+        "Madagascar"@ro,
+        "Madagaskar"@sk,
+        "Madagaskar"@sl,
+        "Madagaskar"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MH>,
+        <http://publications.europa.eu/resource/authority/country/MHL>,
+        <http://sws.geonames.org/2080185/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MH" ;
+    skos:prefLabel "Marshall Islands",
+        "Маршалови острови"@bg,
+        "Marshallovy ostrovy"@cs,
+        "Marshalløerne"@da,
+        "Marshallinseln"@de,
+        "Νήσοι Μάρσαλ"@el,
+        "Marshall Islands"@en,
+        "Islas Marshall"@es,
+        "Marshalli Saared"@et,
+        "Marshallinsaaret"@fi,
+        "Îles Marshall (les)"@fr,
+        "Oileáin Marshall"@ga,
+        "Maršalovi Otoci"@hr,
+        "Marshall-szigetek"@hu,
+        "Isole Marshall"@it,
+        "Maršalo Salos"@lt,
+        "Māršala Salas"@lv,
+        "il-Gżejjer Marshall"@mt,
+        "Marshalleilanden"@nl,
+        "Wyspy Marshalla"@pl,
+        "Ilhas Marshall"@pt,
+        "Insulele Marshall"@ro,
+        "Marshallove ostrovy"@sk,
+        "Marshallovi otoki"@sl,
+        "Marshallöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MK> a skos:Concept ;
+    skos:altLabel "The Republic of North Macedonia"@en ;
+    skos:exactMatch <http://dbpedia.org/resource/Macedonia>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MKD>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/MK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MK>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/MK>,
+        <http://publications.europa.eu/resource/authority/country/MKD>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/MK>,
+        <http://rod.eionet.europa.eu/spatial/24>,
+        <http://sws.geonames.org/718075/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MK" ;
+    skos:prefLabel "North Macedonia" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ML> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ML>,
+        <http://publications.europa.eu/resource/authority/country/MLI>,
+        <http://sws.geonames.org/2453866/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ML" ;
+    skos:prefLabel "Mali",
+        "Мали"@bg,
+        "Mali"@cs,
+        "Mali"@da,
+        "Mali"@de,
+        "Μάλι"@el,
+        "Mali"@en,
+        "Mali"@es,
+        "Mali"@et,
+        "Mali"@fi,
+        "Mali (le)"@fr,
+        "Mailí"@ga,
+        "Mali"@hr,
+        "Mali"@hu,
+        "Mali"@it,
+        "Malis"@lt,
+        "Mali"@lv,
+        "Mali"@mt,
+        "Mali"@nl,
+        "Mali"@pl,
+        "Mali"@pt,
+        "Mali"@ro,
+        "Mali"@sk,
+        "Mali"@sl,
+        "Mali"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MM>,
+        <http://publications.europa.eu/resource/authority/country/MMR>,
+        <http://sws.geonames.org/1327865/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MM" ;
+    skos:prefLabel "Myanmar",
+        "Мианмар/Бирма"@bg,
+        "Myanmar/Barma"@cs,
+        "Myanmar/Burma"@da,
+        "Myanmar/Birma"@de,
+        "Μιανμάρ/Βιρμανία (η)"@el,
+        "Myanmar/Burma"@en,
+        "Myanmar/Birmania"@es,
+        "Myanmar/Birma"@et,
+        "Myanmar/Burma"@fi,
+        "Myanmar (le)/Birmanie (la)"@fr,
+        "Maenmar/Burma"@ga,
+        "Mjanma/Burma"@hr,
+        "Mianmar/Burma"@hu,
+        "Myanmar/Birmania"@it,
+        "Mianmaras / Birma"@lt,
+        "Mjanma/Birma"@lv,
+        "il-Mjanmar/Burma"@mt,
+        "Myanmar/Birma"@nl,
+        "Mjanma/Birma"@pl,
+        "Mianmar/Birmânia"@pt,
+        "Myanmar/Birmania"@ro,
+        "Mjanmarsko/Barma"@sk,
+        "Mjanmar/Burma"@sl,
+        "Myanmar/Burma"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MNG>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MN>,
+        <http://publications.europa.eu/resource/authority/country/MNG>,
+        <http://sws.geonames.org/2029969/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MN" ;
+    skos:prefLabel "Mongolia",
+        "Монголия"@bg,
+        "Mongolsko"@cs,
+        "Mongoliet"@da,
+        "die Mongolei"@de,
+        "Μογγολία"@el,
+        "Mongolia"@en,
+        "Mongolia"@es,
+        "Mongoolia"@et,
+        "Mongolia"@fi,
+        "Mongolie (la)"@fr,
+        "an Mhongóil"@ga,
+        "Mongolija"@hr,
+        "Mongólia"@hu,
+        "Mongolia"@it,
+        "Mongolija"@lt,
+        "Mongolija"@lv,
+        "il-Mongolja"@mt,
+        "Mongolië"@nl,
+        "Mongolia"@pl,
+        "Mongólia"@pt,
+        "Mongolia"@ro,
+        "Mongolsko"@sk,
+        "Mongolija"@sl,
+        "Mongoliet"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MO>,
+        <http://publications.europa.eu/resource/authority/country/MAC>,
+        <http://sws.geonames.org/1821275/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MO" ;
+    skos:prefLabel "Macau",
+        "Макао"@bg,
+        "Macao"@cs,
+        "Macao"@da,
+        "Macau"@de,
+        "Μακάο"@el,
+        "Macao"@en,
+        "Macao"@es,
+        "Macau"@et,
+        "Macao"@fi,
+        "Macao"@fr,
+        "Macao"@ga,
+        "Macao"@hr,
+        "Makaó"@hu,
+        "Macao"@it,
+        "Makao"@lt,
+        "Makao"@lv,
+        "il-Makaw"@mt,
+        "Macau"@nl,
+        "Makau"@pl,
+        "Macau"@pt,
+        "Macao"@ro,
+        "Macao"@sk,
+        "Macao"@sl,
+        "Macao"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MP> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MP>,
+        <http://publications.europa.eu/resource/authority/country/MNP>,
+        <http://sws.geonames.org/4041467/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MP" ;
+    skos:prefLabel "Northern Mariana Islands",
+        "Северни Мариански острови"@bg,
+        "Ostrovy Severní Mariany"@cs,
+        "Nordmarianerne"@da,
+        "die Nördlichen Marianen"@de,
+        "Νήσοι Βόρειες Μαριάνες"@el,
+        "Northern Mariana Islands"@en,
+        "Islas Marianas del Norte"@es,
+        "Põhja-Mariaanid"@et,
+        "Pohjois-Mariaanit"@fi,
+        "Îles Mariannes du Nord (les)"@fr,
+        "na hOileáin Mháirianacha Thuaidh"@ga,
+        "Sjeverni Marijanski Otoci"@hr,
+        "Északi-Mariana-szigetek"@hu,
+        "Isole Marianne settentrionali (le)"@it,
+        "Marianos Šiaurinės Salos"@lt,
+        "Ziemeļu Marianas Salas"@lv,
+        "il-Gżejjer tal-Marjanas tat-Tramuntana"@mt,
+        "Noordelijke Marianen"@nl,
+        "Mariany Północne"@pl,
+        "Ilhas Marianas do Norte"@pt,
+        "Insulele Mariane de Nord"@ro,
+        "Ostrovy Severné Mariány(MP1)"@sk,
+        "Severni Marianski otoki"@sl,
+        "Nordmarianerna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MQ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MTQ>,
+        <http://publications.europa.eu/resource/authority/country/MTQ>,
+        <http://sws.geonames.org/3570311/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MQ" ;
+    skos:prefLabel "Martinique",
+        "Мартиника"@bg,
+        "Martinik"@cs,
+        "Martinique"@da,
+        "Martinique"@de,
+        "Μαρτινίκα"@el,
+        "Martinique"@en,
+        "Martinica"@es,
+        "Martinique"@et,
+        "Martinique"@fi,
+        "Martinique (la)"@fr,
+        "Martinique"@ga,
+        "Martinique"@hr,
+        "Martinique"@hu,
+        "Martinica (la)"@it,
+        "Martinika"@lt,
+        "Martinika"@lv,
+        "Martinique"@mt,
+        "Martinique"@nl,
+        "Martynika"@pl,
+        "Martinica"@pt,
+        "Martinica"@ro,
+        "Martinik"@sk,
+        "Martinik"@sl,
+        "Martinique"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MR>,
+        <http://publications.europa.eu/resource/authority/country/MRT>,
+        <http://sws.geonames.org/2378080/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MR" ;
+    skos:prefLabel "Mauritania",
+        "Мавритания"@bg,
+        "Mauritánie"@cs,
+        "Mauretanien"@da,
+        "Mauretanien"@de,
+        "Μαυριτανία"@el,
+        "Mauritania"@en,
+        "Mauritania"@es,
+        "Mauritaania"@et,
+        "Mauritania"@fi,
+        "Mauritanie (la)"@fr,
+        "an Mháratáin"@ga,
+        "Mauretanija"@hr,
+        "Mauritánia"@hu,
+        "Mauritania"@it,
+        "Mauritanija"@lt,
+        "Mauritānija"@lv,
+        "il-Mawritanja"@mt,
+        "Mauritanië"@nl,
+        "Mauretania"@pl,
+        "Mauritânia"@pt,
+        "Mauritania"@ro,
+        "Mauritánia"@sk,
+        "Mavretanija"@sl,
+        "Mauretanien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MS> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MSR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MS>,
+        <http://publications.europa.eu/resource/authority/country/MSR>,
+        <http://sws.geonames.org/3578097/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MS" ;
+    skos:prefLabel "Montserrat",
+        "Монтсерат"@bg,
+        "Montserrat"@cs,
+        "Montserrat"@da,
+        "Montserrat"@de,
+        "Μοντσεράτ (το)"@el,
+        "Montserrat"@en,
+        "Montserrat"@es,
+        "Montserrat"@et,
+        "Montserrat"@fi,
+        "Montserrat"@fr,
+        "Montsarat"@ga,
+        "Montserrat"@hr,
+        "Montserrat"@hu,
+        "Montserrat"@it,
+        "Montseratas"@lt,
+        "Montserrata"@lv,
+        "Montserrat"@mt,
+        "Montserrat"@nl,
+        "Montserrat"@pl,
+        "Monserrate"@pt,
+        "Montserrat"@ro,
+        "Montserrat"@sk,
+        "Montserrat"@sl,
+        "Montserrat"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MT> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Malta>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/MT>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/MT>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MLT>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/MT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/MT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MT>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/MT>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/MT>,
+        <http://publications.europa.eu/resource/authority/country/MLT>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/MT>,
+        <http://rod.eionet.europa.eu/spatial/25>,
+        <http://sws.geonames.org/2562770/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MT" ;
+    skos:prefLabel "Malta",
+        "Малта"@bg,
+        "Malta"@cs,
+        "Malta"@da,
+        "Malta"@de,
+        "Μάλτα"@el,
+        "Malta"@en,
+        "Malta"@es,
+        "Malta"@et,
+        "Malta"@fi,
+        "Malte"@fr,
+        "Málta"@ga,
+        "Malta"@hr,
+        "Málta"@hu,
+        "Malta"@it,
+        "Malta"@lt,
+        "Malta"@lv,
+        "Malta"@mt,
+        "Malta"@nl,
+        "Malta"@pl,
+        "Malta"@pt,
+        "Malta"@ro,
+        "Malta"@sk,
+        "Malta"@sl,
+        "Malta"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MU> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MU>,
+        <http://publications.europa.eu/resource/authority/country/MUS>,
+        <http://sws.geonames.org/934292/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MU" ;
+    skos:prefLabel "Mauritius",
+        "Мавриций"@bg,
+        "Mauricius"@cs,
+        "Mauritius"@da,
+        "Mauritius"@de,
+        "Μαυρίκιος"@el,
+        "Mauritius"@en,
+        "Mauricio"@es,
+        "Mauritius"@et,
+        "Mauritius"@fi,
+        "Maurice"@fr,
+        "Oileán Mhuirís"@ga,
+        "Mauricijus"@hr,
+        "Mauritius"@hu,
+        "Maurizio"@it,
+        "Mauricijus"@lt,
+        "Maurīcija"@lv,
+        "il-Mawrizju"@mt,
+        "Mauritius"@nl,
+        "Mauritius"@pl,
+        "Maurícia"@pt,
+        "Mauritius"@ro,
+        "Maurícius"@sk,
+        "Mauritius"@sl,
+        "Mauritius"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MV> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MV>,
+        <http://publications.europa.eu/resource/authority/country/MDV>,
+        <http://sws.geonames.org/1282028/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MV" ;
+    skos:prefLabel "Maldives",
+        "Малдивски острови"@bg,
+        "Maledivy"@cs,
+        "Maldiverne"@da,
+        "Malediven"@de,
+        "Μαλδίβες"@el,
+        "Maldives"@en,
+        "Maldivas"@es,
+        "Maldiivid"@et,
+        "Malediivit"@fi,
+        "Maldives (les)"@fr,
+        "Oileáin Mhaildíve"@ga,
+        "Maldivi"@hr,
+        "Maldív-szigetek"@hu,
+        "Maldive"@it,
+        "Maldyvai"@lt,
+        "Maldīvija"@lv,
+        "il-Maldive"@mt,
+        "Maldiven"@nl,
+        "Malediwy"@pl,
+        "Maldivas"@pt,
+        "Maldive"@ro,
+        "Maldivy"@sk,
+        "Maldivi"@sl,
+        "Maldiverna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MW>,
+        <http://publications.europa.eu/resource/authority/country/MWI>,
+        <http://sws.geonames.org/927384/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MW" ;
+    skos:prefLabel "Malawi",
+        "Малави"@bg,
+        "Malawi"@cs,
+        "Malawi"@da,
+        "Malawi"@de,
+        "Μαλάουι"@el,
+        "Malawi"@en,
+        "Malaui"@es,
+        "Malawi"@et,
+        "Malawi"@fi,
+        "Malawi (le)"@fr,
+        "an Mhaláiv"@ga,
+        "Malavi"@hr,
+        "Malawi"@hu,
+        "Malawi"@it,
+        "Malavis"@lt,
+        "Malāvija"@lv,
+        "il-Malawi"@mt,
+        "Malawi"@nl,
+        "Malawi"@pl,
+        "Maláui"@pt,
+        "Malawi"@ro,
+        "Malawi"@sk,
+        "Malavi"@sl,
+        "Malawi"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MX> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MX>,
+        <http://publications.europa.eu/resource/authority/country/MEX>,
+        <http://sws.geonames.org/3996063/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MX" ;
+    skos:prefLabel "Mexico",
+        "Мексико"@bg,
+        "Mexiko"@cs,
+        "Mexico"@da,
+        "Mexiko"@de,
+        "Μεξικό"@el,
+        "Mexico"@en,
+        "México"@es,
+        "Mehhiko"@et,
+        "Meksiko"@fi,
+        "Mexique (le)"@fr,
+        "Meicsiceo"@ga,
+        "Meksiko"@hr,
+        "Mexikó"@hu,
+        "Messico"@it,
+        "Meksika"@lt,
+        "Meksika"@lv,
+        "il-Messiku"@mt,
+        "Mexico"@nl,
+        "Meksyk"@pl,
+        "México"@pt,
+        "Mexic"@ro,
+        "Mexiko"@sk,
+        "Mehika"@sl,
+        "Mexiko"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MY> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MY>,
+        <http://publications.europa.eu/resource/authority/country/MYS>,
+        <http://sws.geonames.org/1733045/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MY" ;
+    skos:prefLabel "Malaysia",
+        "Малайзия"@bg,
+        "Malajsie"@cs,
+        "Malaysia"@da,
+        "Malaysia"@de,
+        "Μαλαισία"@el,
+        "Malaysia"@en,
+        "Malasia"@es,
+        "Malaisia"@et,
+        "Malesia"@fi,
+        "Malaisie (la)"@fr,
+        "an Mhalaeisia"@ga,
+        "Malezija"@hr,
+        "Malajzia"@hu,
+        "Malaysia"@it,
+        "Malaizija"@lt,
+        "Malaizija"@lv,
+        "il-Malasja"@mt,
+        "Maleisië"@nl,
+        "Malezja"@pl,
+        "Malásia"@pt,
+        "Malaysia"@ro,
+        "Malajzia"@sk,
+        "Malezija"@sl,
+        "Malaysia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/MZ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/MZ>,
+        <http://publications.europa.eu/resource/authority/country/MOZ>,
+        <http://sws.geonames.org/1036973/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "MZ" ;
+    skos:prefLabel "Mozambique",
+        "Мозамбик"@bg,
+        "Mosambik"@cs,
+        "Mozambique"@da,
+        "Mosambik"@de,
+        "Μοζαμβίκη"@el,
+        "Mozambique"@en,
+        "Mozambique"@es,
+        "Mosambiik"@et,
+        "Mosambik"@fi,
+        "Mozambique (le)"@fr,
+        "Mósaimbíc"@ga,
+        "Mozambik"@hr,
+        "Mozambik"@hu,
+        "Mozambico"@it,
+        "Mozambikas"@lt,
+        "Mozambika"@lv,
+        "il-Możambik"@mt,
+        "Mozambique"@nl,
+        "Mozambik"@pl,
+        "Moçambique"@pt,
+        "Mozambic"@ro,
+        "Mozambik"@sk,
+        "Mozambik"@sl,
+        "Moçambique"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NA> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NA>,
+        <http://publications.europa.eu/resource/authority/country/NAM>,
+        <http://sws.geonames.org/3355338/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NA" ;
+    skos:prefLabel "Namibia",
+        "Намибия"@bg,
+        "Namibie"@cs,
+        "Namibia"@da,
+        "Namibia"@de,
+        "Ναμίμπια"@el,
+        "Namibia"@en,
+        "Namibia"@es,
+        "Namiibia"@et,
+        "Namibia"@fi,
+        "Namibie (la)"@fr,
+        "an Namaib"@ga,
+        "Namibija"@hr,
+        "Namíbia"@hu,
+        "Namibia"@it,
+        "Namibija"@lt,
+        "Namībija"@lv,
+        "in-Namibja"@mt,
+        "Namibië"@nl,
+        "Namibia"@pl,
+        "Namíbia"@pt,
+        "Namibia"@ro,
+        "Namíbia"@sk,
+        "Namibija"@sl,
+        "Namibia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NC> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/NCL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NC>,
+        <http://publications.europa.eu/resource/authority/country/NCL>,
+        <http://sws.geonames.org/2139685/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NC" ;
+    skos:prefLabel "New Caledonia",
+        "Нова Каледония"@bg,
+        "Nová Kaledonie"@cs,
+        "Ny Kaledonien"@da,
+        "Neukaledonien"@de,
+        "Νέα Καληδονία"@el,
+        "New Caledonia"@en,
+        "Nueva Caledonia"@es,
+        "Uus-Kaledoonia"@et,
+        "Uusi-Kaledonia"@fi,
+        "Nouvelle-Calédonie (la)"@fr,
+        "an Nua-Chaladóin"@ga,
+        "Nova Kaledonija"@hr,
+        "Új-Kaledónia"@hu,
+        "Nuova Caledonia (la)"@it,
+        "Naujoji Kaledonija"@lt,
+        "Jaunkaledonija"@lv,
+        "il-Kaledonja Ġdida"@mt,
+        "Nieuw-Caledonië"@nl,
+        "Nowa Kaledonia"@pl,
+        "Nova Caledónia"@pt,
+        "Noua Caledonie"@ro,
+        "Nová Kaledónia"@sk,
+        "Nova Kaledonija"@sl,
+        "Nya Kaledonien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NE>,
+        <http://publications.europa.eu/resource/authority/country/NER>,
+        <http://sws.geonames.org/2440476/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NE" ;
+    skos:prefLabel "Niger",
+        "Нигер"@bg,
+        "Niger"@cs,
+        "Niger"@da,
+        "Niger"@de,
+        "Νίγηρας"@el,
+        "Niger"@en,
+        "Níger"@es,
+        "Niger"@et,
+        "Niger"@fi,
+        "Niger (le)"@fr,
+        "an Nígir"@ga,
+        "Niger"@hr,
+        "Niger"@hu,
+        "Niger"@it,
+        "Nigeris"@lt,
+        "Nigēra"@lv,
+        "in-Niġer"@mt,
+        "Niger"@nl,
+        "Niger"@pl,
+        "Níger"@pt,
+        "Niger"@ro,
+        "Niger"@sk,
+        "Niger"@sl,
+        "Niger"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NF>,
+        <http://publications.europa.eu/resource/authority/country/NFK>,
+        <http://sws.geonames.org/2155115/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NF" ;
+    skos:prefLabel "Norfolk Island",
+        "Oстров Норфолк"@bg,
+        "Ostrov Norfolk"@cs,
+        "Norfolk Island"@da,
+        "die Norfolkinsel"@de,
+        "Νήσος Νόρφολκ"@el,
+        "Norfolk Island"@en,
+        "Isla Norfolk"@es,
+        "Norfolki saar"@et,
+        "Norfolkinsaari"@fi,
+        "Île Norfolk (l’)"@fr,
+        "Oileán Norfolk"@ga,
+        "Norfolk"@hr,
+        "Norfolk-sziget"@hu,
+        "Isola Norfolk (l’)"@it,
+        "Norfolko Sala"@lt,
+        "Norfolkas Sala"@lv,
+        "il-Gżira Norfolk"@mt,
+        "Norfolk"@nl,
+        "Wyspa Norfolk"@pl,
+        "Ilha Norfolk"@pt,
+        "Insula Norfolk"@ro,
+        "Ostrov Norfolk"@sk,
+        "Norfolški otok"@sl,
+        "Norfolkön"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NG>,
+        <http://publications.europa.eu/resource/authority/country/NGA>,
+        <http://sws.geonames.org/2328926/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NG" ;
+    skos:prefLabel "Nigeria",
+        "Нигерия"@bg,
+        "Nigérie"@cs,
+        "Nigeria"@da,
+        "Nigeria"@de,
+        "Νιγηρία"@el,
+        "Nigeria"@en,
+        "Nigeria"@es,
+        "Nigeeria"@et,
+        "Nigeria"@fi,
+        "Nigeria (le)"@fr,
+        "an Nigéir"@ga,
+        "Nigerija"@hr,
+        "Nigéria"@hu,
+        "Nigeria"@it,
+        "Nigerija"@lt,
+        "Nigērija"@lv,
+        "in-Niġerja"@mt,
+        "Nigeria"@nl,
+        "Nigeria"@pl,
+        "Nigéria"@pt,
+        "Nigeria"@ro,
+        "Nigéria"@sk,
+        "Nigerija"@sl,
+        "Nigeria"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NI> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NI>,
+        <http://publications.europa.eu/resource/authority/country/NIC>,
+        <http://sws.geonames.org/3617476/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NI" ;
+    skos:prefLabel "Nicaragua",
+        "Никарагуа"@bg,
+        "Nikaragua"@cs,
+        "Nicaragua"@da,
+        "Nicaragua"@de,
+        "Νικαράγουα"@el,
+        "Nicaragua"@en,
+        "Nicaragua"@es,
+        "Nicaragua"@et,
+        "Nicaragua"@fi,
+        "Nicaragua (le)"@fr,
+        "Nicearagua"@ga,
+        "Nikaragva"@hr,
+        "Nicaragua"@hu,
+        "Nicaragua"@it,
+        "Nikaragva"@lt,
+        "Nikaragva"@lv,
+        "in-Nikaragwa"@mt,
+        "Nicaragua"@nl,
+        "Nikaragua"@pl,
+        "Nicarágua"@pt,
+        "Nicaragua"@ro,
+        "Nikaragua"@sk,
+        "Nikaragva"@sl,
+        "Nicaragua"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NL> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Netherlands>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/NL>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/NL>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/NLD>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/NL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/NL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NL>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/NL>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/NL>,
+        <http://publications.europa.eu/resource/authority/country/NLD>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/NL>,
+        <http://rod.eionet.europa.eu/spatial/27>,
+        <http://sws.geonames.org/2750405/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NL" ;
+    skos:prefLabel "Netherlands",
+        "Нидерландия"@bg,
+        "Nizozemsko"@cs,
+        "Nederlandene"@da,
+        "die Niederlande"@de,
+        "Κάτω Χώρες"@el,
+        "Netherlands"@en,
+        "Países Bajos"@es,
+        "Madalmaad"@et,
+        "Alankomaat"@fi,
+        "Pays-Bas (les)"@fr,
+        "an Ísiltír"@ga,
+        "Nizozemska"@hr,
+        "Hollandia"@hu,
+        "Paesi Bassi"@it,
+        "Nyderlandai"@lt,
+        "Nīderlande"@lv,
+        "il-Pajjiżi l-Baxxi"@mt,
+        "Nederland"@nl,
+        "Niderlandy(NL1)"@pl,
+        "Países Baixos"@pt,
+        "Țările de Jos"@ro,
+        "Holandsko"@sk,
+        "Nizozemska"@sl,
+        "Nederländerna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NO> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Norway>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/NOR>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/NO>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/NO>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NO>,
+        <http://publications.europa.eu/resource/authority/country/NOR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/NO>,
+        <http://rod.eionet.europa.eu/spatial/28>,
+        <http://sws.geonames.org/3144096/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NO" ;
+    skos:prefLabel "Norway",
+        "Норвегия"@bg,
+        "Norsko"@cs,
+        "Norge"@da,
+        "Norwegen"@de,
+        "Νορβηγία"@el,
+        "Norway"@en,
+        "Noruega"@es,
+        "Norra"@et,
+        "Norja"@fi,
+        "Norvège (la)"@fr,
+        "an Iorua"@ga,
+        "Norveška"@hr,
+        "Norvégia"@hu,
+        "Norvegia"@it,
+        "Norvegija"@lt,
+        "Norvēģija"@lv,
+        "in-Norveġja"@mt,
+        "Noorwegen"@nl,
+        "Norwegia"@pl,
+        "Noruega"@pt,
+        "Norvegia"@ro,
+        "Nórsko"@sk,
+        "Norveška"@sl,
+        "Norge"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NP> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NP>,
+        <http://publications.europa.eu/resource/authority/country/NPL>,
+        <http://sws.geonames.org/1282988/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NP" ;
+    skos:prefLabel "Nepal",
+        "Непал"@bg,
+        "Nepál"@cs,
+        "Nepal"@da,
+        "Nepal"@de,
+        "Νεπάλ"@el,
+        "Nepal"@en,
+        "Nepal"@es,
+        "Nepal"@et,
+        "Nepal"@fi,
+        "Népal (le)"@fr,
+        "Neipeal"@ga,
+        "Nepal"@hr,
+        "Nepál"@hu,
+        "Nepal"@it,
+        "Nepalas"@lt,
+        "Nepāla"@lv,
+        "in-Nepal"@mt,
+        "Nepal"@nl,
+        "Nepal"@pl,
+        "Nepal"@pt,
+        "Nepal"@ro,
+        "Nepál"@sk,
+        "Nepal"@sl,
+        "Nepal"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NR>,
+        <http://publications.europa.eu/resource/authority/country/NRU>,
+        <http://sws.geonames.org/2110425/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NR" ;
+    skos:prefLabel "Nauru",
+        "Науру"@bg,
+        "Nauru"@cs,
+        "Nauru"@da,
+        "Nauru"@de,
+        "Ναουρού"@el,
+        "Nauru"@en,
+        "Nauru"@es,
+        "Nauru"@et,
+        "Nauru"@fi,
+        "Nauru"@fr,
+        "Nárú"@ga,
+        "Nauru"@hr,
+        "Nauru"@hu,
+        "Nauru"@it,
+        "Nauru"@lt,
+        "Nauru"@lv,
+        "Nauru"@mt,
+        "Nauru"@nl,
+        "Nauru"@pl,
+        "Nauru"@pt,
+        "Nauru"@ro,
+        "Nauru"@sk,
+        "Nauru"@sl,
+        "Nauru"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NU> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NU>,
+        <http://publications.europa.eu/resource/authority/country/NIU>,
+        <http://sws.geonames.org/4036232/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NU" ;
+    skos:prefLabel "Niue",
+        "Ниуе"@bg,
+        "Niue"@cs,
+        "Niue"@da,
+        "Niue"@de,
+        "Νιούε (το)"@el,
+        "Niue"@en,
+        "Niue"@es,
+        "Niue"@et,
+        "Niue"@fi,
+        "Niue"@fr,
+        "Niue"@ga,
+        "Niue"@hr,
+        "Niue"@hu,
+        "Niue"@it,
+        "Niujė"@lt,
+        "Niue"@lv,
+        "Nju"@mt,
+        "Niue"@nl,
+        "Niue"@pl,
+        "Niuê"@pt,
+        "Niue"@ro,
+        "Niue"@sk,
+        "Niue"@sl,
+        "Niue"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/NZ> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/New_Zealand>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/NZ>,
+        <http://publications.europa.eu/resource/authority/country/NZL>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/NZ>,
+        <http://sws.geonames.org/2186224/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "NZ" ;
+    skos:prefLabel "New Zealand",
+        "Нова Зеландия"@bg,
+        "Nový Zéland"@cs,
+        "New Zealand"@da,
+        "Neuseeland"@de,
+        "Νέα Ζηλανδία"@el,
+        "New Zealand"@en,
+        "Nueva Zelanda"@es,
+        "Uus-Meremaa"@et,
+        "Uusi-Seelanti"@fi,
+        "Nouvelle-Zélande (la)"@fr,
+        "an Nua-Shéalainn"@ga,
+        "Novi Zeland"@hr,
+        "Új-Zéland"@hu,
+        "Nuova Zelanda"@it,
+        "Naujoji Zelandija"@lt,
+        "Jaunzēlande"@lv,
+        "in-New Zealand"@mt,
+        "Nieuw-Zeeland"@nl,
+        "Nowa Zelandia"@pl,
+        "Nova Zelândia"@pt,
+        "Noua Zeelandă"@ro,
+        "Nový Zéland"@sk,
+        "Nova Zelandija"@sl,
+        "Nya Zeeland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/OM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/OM>,
+        <http://publications.europa.eu/resource/authority/country/OMN>,
+        <http://sws.geonames.org/286963/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "OM" ;
+    skos:prefLabel "Oman",
+        "Оман"@bg,
+        "Omán"@cs,
+        "Oman"@da,
+        "Oman"@de,
+        "Ομάν"@el,
+        "Oman"@en,
+        "Omán"@es,
+        "Omaan"@et,
+        "Oman"@fi,
+        "Oman"@fr,
+        "Óman"@ga,
+        "Oman"@hr,
+        "Omán"@hu,
+        "Oman"@it,
+        "Omanas"@lt,
+        "Omāna"@lv,
+        "l-Oman"@mt,
+        "Oman"@nl,
+        "Oman"@pl,
+        "Omã"@pt,
+        "Oman"@ro,
+        "Omán"@sk,
+        "Oman"@sl,
+        "Oman"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PA> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PA>,
+        <http://publications.europa.eu/resource/authority/country/PAN>,
+        <http://sws.geonames.org/3703430/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PA" ;
+    skos:prefLabel "Panama",
+        "Панама"@bg,
+        "Panama"@cs,
+        "Panama"@da,
+        "Panama"@de,
+        "Παναμάς"@el,
+        "Panama"@en,
+        "Panamá"@es,
+        "Panama"@et,
+        "Panama"@fi,
+        "Panama (le)"@fr,
+        "Panama"@ga,
+        "Panama"@hr,
+        "Panama"@hu,
+        "Panama"@it,
+        "Panama"@lt,
+        "Panama"@lv,
+        "il-Panama"@mt,
+        "Panama"@nl,
+        "Panama"@pl,
+        "Panamá"@pt,
+        "Panama"@ro,
+        "Panama"@sk,
+        "Panama"@sl,
+        "Panama"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PE>,
+        <http://publications.europa.eu/resource/authority/country/PER>,
+        <http://sws.geonames.org/3932488/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PE" ;
+    skos:prefLabel "Peru",
+        "Перу"@bg,
+        "Peru"@cs,
+        "Peru"@da,
+        "Peru"@de,
+        "Περού"@el,
+        "Peru"@en,
+        "Perú"@es,
+        "Peruu"@et,
+        "Peru"@fi,
+        "Pérou (le)"@fr,
+        "Peiriú"@ga,
+        "Peru"@hr,
+        "Peru"@hu,
+        "Perú"@it,
+        "Peru"@lt,
+        "Peru"@lv,
+        "il-Perù"@mt,
+        "Peru"@nl,
+        "Peru"@pl,
+        "Peru"@pt,
+        "Peru"@ro,
+        "Peru"@sk,
+        "Peru"@sl,
+        "Peru"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/PYF>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PF>,
+        <http://publications.europa.eu/resource/authority/country/PYF>,
+        <http://sws.geonames.org/4030656/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PF" ;
+    skos:prefLabel "French Polynesia",
+        "Френска Полинезия"@bg,
+        "Francouzská Polynésie"@cs,
+        "Fransk Polynesien"@da,
+        "Französisch-Polynesien"@de,
+        "Γαλλική Πολυνησία"@el,
+        "French Polynesia"@en,
+        "Polinesia Francesa"@es,
+        "Prantsuse Polüneesia"@et,
+        "Ranskan Polynesia"@fi,
+        "Polynésie française (la)"@fr,
+        "Polainéis na Fraince"@ga,
+        "Francuska Polinezija"@hr,
+        "Francia Polinézia"@hu,
+        "Polinesia francese (la)"@it,
+        "Prancūzijos Polinezija"@lt,
+        "Francijas Polinēzija"@lv,
+        "il-Polineżja Franċiża"@mt,
+        "Frans-Polynesië"@nl,
+        "Polinezja Francuska"@pl,
+        "Polinésia Francesa"@pt,
+        "Polinezia Franceză"@ro,
+        "Francúzska Polynézia"@sk,
+        "Francoska Polinezija"@sl,
+        "Franska Polynesien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PG>,
+        <http://publications.europa.eu/resource/authority/country/PNG>,
+        <http://sws.geonames.org/2088628/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PG" ;
+    skos:prefLabel "Papua New Guinea",
+        "Папуа-Нова Гвинея"@bg,
+        "Papua-Nová Guinea"@cs,
+        "Papua Ny Guinea"@da,
+        "Papua-Neuguinea"@de,
+        "Παπουασία-Νέα Γουινέα"@el,
+        "Papua New Guinea"@en,
+        "Papúa Nueva Guinea"@es,
+        "Paapua Uus-Guinea"@et,
+        "Papua-Uusi-Guinea"@fi,
+        "Papouasie -"@fr,
+        "Nua-Ghuine Phapua"@ga,
+        "Papua Nova Gvineja"@hr,
+        "Pápua Új-Guinea"@hu,
+        "Papua"@it,
+        "Papua Naujoji Gvinėja"@lt,
+        "Papua-Jaungvineja"@lv,
+        "il-Papwa Ginea Ġdida"@mt,
+        "Papoea-Nieuw-Guinea"@nl,
+        "Papua-Nowa Gwinea"@pl,
+        "Papua-Nova Guiné"@pt,
+        "Papua-Noua Guinee"@ro,
+        "Papua-Nová Guinea"@sk,
+        "Papua Nova Gvineja"@sl,
+        "Papua Nya Guinea"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PH>,
+        <http://publications.europa.eu/resource/authority/country/PHL>,
+        <http://sws.geonames.org/1694008/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PH" ;
+    skos:prefLabel "Philippines",
+        "Филипини"@bg,
+        "Filipíny"@cs,
+        "Filippinerne"@da,
+        "die Philippinen"@de,
+        "Φιλιππίνες"@el,
+        "Philippines"@en,
+        "Filipinas"@es,
+        "Filipiinid"@et,
+        "Filippiinit"@fi,
+        "Philippines (les)"@fr,
+        "na hOileáin Fhilipíneacha"@ga,
+        "Filipini"@hr,
+        "Fülöp-szigetek"@hu,
+        "Filippine"@it,
+        "Filipinai"@lt,
+        "Filipīnas"@lv,
+        "il-Filippini"@mt,
+        "Filipijnen"@nl,
+        "Filipiny"@pl,
+        "Filipinas"@pt,
+        "Filipine"@ro,
+        "Filipíny"@sk,
+        "Filipini"@sl,
+        "Filippinerna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PK> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PK>,
+        <http://publications.europa.eu/resource/authority/country/PAK>,
+        <http://sws.geonames.org/1168579/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PK" ;
+    skos:prefLabel "Pakistan",
+        "Пакистан"@bg,
+        "Pákistán"@cs,
+        "Pakistan"@da,
+        "Pakistan"@de,
+        "Πακιστάν"@el,
+        "Pakistan"@en,
+        "Pakistán"@es,
+        "Pakistan"@et,
+        "Pakistan"@fi,
+        "Pakistan (le)"@fr,
+        "an Phacastáin"@ga,
+        "Pakistan"@hr,
+        "Pakisztán"@hu,
+        "Pakistan"@it,
+        "Pakistanas"@lt,
+        "Pakistāna"@lv,
+        "il-Pakistan"@mt,
+        "Pakistan"@nl,
+        "Pakistan"@pl,
+        "Paquistão"@pt,
+        "Pakistan"@ro,
+        "Pakistan"@sk,
+        "Pakistan"@sl,
+        "Pakistan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PL> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Poland>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/PL>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/PL>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/POL>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/PL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/PL>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PL>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/PL>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/PL>,
+        <http://publications.europa.eu/resource/authority/country/POL>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/PL>,
+        <http://rod.eionet.europa.eu/spatial/29>,
+        <http://sws.geonames.org/798544/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PL" ;
+    skos:prefLabel "Poland",
+        "Полша"@bg,
+        "Polsko"@cs,
+        "Polen"@da,
+        "Polen"@de,
+        "Πολωνία"@el,
+        "Poland"@en,
+        "Polonia"@es,
+        "Poola"@et,
+        "Puola"@fi,
+        "Pologne (la)"@fr,
+        "an Pholainn"@ga,
+        "Poljska"@hr,
+        "Lengyelország"@hu,
+        "Polonia"@it,
+        "Lenkija"@lt,
+        "Polija"@lv,
+        "il-Polonja"@mt,
+        "Polen"@nl,
+        "Polska"@pl,
+        "Polónia"@pt,
+        "Polonia"@ro,
+        "Poľsko"@sk,
+        "Poljska"@sl,
+        "Polen"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SPM>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PM>,
+        <http://publications.europa.eu/resource/authority/country/SPM>,
+        <http://sws.geonames.org/3424932/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PM" ;
+    skos:prefLabel "Saint Pierre and Miquelon",
+        "Сен Пиер и Микелон"@bg,
+        "Saint-Pierre a Miquelon"@cs,
+        "Saint-Pierre og Miquelon"@da,
+        "St. Pierre und Miquelon"@de,
+        "Σεν Πιερ και Μικελόν"@el,
+        "Saint Pierre and Miquelon"@en,
+        "San Pedro y Miquelón"@es,
+        "Saint-Pierre ja Miquelon"@et,
+        "Saint-Pierre ja Miquelon"@fi,
+        "Saint-Pierre-et-Miquelon"@fr,
+        "San Pierre agus Miquelon"@ga,
+        "Saint-Pierre-et-Miquelon"@hr,
+        "Saint-Pierre"@hu,
+        "Saint Pierre e Miquelon"@it,
+        "Sen Pjeras ir Mikelonas"@lt,
+        "Senpjēra un Mikelona"@lv,
+        "Saint Pierre u Miquelon"@mt,
+        "Saint-Pierre en Miquelon"@nl,
+        "Saint-Pierre i Miquelon"@pl,
+        "São Pedro e Miquelão"@pt,
+        "Saint-Pierre și Miquelon"@ro,
+        "Saint Pierre a Miquelon"@sk,
+        "Saint Pierre in Miquelon"@sl,
+        "Saint-Pierre-et-Miquelon"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/PCN>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PN>,
+        <http://publications.europa.eu/resource/authority/country/PCN>,
+        <http://sws.geonames.org/4030699/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PN" ;
+    skos:prefLabel "Pitcairn",
+        "Oстрови Питкерн"@bg,
+        "Pitcairn"@cs,
+        "Pitcairn"@da,
+        "die Pitcairninseln"@de,
+        "Νήσοι Πίτκερν"@el,
+        "Pitcairn Islands"@en,
+        "Islas Pitcairn"@es,
+        "Pitcairn"@et,
+        "Pitcairn"@fi,
+        "Îles Pitcairn (les)"@fr,
+        "Oileáin Pitcairn"@ga,
+        "Otoci Pitcairn"@hr,
+        "Pitcairn-szigetek"@hu,
+        "Isole Pitcairn (le)"@it,
+        "Pitkernas"@lt,
+        "Pitkērna"@lv,
+        "il-Gżejjer Pitcairn"@mt,
+        "Pitcairneilanden"@nl,
+        "Pitcairn"@pl,
+        "Ilhas Pitcairn"@pt,
+        "Insulele Pitcairn"@ro,
+        "Pitcairnove ostrovy"@sk,
+        "Pitcairn"@sl,
+        "Pitcairnöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PR>,
+        <http://publications.europa.eu/resource/authority/country/PRI>,
+        <http://sws.geonames.org/4566966/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PR" ;
+    skos:prefLabel "Puerto Rico",
+        "Пуерто Рико"@bg,
+        "Portoriko"@cs,
+        "Puerto Rico"@da,
+        "Puerto Rico"@de,
+        "Πουέρτο Ρίκο"@el,
+        "Puerto Rico"@en,
+        "Puerto Rico"@es,
+        "Puerto Rico"@et,
+        "Puerto Rico"@fi,
+        "Porto Rico"@fr,
+        "Pórtó Ríce"@ga,
+        "Puerto Rico"@hr,
+        "Puerto Rico"@hu,
+        "Portorico"@it,
+        "Puerto Rikas"@lt,
+        "Puertoriko"@lv,
+        "Puerto Riko"@mt,
+        "Puerto Rico"@nl,
+        "Portoryko"@pl,
+        "Porto Rico"@pt,
+        "Puerto Rico"@ro,
+        "Portoriko"@sk,
+        "Portoriko"@sl,
+        "Puerto Rico"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PS> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/State_of_Palestine>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PS>,
+        <http://publications.europa.eu/resource/authority/country/PSE>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/PS>,
+        <http://rod.eionet.europa.eu/spatial/118>,
+        <http://sws.geonames.org/6254930/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PS" ;
+    skos:prefLabel "Palestine" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PT> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Portugal>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/PT>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/PT>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/PRT>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/PT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/PT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PT>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/PT>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/PT>,
+        <http://publications.europa.eu/resource/authority/country/PRT>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/PT>,
+        <http://rod.eionet.europa.eu/spatial/30>,
+        <http://sws.geonames.org/2264397/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PT" ;
+    skos:prefLabel "Portugal",
+        "Португалия"@bg,
+        "Portugalsko"@cs,
+        "Portugal"@da,
+        "Portugal"@de,
+        "Πορτογαλία"@el,
+        "Portugal"@en,
+        "Portugal"@es,
+        "Portugal"@et,
+        "Portugali"@fi,
+        "Portugal (le)"@fr,
+        "an Phortaingéil"@ga,
+        "Portugal"@hr,
+        "Portugália"@hu,
+        "Portogallo"@it,
+        "Portugalija"@lt,
+        "Portugāle"@lv,
+        "il-Portugall"@mt,
+        "Portugal"@nl,
+        "Portugalia"@pl,
+        "Portugal"@pt,
+        "Portugalia"@ro,
+        "Portugalsko"@sk,
+        "Portugalska"@sl,
+        "Portugal"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PW>,
+        <http://publications.europa.eu/resource/authority/country/PLW>,
+        <http://sws.geonames.org/1559582/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PW" ;
+    skos:prefLabel "Palau",
+        "Палау"@bg,
+        "Palau"@cs,
+        "Palau"@da,
+        "Palau"@de,
+        "Παλάου"@el,
+        "Palau"@en,
+        "Palaos"@es,
+        "Belau"@et,
+        "Palau"@fi,
+        "Palaos"@fr,
+        "Oileáin Palau"@ga,
+        "Palau"@hr,
+        "Palau"@hu,
+        "Palau"@it,
+        "Palau"@lt,
+        "Palau"@lv,
+        "il-Palaw"@mt,
+        "Palau"@nl,
+        "Palau"@pl,
+        "Palau"@pt,
+        "Palau"@ro,
+        "Palau"@sk,
+        "Palau"@sl,
+        "Palau"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/PY> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/PY>,
+        <http://publications.europa.eu/resource/authority/country/PRY>,
+        <http://sws.geonames.org/3437598/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "PY" ;
+    skos:prefLabel "Paraguay",
+        "Парагвай"@bg,
+        "Paraguay"@cs,
+        "Paraguay"@da,
+        "Paraguay"@de,
+        "Παραγουάη"@el,
+        "Paraguay"@en,
+        "Paraguay"@es,
+        "Paraguay"@et,
+        "Paraguay"@fi,
+        "Paraguay (le)"@fr,
+        "Paragua"@ga,
+        "Paragvaj"@hr,
+        "Paraguay"@hu,
+        "Paraguay"@it,
+        "Paragvajus"@lt,
+        "Paragvaja"@lv,
+        "il-Paragwaj"@mt,
+        "Paraguay"@nl,
+        "Paragwaj"@pl,
+        "Paraguai"@pt,
+        "Paraguay"@ro,
+        "Paraguaj"@sk,
+        "Paragvaj"@sl,
+        "Paraguay"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/QA> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/QA>,
+        <http://publications.europa.eu/resource/authority/country/QAT>,
+        <http://sws.geonames.org/289688/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "QA" ;
+    skos:prefLabel "Qatar",
+        "Катар"@bg,
+        "Katar"@cs,
+        "Qatar"@da,
+        "Katar"@de,
+        "Κατάρ"@el,
+        "Qatar"@en,
+        "Qatar"@es,
+        "Katar"@et,
+        "Qatar"@fi,
+        "Qatar (le)"@fr,
+        "Catar"@ga,
+        "Katar"@hr,
+        "Katar"@hu,
+        "Qatar"@it,
+        "Kataras"@lt,
+        "Katara"@lv,
+        "il-Qatar"@mt,
+        "Qatar"@nl,
+        "Katar"@pl,
+        "Catar"@pt,
+        "Qatar"@ro,
+        "Katar"@sk,
+        "Katar"@sl,
+        "Qatar"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/RE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/REU>,
+        <http://publications.europa.eu/resource/authority/country/REU>,
+        <http://sws.geonames.org/935317/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "RE" ;
+    skos:prefLabel "Reunion",
+        "Реюнион"@bg,
+        "Réunion"@cs,
+        "Réunion"@da,
+        "Réunion"@de,
+        "Ρεϊνιόν"@el,
+        "Réunion"@en,
+        "Reunión"@es,
+        "Réunion"@et,
+        "Réunion"@fi,
+        "La Réunion"@fr,
+        "La Réunion"@ga,
+        "Réunion"@hr,
+        "Réunion"@hu,
+        "Riunione (la)"@it,
+        "Reunjonas"@lt,
+        "Reinjona"@lv,
+        "Réunion"@mt,
+        "Réunion"@nl,
+        "Reunion"@pl,
+        "Reunião"@pt,
+        "Réunion"@ro,
+        "Réunion"@sk,
+        "Reunion"@sl,
+        "Réunion"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/RO> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Romania>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/RO>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ROU>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/RO>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/RO>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/RO>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/RO>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/RO>,
+        <http://publications.europa.eu/resource/authority/country/ROU>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/RO>,
+        <http://rod.eionet.europa.eu/spatial/31>,
+        <http://sws.geonames.org/798549/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "RO" ;
+    skos:prefLabel "Romania",
+        "Румъния"@bg,
+        "Rumunsko"@cs,
+        "Rumænien"@da,
+        "Rumänien"@de,
+        "Ρουμανία"@el,
+        "Romania"@en,
+        "Rumanía"@es,
+        "Rumeenia"@et,
+        "Romania"@fi,
+        "Roumanie (la)"@fr,
+        "an Rómáin"@ga,
+        "Rumunjska"@hr,
+        "Románia"@hu,
+        "Romania"@it,
+        "Rumunija"@lt,
+        "Rumānija"@lv,
+        "ir-Rumanija"@mt,
+        "Roemenië"@nl,
+        "Rumunia"@pl,
+        "Roménia"@pt,
+        "România"@ro,
+        "Rumunsko"@sk,
+        "Romunija"@sl,
+        "Rumänien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/RS> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Serbia>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SRB>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/RS>,
+        <http://publications.europa.eu/resource/authority/country/SRB>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/RS>,
+        <http://rod.eionet.europa.eu/spatial/41>,
+        <http://sws.geonames.org/6290252/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "RS" ;
+    skos:prefLabel "Serbia",
+        "Сърбия"@bg,
+        "Srbsko"@cs,
+        "Serbien"@da,
+        "Serbien"@de,
+        "Σερβία"@el,
+        "Serbia"@en,
+        "Serbia"@es,
+        "Serbia"@et,
+        "Serbia"@fi,
+        "Serbie (la)"@fr,
+        "an tSeirbia"@ga,
+        "Srbija"@hr,
+        "Szerbia"@hu,
+        "Serbia"@it,
+        "Serbija"@lt,
+        "Serbija"@lv,
+        "is-Serbja"@mt,
+        "Servië"@nl,
+        "Serbia"@pl,
+        "Sérvia"@pt,
+        "Serbia"@ro,
+        "Srbsko"@sk,
+        "Srbija"@sl,
+        "Serbien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/RU> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Russia>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/RUS>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/RU>,
+        <http://publications.europa.eu/resource/authority/country/RUS>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/RU>,
+        <http://rod.eionet.europa.eu/spatial/32>,
+        <http://sws.geonames.org/2017370/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "RU" ;
+    skos:prefLabel "Russian Federation",
+        "Русия"@bg,
+        "Rusko"@cs,
+        "Rusland"@da,
+        "Russland"@de,
+        "Ρωσία"@el,
+        "Russia"@en,
+        "Rusia"@es,
+        "Venemaa"@et,
+        "Venäjä"@fi,
+        "Russie (la)"@fr,
+        "an Rúis"@ga,
+        "Rusija"@hr,
+        "Oroszország"@hu,
+        "Russia"@it,
+        "Rusija"@lt,
+        "Krievija"@lv,
+        "ir-Russja"@mt,
+        "Rusland"@nl,
+        "Rosja"@pl,
+        "Rússia"@pt,
+        "Rusia"@ro,
+        "Rusko"@sk,
+        "Rusija"@sl,
+        "Ryssland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/RW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/RW>,
+        <http://publications.europa.eu/resource/authority/country/RWA>,
+        <http://sws.geonames.org/49518/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "RW" ;
+    skos:prefLabel "Rwanda",
+        "Руанда"@bg,
+        "Rwanda"@cs,
+        "Rwanda"@da,
+        "Ruanda"@de,
+        "Ρουάντα"@el,
+        "Rwanda"@en,
+        "Ruanda"@es,
+        "Rwanda"@et,
+        "Ruanda"@fi,
+        "Rwanda (le)"@fr,
+        "Ruanda"@ga,
+        "Ruanda"@hr,
+        "Ruanda"@hu,
+        "Ruanda"@it,
+        "Ruanda"@lt,
+        "Ruanda"@lv,
+        "ir-Rwanda"@mt,
+        "Rwanda"@nl,
+        "Rwanda"@pl,
+        "Ruanda"@pt,
+        "Rwanda"@ro,
+        "Rwanda"@sk,
+        "Ruanda"@sl,
+        "Rwanda"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SA> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SA>,
+        <http://publications.europa.eu/resource/authority/country/SAU>,
+        <http://sws.geonames.org/102358/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SA" ;
+    skos:prefLabel "Saudi Arabia",
+        "Саудитска Арабия"@bg,
+        "Saúdská Arábie"@cs,
+        "Saudi-Arabien"@da,
+        "Saudi-Arabien"@de,
+        "Σαουδική Αραβία"@el,
+        "Saudi Arabia"@en,
+        "Arabia Saudí"@es,
+        "Saudi Araabia"@et,
+        "Saudi-Arabia"@fi,
+        "Arabie saoudite (l’)"@fr,
+        "an Araib Shádach"@ga,
+        "Saudijska Arabija"@hr,
+        "Szaúd-Arábia"@hu,
+        "Arabia Saudita"@it,
+        "Saudo Arabija"@lt,
+        "Saūda Arābija"@lv,
+        "l-Arabja Sawdija"@mt,
+        "Saudi- Arabië"@nl,
+        "Arabia Saudyjska"@pl,
+        "Arábia Saudita"@pt,
+        "Arabia Saudită"@ro,
+        "Saudská Arábia"@sk,
+        "Saudova Arabija"@sl,
+        "Saudiarabien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SB> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SB>,
+        <http://publications.europa.eu/resource/authority/country/SLB>,
+        <http://sws.geonames.org/2103350/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SB" ;
+    skos:prefLabel "Solomon Islands",
+        "Соломонови острови"@bg,
+        "Šalamounovy ostrovy"@cs,
+        "Salomonøerne"@da,
+        "die Salomonen"@de,
+        "Νήσοι Σολομώντος"@el,
+        "Solomon Islands"@en,
+        "Islas Salomón"@es,
+        "Saalomoni Saared"@et,
+        "Salomonsaaret"@fi,
+        "Îles Salomon (les)"@fr,
+        "Oileáin Sholomón"@ga,
+        "Salomonski Otoci"@hr,
+        "Salamon-szigetek"@hu,
+        "Isole Salomone"@it,
+        "Saliamono Salos"@lt,
+        "Zālamana Salas"@lv,
+        "il-Gżejjer Solomon"@mt,
+        "Salomonseilanden"@nl,
+        "Wyspy Salomona"@pl,
+        "Ilhas Salomão"@pt,
+        "Insulele Solomon"@ro,
+        "Šalamúnove ostrovy"@sk,
+        "Salomonovi otoki"@sl,
+        "Salomonöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SC> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SC>,
+        <http://publications.europa.eu/resource/authority/country/SYC>,
+        <http://sws.geonames.org/241170/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SC" ;
+    skos:prefLabel "Seychelles",
+        "Сейшелски острови"@bg,
+        "Seychely"@cs,
+        "Seychellerne"@da,
+        "die Seychellen"@de,
+        "Σεϋχέλλες"@el,
+        "Seychelles"@en,
+        "Seychelles"@es,
+        "Seišellid"@et,
+        "Seychellit"@fi,
+        "Seychelles (les)"@fr,
+        "na Séiséil"@ga,
+        "Sejšeli"@hr,
+        "Seychelle-szigetek"@hu,
+        "Seychelles"@it,
+        "Seišeliai"@lt,
+        "Seišelas"@lv,
+        "is-Seychelles"@mt,
+        "Seychellen"@nl,
+        "Seszele"@pl,
+        "Seicheles"@pt,
+        "Seychelles"@ro,
+        "Seychely"@sk,
+        "Sejšeli"@sl,
+        "Seychellerna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SD> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SD>,
+        <http://publications.europa.eu/resource/authority/country/SDN>,
+        <http://sws.geonames.org/366755/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SD" ;
+    skos:prefLabel "Sudan",
+        "Судан"@bg,
+        "Súdán"@cs,
+        "Sudan"@da,
+        "Sudan"@de,
+        "Σουδάν"@el,
+        "Sudan"@en,
+        "Sudán"@es,
+        "Sudaan"@et,
+        "Sudan"@fi,
+        "Soudan (le)"@fr,
+        "an tSúdáin"@ga,
+        "Sudan"@hr,
+        "Szudán"@hu,
+        "Sudan"@it,
+        "Sudanas"@lt,
+        "Sudāna"@lv,
+        "is-Sudan"@mt,
+        "Sudan"@nl,
+        "Sudan"@pl,
+        "Sudão"@pt,
+        "Sudan"@ro,
+        "Sudán"@sk,
+        "Sudan"@sl,
+        "Sudan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SE> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Sweden>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/SE>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/SE>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SWE>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/SE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/SE>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SE>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/SE>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/SE>,
+        <http://publications.europa.eu/resource/authority/country/SWE>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/SE>,
+        <http://rod.eionet.europa.eu/spatial/36>,
+        <http://sws.geonames.org/2661886/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SE" ;
+    skos:prefLabel "Sweden",
+        "Швеция"@bg,
+        "Švédsko"@cs,
+        "Sverige"@da,
+        "Schweden"@de,
+        "Σουηδία"@el,
+        "Sweden"@en,
+        "Suecia"@es,
+        "Rootsi"@et,
+        "Ruotsi"@fi,
+        "Suède (la)"@fr,
+        "an tSualainn"@ga,
+        "Švedska"@hr,
+        "Svédország"@hu,
+        "Svezia"@it,
+        "Švedija"@lt,
+        "Zviedrija"@lv,
+        "l-Isvezja"@mt,
+        "Zweden"@nl,
+        "Szwecja"@pl,
+        "Suécia"@pt,
+        "Suedia"@ro,
+        "Švédsko"@sk,
+        "Švedska"@sl,
+        "Sverige"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SG>,
+        <http://publications.europa.eu/resource/authority/country/SGP>,
+        <http://sws.geonames.org/1880251/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SG" ;
+    skos:prefLabel "Singapore",
+        "Сингапур"@bg,
+        "Singapur"@cs,
+        "Singapore"@da,
+        "Singapur"@de,
+        "Σινγκαπούρη"@el,
+        "Singapore"@en,
+        "Singapur"@es,
+        "Singapur"@et,
+        "Singapore"@fi,
+        "Singapour"@fr,
+        "Singeapór"@ga,
+        "Singapur"@hr,
+        "Szingapúr"@hu,
+        "Singapore"@it,
+        "Singapūras"@lt,
+        "Singapūra"@lv,
+        "Singapor"@mt,
+        "Singapore"@nl,
+        "Singapur"@pl,
+        "Singapura"@pt,
+        "Singapore"@ro,
+        "Singapur"@sk,
+        "Singapur"@sl,
+        "Singapore"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SHN>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SH>,
+        <http://publications.europa.eu/resource/authority/country/SHN>,
+        <http://sws.geonames.org/3370751/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SH" ;
+    skos:prefLabel "Saint Helena",
+        "Света Елена, Възнесение и Тристан да Куня"@bg,
+        "Svatá Helena, Ascension a Tristan da Cunha"@cs,
+        "Saint Helena, Ascension og Tristan da Cunha"@da,
+        "St. Helena, Ascension und Tristan da Cunha"@de,
+        "Αγία Ελένη, Ασενσιόν και Τριστάν ντα Κούνα"@el,
+        "Saint Helena, Ascension and Tristan da Cunha"@en,
+        "Santa Elena, Ascensión y Tristán da Cunha"@es,
+        "Saint Helena, Ascension ja Tristan da Cunha"@et,
+        "Saint Helena, Ascension ja Tristan da Cunha"@fi,
+        "Sainte-Hélène, Ascension et Tristan da Cunha"@fr,
+        "San Héilin, Oileán na Deascabhála agus Tristan da Cunha"@ga,
+        "Sveta Helena, Ascension i Tristan da Cunha"@hr,
+        "Szent Ilona, Ascension és Tristan da Cunha"@hu,
+        "Sant’Elena, Ascensione e Tristan da Cunha"@it,
+        "Šv. Elenos, Dangun Žengimo ir Tristano da Kunjos Salos"@lt,
+        "Svētās Helēnas, Debesbraukšanas un Tristana da Kuņas Salas"@lv,
+        "Sant’Elena, Ascension u Tristan da Cunha"@mt,
+        "Sint-Helena, Ascension en Tristan da Cunha"@nl,
+        "Święta Helena, Wyspa Wniebowstąpienia i Tristan da Cunha"@pl,
+        "Santa Helena, Ascensão e Tristão da Cunha"@pt,
+        "Sfânta Elena, Ascension și Tristan da Cunha"@ro,
+        "Svätá Helena, Ascension a Tristan da Cunha"@sk,
+        "Sveta Helena, Ascension in Tristan da Cunha"@sl,
+        "Sankt Helena, Ascension och Tristan da Cunha"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SI> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Slovenia>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/SI>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/SI>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SVN>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/SI>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/SI>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SI>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/SI>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/SI>,
+        <http://publications.europa.eu/resource/authority/country/SVN>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/SI>,
+        <http://rod.eionet.europa.eu/spatial/34>,
+        <http://sws.geonames.org/3190538/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SI" ;
+    skos:prefLabel "Slovenia",
+        "Словения"@bg,
+        "Slovinsko"@cs,
+        "Slovenien"@da,
+        "Slowenien"@de,
+        "Σλοβενία"@el,
+        "Slovenia"@en,
+        "Eslovenia"@es,
+        "Sloveenia"@et,
+        "Slovenia"@fi,
+        "Slovénie (la)"@fr,
+        "an tSlóivéin"@ga,
+        "Slovenija"@hr,
+        "Szlovénia"@hu,
+        "Slovenia"@it,
+        "Slovėnija"@lt,
+        "Slovēnija"@lv,
+        "is-Slovenja"@mt,
+        "Slovenië"@nl,
+        "Słowenia"@pl,
+        "Eslovénia"@pt,
+        "Slovenia"@ro,
+        "Slovinsko"@sk,
+        "Slovenija"@sl,
+        "Slovenien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SJ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SJM>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SJ>,
+        <http://publications.europa.eu/resource/authority/country/SJM>,
+        <http://sws.geonames.org/607072/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SJ" ;
+    skos:prefLabel "Svalbard and Jan Mayen Islands",
+        "Свалбард и Ян Майен"@bg,
+        "Svalbard a Jan Mayen"@cs,
+        "Svalbard og Jan Mayen"@da,
+        "Svalbard und Jan Mayen"@de,
+        "Σβάλμπαρντ και Γιαν Μαγιέν"@el,
+        "Svalbard and Jan Mayen"@en,
+        "Svalbard y Jan Mayen"@es,
+        "Svalbard ja Jan Mayen"@et,
+        "Svalbard ja Jan Mayen"@fi,
+        "Svalbard et Jan Mayen"@fr,
+        "Svalbard agus Jan Mayen"@ga,
+        "Svalbard i Jan Mayen"@hr,
+        "Svalbard és Jan Mayen"@hu,
+        "Svalbard e Jan Mayen"@it,
+        "Svalbardas ir Janas Majenas"@lt,
+        "Svālbara un Jana Majena Sala"@lv,
+        "Svalbard u Jan Mayen"@mt,
+        "Svalbard en Jan Mayen"@nl,
+        "Svalbard i Jan Mayen"@pl,
+        "Svalbard e Jan Mayen"@pt,
+        "Svalbard și Jan Mayen"@ro,
+        "Svalbard a Jan Mayen"@sk,
+        "Svalbard in Jan Mayen"@sl,
+        "Svalbard och Jan Mayen"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SK> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Slovakia>,
+        <http://dd.eionet.europa.eu/vocabulary/art12_2012/countrycode/SK>,
+        <http://dd.eionet.europa.eu/vocabulary/art17_2006/countries/SK>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SVK>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/SK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/SK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SK>,
+        <http://dd.eionet.europa.eu/vocabulary/habides/habidescountries/SK>,
+        <http://dd.eionet.europa.eu/vocabulary/lcp/lcpcountries/SK>,
+        <http://publications.europa.eu/resource/authority/country/SVK>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/SK>,
+        <http://rod.eionet.europa.eu/spatial/33>,
+        <http://sws.geonames.org/3057568/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SK" ;
+    skos:prefLabel "Slovakia",
+        "Словакия"@bg,
+        "Slovensko"@cs,
+        "Slovakiet"@da,
+        "die Slowakei"@de,
+        "Σλοβακία"@el,
+        "Slovakia"@en,
+        "Eslovaquia"@es,
+        "Slovakkia"@et,
+        "Slovakia"@fi,
+        "Slovaquie (la)"@fr,
+        "an tSlóvaic"@ga,
+        "Slovačka"@hr,
+        "Szlovákia"@hu,
+        "Slovacchia"@it,
+        "Slovakija"@lt,
+        "Slovākija"@lv,
+        "is-Slovakkja"@mt,
+        "Slowakije"@nl,
+        "Słowacja"@pl,
+        "Eslováquia"@pt,
+        "Slovacia"@ro,
+        "Slovensko"@sk,
+        "Slovaška"@sl,
+        "Slovakien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SL> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SL>,
+        <http://publications.europa.eu/resource/authority/country/SLE>,
+        <http://sws.geonames.org/2403846/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SL" ;
+    skos:prefLabel "Sierra Leone",
+        "Сиера Леоне"@bg,
+        "Sierra Leone"@cs,
+        "Sierra Leone"@da,
+        "Sierra Leone"@de,
+        "Σιέρα Λεόνε"@el,
+        "Sierra Leone"@en,
+        "Sierra Leona"@es,
+        "Sierra Leone"@et,
+        "Sierra Leone"@fi,
+        "Sierra Leone (la)"@fr,
+        "Siarra Leon"@ga,
+        "Sijera Leone"@hr,
+        "Sierra Leone"@hu,
+        "Sierra Leone"@it,
+        "Siera Leonė"@lt,
+        "Sjerraleone"@lv,
+        "Sjerra Leone"@mt,
+        "Sierra Leone"@nl,
+        "Sierra Leone"@pl,
+        "Serra Leoa"@pt,
+        "Sierra Leone"@ro,
+        "Sierra Leone"@sk,
+        "Sierra Leone"@sl,
+        "Sierra Leone"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SM> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/San_Marino>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/SMR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SM>,
+        <http://publications.europa.eu/resource/authority/country/SMR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/SM>,
+        <http://rod.eionet.europa.eu/spatial/104>,
+        <http://sws.geonames.org/3168068/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SM" ;
+    skos:prefLabel "San Marino",
+        "Сан Марино"@bg,
+        "San Marino"@cs,
+        "San Marino"@da,
+        "San Marino"@de,
+        "Άγιος Μαρίνος"@el,
+        "San Marino"@en,
+        "San Marino"@es,
+        "San Marino"@et,
+        "San Marino"@fi,
+        "Saint-Marin"@fr,
+        "San Mairíne"@ga,
+        "San Marino"@hr,
+        "San Marino"@hu,
+        "San Marino"@it,
+        "San Marinas"@lt,
+        "Sanmarīno"@lv,
+        "San Marino"@mt,
+        "San Marino"@nl,
+        "San Marino"@pl,
+        "São Marinho"@pt,
+        "San Marino"@ro,
+        "San Maríno"@sk,
+        "San Marino"@sl,
+        "San Marino"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SN>,
+        <http://publications.europa.eu/resource/authority/country/SEN>,
+        <http://sws.geonames.org/2245662/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SN" ;
+    skos:prefLabel "Senegal",
+        "Сенегал"@bg,
+        "Senegal"@cs,
+        "Senegal"@da,
+        "Senegal"@de,
+        "Σενεγάλη"@el,
+        "Senegal"@en,
+        "Senegal"@es,
+        "Senegal"@et,
+        "Senegal"@fi,
+        "Sénégal (le)"@fr,
+        "an tSeineagáil"@ga,
+        "Senegal"@hr,
+        "Szenegál"@hu,
+        "Senegal"@it,
+        "Senegalas"@lt,
+        "Senegāla"@lv,
+        "is-Senegal"@mt,
+        "Senegal"@nl,
+        "Senegal"@pl,
+        "Senegal"@pt,
+        "Senegal"@ro,
+        "Senegal"@sk,
+        "Senegal"@sl,
+        "Senegal"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SO>,
+        <http://publications.europa.eu/resource/authority/country/SOM>,
+        <http://sws.geonames.org/51537/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SO" ;
+    skos:prefLabel "Somalia",
+        "Сомалия"@bg,
+        "Somálsko"@cs,
+        "Somalia"@da,
+        "Somalia"@de,
+        "Σομαλία"@el,
+        "Somalia"@en,
+        "Somalia"@es,
+        "Somaalia"@et,
+        "Somalia"@fi,
+        "Somalie (la)"@fr,
+        "an tSomáil"@ga,
+        "Somalija"@hr,
+        "Szomália"@hu,
+        "Somalia"@it,
+        "Somalis"@lt,
+        "Somālija"@lv,
+        "is-Somalja"@mt,
+        "Somalië"@nl,
+        "Somalia"@pl,
+        "Somália"@pt,
+        "Somalia"@ro,
+        "Somálsko"@sk,
+        "Somalija"@sl,
+        "Somalia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SR> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SR>,
+        <http://publications.europa.eu/resource/authority/country/SUR>,
+        <http://sws.geonames.org/3382998/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SR" ;
+    skos:prefLabel "Suriname",
+        "Суринам"@bg,
+        "Surinam"@cs,
+        "Surinam"@da,
+        "Suriname"@de,
+        "Σουρινάμ"@el,
+        "Suriname"@en,
+        "Surinam"@es,
+        "Suriname"@et,
+        "Suriname"@fi,
+        "Suriname (le)"@fr,
+        "Suranam"@ga,
+        "Surinam"@hr,
+        "Suriname"@hu,
+        "Suriname"@it,
+        "Surinamas"@lt,
+        "Surinama"@lv,
+        "is-Surinam"@mt,
+        "Suriname"@nl,
+        "Surinam"@pl,
+        "Suriname"@pt,
+        "Suriname"@ro,
+        "Surinam"@sk,
+        "Surinam"@sl,
+        "Surinam"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SS> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SS>,
+        <http://publications.europa.eu/resource/authority/country/SSD> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SS" ;
+    skos:prefLabel "South Sudan" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ST> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ST>,
+        <http://publications.europa.eu/resource/authority/country/STP>,
+        <http://sws.geonames.org/2410758/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ST" ;
+    skos:prefLabel "Sao Tome and Principe",
+        "Сао Томе и Принсипи"@bg,
+        "Svatý Tomáš a Princův ostrov"@cs,
+        "São Tomé og Príncipe"@da,
+        "São Tomé und Príncipe"@de,
+        "Σάο Τομέ και Πρίνσιπε"@el,
+        "São Tomé and Príncipe"@en,
+        "Santo Tomé y Príncipe"@es,
+        "São Tomé ja Príncipe"@et,
+        "São Tomé ja Príncipe"@fi,
+        "Sao Tomé-et-Principe"@fr,
+        "São Tomé agus Príncipe"@ga,
+        "Sveti Toma i Princip"@hr,
+        "São Tomé és Príncipe"@hu,
+        "Sao Tomé e Principe"@it,
+        "San Tomė ir Prinsipė"@lt,
+        "Santome un Prinsipi"@lv,
+        "São Tomé u Príncipe"@mt,
+        "Sao Tomé en Principe"@nl,
+        "Wyspy Świętego Tomasza i Książęca"@pl,
+        "São Tomé e Príncipe"@pt,
+        "São Tomé și Principe"@ro,
+        "Svätý Tomáš a Princov ostrov"@sk,
+        "São Tomé in Príncipe"@sl,
+        "São Tomé och Príncipe"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SV> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SV>,
+        <http://publications.europa.eu/resource/authority/country/SLV>,
+        <http://sws.geonames.org/3585968/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SV" ;
+    skos:prefLabel "El Salvador",
+        "Ел Салвадор"@bg,
+        "Salvador"@cs,
+        "El Salvador"@da,
+        "El Salvador"@de,
+        "Ελ Σαλβαδόρ"@el,
+        "El Salvador"@en,
+        "El Salvador"@es,
+        "El Salvador"@et,
+        "El Salvador"@fi,
+        "El Salvador (l’)"@fr,
+        "an tSalvadóir"@ga,
+        "Salvador"@hr,
+        "Salvador"@hu,
+        "El Salvador"@it,
+        "Salvadoras"@lt,
+        "Salvadora"@lv,
+        "El Salvador"@mt,
+        "El Salvador"@nl,
+        "Salwador"@pl,
+        "Salvador"@pt,
+        "El Salvador"@ro,
+        "Salvádor"@sk,
+        "Salvador"@sl,
+        "El Salvador"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SX> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SX>,
+        <http://publications.europa.eu/resource/authority/country/SXM> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SX" ;
+    skos:prefLabel "Sint Maarten" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SY> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Syria>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SY>,
+        <http://publications.europa.eu/resource/authority/country/SYR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/SY>,
+        <http://rod.eionet.europa.eu/spatial/119>,
+        <http://sws.geonames.org/163843/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SY" ;
+    skos:prefLabel "Syria",
+        "Сирия"@bg,
+        "Sýrie"@cs,
+        "Syrien"@da,
+        "Syrien"@de,
+        "Συρία"@el,
+        "Syria"@en,
+        "Siria"@es,
+        "Süüria"@et,
+        "Syyria"@fi,
+        "Syrie (la)"@fr,
+        "an tSiria"@ga,
+        "Sirija"@hr,
+        "Szíria"@hu,
+        "Siria"@it,
+        "Sirija"@lt,
+        "Sīrija"@lv,
+        "is-Sirja"@mt,
+        "Syrië"@nl,
+        "Syria"@pl,
+        "Síria"@pt,
+        "Siria"@ro,
+        "Sýria"@sk,
+        "Sirija"@sl,
+        "Syrien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/SZ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/SZ>,
+        <http://publications.europa.eu/resource/authority/country/SWZ>,
+        <http://sws.geonames.org/934841/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "SZ" ;
+    skos:prefLabel "Swaziland",
+        "Свазиленд"@bg,
+        "Svazijsko"@cs,
+        "Swaziland"@da,
+        "Swasiland"@de,
+        "Σουαζιλάνδη"@el,
+        "Swaziland"@en,
+        "Suazilandia"@es,
+        "Svaasimaa"@et,
+        "Swazimaa"@fi,
+        "Swaziland (le)"@fr,
+        "an tSuasalainn"@ga,
+        "Svazi"@hr,
+        "Szváziföld"@hu,
+        "Swaziland"@it,
+        "Svazilandas"@lt,
+        "Svazilenda"@lv,
+        "is-Sważiland"@mt,
+        "Swaziland"@nl,
+        "Suazi"@pl,
+        "Suazilândia"@pt,
+        "Swaziland"@ro,
+        "Svazijsko"@sk,
+        "Svazi"@sl,
+        "Swaziland"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TC> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/TCA>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TC>,
+        <http://publications.europa.eu/resource/authority/country/TCA>,
+        <http://sws.geonames.org/3576916/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TC" ;
+    skos:prefLabel "Turks and Caicos Islands",
+        "Търкс и Кайкос"@bg,
+        "Ostrovy Turks a Caicos"@cs,
+        "Turks- og Caicosøerne"@da,
+        "die Turks- und Caicosinseln"@de,
+        "Νήσοι Τερκ και Κάικος"@el,
+        "Turks and Caicos Islands"@en,
+        "Islas Turcas y Caicos"@es,
+        "Turks ja Caicos"@et,
+        "Turks- ja Caicossaaret"@fi,
+        "Îles Turks-et-Caïcos (les)"@fr,
+        "Oileáin na dTurcach agus Caicos"@ga,
+        "Otoci Turks i Caicos"@hr,
+        "Turks- és Caicos-szigetek"@hu,
+        "Isole Turks e Caicos (le)"@it,
+        "Terksas ir Kaikosas"@lt,
+        "Tērksas un Kaikosas Salas"@lv,
+        "il-Gżejjer Turks u Kajkos"@mt,
+        "Turks- en Caicoseilanden"@nl,
+        "Wyspy Turks i Caicos"@pl,
+        "Ilhas Turcas e Caicos"@pt,
+        "Insulele Turks și Caicos"@ro,
+        "Turks a Caicos"@sk,
+        "Otoki Turks in Caicos"@sl,
+        "Turks- och Caicosöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TD> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TD>,
+        <http://publications.europa.eu/resource/authority/country/TCD>,
+        <http://sws.geonames.org/2434508/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TD" ;
+    skos:prefLabel "Chad",
+        "Чад"@bg,
+        "Čad"@cs,
+        "Tchad"@da,
+        "Tschad"@de,
+        "Τσαντ"@el,
+        "Chad"@en,
+        "Chad"@es,
+        "Tšaad"@et,
+        "Tšad"@fi,
+        "Tchad (le)"@fr,
+        "Sead"@ga,
+        "Čad"@hr,
+        "Csád"@hu,
+        "Ciad"@it,
+        "Čadas"@lt,
+        "Čada"@lv,
+        "iċ-Ċad"@mt,
+        "Tsjaad"@nl,
+        "Czad"@pl,
+        "Chade"@pt,
+        "Ciad"@ro,
+        "Čad"@sk,
+        "Čad"@sl,
+        "Tchad"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/ATF>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TF>,
+        <http://dd.eionet.europa.eu/vocabulary/fao/refarea/71>,
+        <http://publications.europa.eu/resource/authority/country/ATF>,
+        <http://sws.geonames.org/1546748/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TF" ;
+    skos:prefLabel "French Southern Lands",
+        "Francuske Južne i Antarktičke Zemlje"@bg,
+        "Francouzská jižní a antarktická území"@cs,
+        "franske besiddelser i det sydlige Indiske Ocean og Antarktis, de"@da,
+        "die Französischen Süd- und Antarktisgebiete"@de,
+        "Γαλλικές περιοχές του νοτίου ημισφαιρίου και της Ανταρκτικής"@el,
+        "French Southern and Antarctic Lands"@en,
+        "Territorios Australes Franceses"@es,
+        "Prantsuse Antarktilised ja Lõunaalad"@et,
+        "Ranskan eteläiset ja antarktiset alueet"@fi,
+        "Terres australes et antarctiques françaises (les)"@fr,
+        "Críocha an Deiscirt agus an Antartaigh de chuid na Fraince"@ga,
+        "Francia Déli és Antarktiszi Területek"@hu,
+        "Terre australi e antartiche francesi (le)"@it,
+        "Prancūzijos Pietų ir Antarkties Sritys"@lt,
+        "Francijas Dienvidjūru un Antarktikas Zemes"@lv,
+        "it-Territorji Franċiżi tan-Nofsinhar u Antartiċi"@mt,
+        "Franse Zuidelijke en Zuidpoolgebieden"@nl,
+        "Francuskie Terytoria Południowe i Antarktyczne"@pl,
+        "Terras Austrais e Antárticas Francesas"@pt,
+        "Teritoriile Australe și Antarctice Franceze"@ro,
+        "Francúzske južné a antarktické územia"@sk,
+        "Francoska južna in antarktična ozemlja"@sl,
+        "de franska territorierna i södra Indiska oceanen och Antarktis"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TG>,
+        <http://publications.europa.eu/resource/authority/country/TGO>,
+        <http://sws.geonames.org/2363686/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TG" ;
+    skos:prefLabel "Togo",
+        "Того"@bg,
+        "Togo"@cs,
+        "Togo"@da,
+        "Togo"@de,
+        "Τόγκο"@el,
+        "Togo"@en,
+        "Togo"@es,
+        "Togo"@et,
+        "Togo"@fi,
+        "Togo (le)"@fr,
+        "Tóga"@ga,
+        "Togo"@hr,
+        "Togo"@hu,
+        "Togo"@it,
+        "Togas"@lt,
+        "Togo"@lv,
+        "it-Togo"@mt,
+        "Togo"@nl,
+        "Togo"@pl,
+        "Togo"@pt,
+        "Togo"@ro,
+        "Togo"@sk,
+        "Togo"@sl,
+        "Togo"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TH> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TH>,
+        <http://publications.europa.eu/resource/authority/country/THA>,
+        <http://sws.geonames.org/1605651/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TH" ;
+    skos:prefLabel "Thailand",
+        "Тайланд"@bg,
+        "Thajsko"@cs,
+        "Thailand"@da,
+        "Thailand"@de,
+        "Ταϊλάνδη"@el,
+        "Thailand"@en,
+        "Tailandia"@es,
+        "Tai"@et,
+        "Thaimaa"@fi,
+        "Thaïlande (la)"@fr,
+        "an Téalainn"@ga,
+        "Tajland"@hr,
+        "Thaiföld"@hu,
+        "Thailandia"@it,
+        "Tailandas"@lt,
+        "Taizeme"@lv,
+        "it-Tajlandja"@mt,
+        "Thailand"@nl,
+        "Tajlandia"@pl,
+        "Tailândia"@pt,
+        "Thailanda"@ro,
+        "Thajsko"@sk,
+        "Tajska"@sl,
+        "Thailand"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TJ> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Tajikistan>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/TJK>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TJ>,
+        <http://publications.europa.eu/resource/authority/country/TJK>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/TJ>,
+        <http://rod.eionet.europa.eu/spatial/105>,
+        <http://sws.geonames.org/1220409/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TJ" ;
+    skos:prefLabel "Tajikistan",
+        "Таджикистан"@bg,
+        "Tádžikistán"@cs,
+        "Tadsjikistan"@da,
+        "Tadschikistan"@de,
+        "Τατζικιστάν"@el,
+        "Tajikistan"@en,
+        "Tayikistán"@es,
+        "Tadžikistan"@et,
+        "Tadžikistan"@fi,
+        "Tadjikistan (le)"@fr,
+        "an Táidsíceastáin"@ga,
+        "Tadžikistan"@hr,
+        "Tádzsikisztán"@hu,
+        "Tagikistan"@it,
+        "Tadžikistanas"@lt,
+        "Tadžikistāna"@lv,
+        "it-Taġikistan"@mt,
+        "Tadzjikistan"@nl,
+        "Tadżykistan"@pl,
+        "Tajiquistão"@pt,
+        "Tadjikistan"@ro,
+        "Tadžikistan"@sk,
+        "Tadžikistan"@sl,
+        "Tadzjikistan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TK> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TK>,
+        <http://publications.europa.eu/resource/authority/country/TKL>,
+        <http://sws.geonames.org/4031074/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TK" ;
+    skos:prefLabel "Tokelau",
+        "Токелау"@bg,
+        "Tokelau"@cs,
+        "Tokelau"@da,
+        "Tokelau"@de,
+        "Τοκελάου (το)"@el,
+        "Tokelau"@en,
+        "Tokelau"@es,
+        "Tokelau"@et,
+        "Tokelau"@fi,
+        "Tokélaou (les)"@fr,
+        "Tócalá"@ga,
+        "Tokelau"@hr,
+        "Tokelau-szigetek"@hu,
+        "Tokelau (le)"@it,
+        "Tokelau"@lt,
+        "Tokelau"@lv,
+        "it-Tokelaw"@mt,
+        "Tokelau-eilanden"@nl,
+        "Tokelau"@pl,
+        "Toquelau"@pt,
+        "Tokelau"@ro,
+        "Tokelau"@sk,
+        "Tokelau"@sl,
+        "Tokelauöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TL> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TL>,
+        <http://publications.europa.eu/resource/authority/country/TLS>,
+        <http://sws.geonames.org/1966436/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TL" ;
+    skos:prefLabel "Timor-Leste",
+        "Източен Тимор"@bg,
+        "Východní Timor"@cs,
+        "Timor-Leste"@da,
+        "Timor-Leste"@de,
+        "Ανατολικό Τιμόρ"@el,
+        "Timor-Leste"@en,
+        "Timor Oriental"@es,
+        "Ida-Timor"@et,
+        "Itä-Timor"@fi,
+        "Timor-Oriental (le)"@fr,
+        "Tíomór Thoir"@ga,
+        "Istočni Timor"@hr,
+        "Kelet-Timor"@hu,
+        "Timor Leste"@it,
+        "Rytų Timoras"@lt,
+        "Austrumtimora"@lv,
+        "Timor Leste"@mt,
+        "Oost-Timor"@nl,
+        "Timor Wschodni"@pl,
+        "Timor-Leste"@pt,
+        "Timorul de Est"@ro,
+        "Východný Timor"@sk,
+        "Vzhodni Timor"@sl,
+        "Östtimor"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TM> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Turkmenistan>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/TKM>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TM>,
+        <http://publications.europa.eu/resource/authority/country/TKM>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/TM>,
+        <http://rod.eionet.europa.eu/spatial/106>,
+        <http://sws.geonames.org/1218197/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TM" ;
+    skos:prefLabel "Turkmenistan",
+        "Туркменистан"@bg,
+        "Turkmenistán"@cs,
+        "Turkmenistan"@da,
+        "Turkmenistan"@de,
+        "Τουρκμενιστάν"@el,
+        "Turkmenistan"@en,
+        "Turkmenistán"@es,
+        "Türkmenistan"@et,
+        "Turkmenistan"@fi,
+        "Turkménistan (le)"@fr,
+        "an Tuircméanastáin"@ga,
+        "Turkmenistan"@hr,
+        "Türkmenisztán"@hu,
+        "Turkmenistan"@it,
+        "Turkmėnistanas"@lt,
+        "Turkmenistāna"@lv,
+        "it-Turkmenistan"@mt,
+        "Turkmenistan"@nl,
+        "Turkmenistan"@pl,
+        "Turquemenistão"@pt,
+        "Turkmenistan"@ro,
+        "Turkménsko"@sk,
+        "Turkmenistan"@sl,
+        "Turkmenistan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TN> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Tunisia>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/TUN>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TN>,
+        <http://publications.europa.eu/resource/authority/country/TUN>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/TN>,
+        <http://rod.eionet.europa.eu/spatial/113>,
+        <http://sws.geonames.org/2464461/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TN" ;
+    skos:prefLabel "Tunisia",
+        "Тунис"@bg,
+        "Tunisko"@cs,
+        "Tunesien"@da,
+        "Tunesien"@de,
+        "Τυνησία"@el,
+        "Tunisia"@en,
+        "Túnez"@es,
+        "Tuneesia"@et,
+        "Tunisia"@fi,
+        "Tunisie (la)"@fr,
+        "an Túinéis"@ga,
+        "Tunis"@hr,
+        "Tunézia"@hu,
+        "Tunisia"@it,
+        "Tunisas"@lt,
+        "Tunisija"@lv,
+        "it-Tuneżija"@mt,
+        "Tunesië"@nl,
+        "Tunezja"@pl,
+        "Tunísia"@pt,
+        "Tunisia"@ro,
+        "Tunisko"@sk,
+        "Tunizija"@sl,
+        "Tunisien"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TO> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TO>,
+        <http://publications.europa.eu/resource/authority/country/TON>,
+        <http://sws.geonames.org/4032283/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TO" ;
+    skos:prefLabel "Tonga",
+        "Тонга"@bg,
+        "Tonga"@cs,
+        "Tonga"@da,
+        "Tonga"@de,
+        "Τόνγκα"@el,
+        "Tonga"@en,
+        "Tonga"@es,
+        "Tonga"@et,
+        "Tonga"@fi,
+        "Tonga (les)"@fr,
+        "Tonga"@ga,
+        "Tonga"@hr,
+        "Tonga"@hu,
+        "Tonga"@it,
+        "Tonga"@lt,
+        "Tonga"@lv,
+        "Tonga"@mt,
+        "Tonga"@nl,
+        "Tonga"@pl,
+        "Tonga"@pt,
+        "Tonga"@ro,
+        "Tonga"@sk,
+        "Tonga"@sl,
+        "Tonga"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TR> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Turkey>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/TUR>,
+        <http://dd.eionet.europa.eu/vocabulary/common/nuts/TR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/cities/TR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TR>,
+        <http://publications.europa.eu/resource/authority/country/TUR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/TR>,
+        <http://rod.eionet.europa.eu/spatial/38>,
+        <http://sws.geonames.org/298795/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TR" ;
+    skos:prefLabel "Turkey",
+        "Турция"@bg,
+        "Turecko"@cs,
+        "Tyrkiet"@da,
+        "die Türkei"@de,
+        "Τουρκία"@el,
+        "Turkey"@en,
+        "Turquía"@es,
+        "Türgi"@et,
+        "Turkki"@fi,
+        "Turquie (la)"@fr,
+        "an Tuirc"@ga,
+        "Turska"@hr,
+        "Törökország"@hu,
+        "Turchia"@it,
+        "Turkija"@lt,
+        "Turcija"@lv,
+        "it-Turkija"@mt,
+        "Turkije"@nl,
+        "Turcja"@pl,
+        "Turquia"@pt,
+        "Turcia"@ro,
+        "Turecko"@sk,
+        "Turčija"@sl,
+        "Turkiet"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TT> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TT>,
+        <http://publications.europa.eu/resource/authority/country/TTO>,
+        <http://sws.geonames.org/3573591/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TT" ;
+    skos:prefLabel "Trinidad and Tobago",
+        "Тринидад и Тобаго"@bg,
+        "Trinidad a Tobago"@cs,
+        "Trinidad og Tobago"@da,
+        "Trinidad und Tobago"@de,
+        "Τρινιδάδ και Τομπάγκο"@el,
+        "Trinidad and Tobago"@en,
+        "Trinidad y Tobago"@es,
+        "Trinidad ja Tobago"@et,
+        "Trinidad ja Tobago"@fi,
+        "Trinité-et-Tobago"@fr,
+        "Oileán na Tríonóide agus Tobága"@ga,
+        "Trinidad and Tobago"@hr,
+        "Trinidad és Tobago"@hu,
+        "Trinidad e Tobago"@it,
+        "Trinidadas ir Tobagas"@lt,
+        "Trinidāda un Tobāgo"@lv,
+        "Trinidad u Tobago"@mt,
+        "Trinidad en Tobago"@nl,
+        "Trynidad i Tobago"@pl,
+        "Trindade e Tobago"@pt,
+        "Trinidad și Tobago"@ro,
+        "Trinidad a Tobago"@sk,
+        "Trinidad in Tobago"@sl,
+        "Trinidad och Tobago"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TV> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TV>,
+        <http://publications.europa.eu/resource/authority/country/TUV>,
+        <http://sws.geonames.org/2110297/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TV" ;
+    skos:prefLabel "Tuvalu",
+        "Тувалу"@bg,
+        "Tuvalu"@cs,
+        "Tuvalu"@da,
+        "Tuvalu"@de,
+        "Τουβαλού"@el,
+        "Tuvalu"@en,
+        "Tuvalu"@es,
+        "Tuvalu"@et,
+        "Tuvalu"@fi,
+        "Tuvalu (les)"@fr,
+        "Tuvalu"@ga,
+        "Tuvalu"@hr,
+        "Tuvalu"@hu,
+        "Tuvalu"@it,
+        "Tuvalu"@lt,
+        "Tuvalu"@lv,
+        "Tuvalu"@mt,
+        "Tuvalu"@nl,
+        "Tuvalu"@pl,
+        "Tuvalu"@pt,
+        "Tuvalu"@ro,
+        "Tuvalu"@sk,
+        "Tuvalu"@sl,
+        "Tuvalu"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TW>,
+        <http://publications.europa.eu/resource/authority/country/TWN>,
+        <http://sws.geonames.org/1668284/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TW" ;
+    skos:prefLabel "Taiwan",
+        "Тайван"@bg,
+        "Tchaj-wan"@cs,
+        "Taiwan"@da,
+        "Taiwan"@de,
+        "Ταϊβάν"@el,
+        "Taiwan"@en,
+        "Taiwán"@es,
+        "Taiwan"@et,
+        "Taiwan"@fi,
+        "Taïwan"@fr,
+        "an Téaváin"@ga,
+        "Tajvan"@hr,
+        "Tajvan"@hu,
+        "Taiwan"@it,
+        "Taivanas"@lt,
+        "Taivāna"@lv,
+        "it-Tajwan"@mt,
+        "Taiwan"@nl,
+        "Tajwan"@pl,
+        "Taiwan"@pt,
+        "Taiwan"@ro,
+        "Taiwan"@sk,
+        "Tajvan"@sl,
+        "Taiwan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/TZ> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/TZ>,
+        <http://publications.europa.eu/resource/authority/country/TZA>,
+        <http://sws.geonames.org/149590/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "TZ" ;
+    skos:prefLabel "Tanzania",
+        "Танзания"@bg,
+        "Tanzanie"@cs,
+        "Tanzania"@da,
+        "Tansania"@de,
+        "Τανζανία"@el,
+        "Tanzania"@en,
+        "Tanzania"@es,
+        "Tansaania"@et,
+        "Tansania"@fi,
+        "Tanzanie (la)"@fr,
+        "an Tansáin"@ga,
+        "Tanzanija"@hr,
+        "Tanzánia"@hu,
+        "Tanzania"@it,
+        "Tanzanija"@lt,
+        "Tanzānija"@lv,
+        "it-Tanzanija"@mt,
+        "Tanzania"@nl,
+        "Tanzania"@pl,
+        "Tanzânia"@pt,
+        "Tanzania"@ro,
+        "Tanzánia"@sk,
+        "Tanzanija"@sl,
+        "Tanzania"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/UA> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Ukraine>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/UKR>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/UA>,
+        <http://publications.europa.eu/resource/authority/country/UKR>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/UA>,
+        <http://rod.eionet.europa.eu/spatial/39>,
+        <http://sws.geonames.org/690791/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "UA" ;
+    skos:prefLabel "Ukraine",
+        "Украйна"@bg,
+        "Ukrajina"@cs,
+        "Ukraine"@da,
+        "die Ukraine"@de,
+        "Ουκρανία"@el,
+        "Ukraine"@en,
+        "Ucrania"@es,
+        "Ukraina"@et,
+        "Ukraina"@fi,
+        "Ukraine (l’)"@fr,
+        "an Úcráin"@ga,
+        "Ukrajina"@hr,
+        "Ukrajna"@hu,
+        "Ucraina"@it,
+        "Ukraina"@lt,
+        "Ukraina"@lv,
+        "l-Ukraina"@mt,
+        "Oekraïne"@nl,
+        "Ukraina"@pl,
+        "Ucrânia"@pt,
+        "Ucraina"@ro,
+        "Ukrajina"@sk,
+        "Ukrajina"@sl,
+        "Ukraina"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/UG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/UG>,
+        <http://publications.europa.eu/resource/authority/country/UGA>,
+        <http://sws.geonames.org/226074/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "UG" ;
+    skos:prefLabel "Uganda",
+        "Уганда"@bg,
+        "Uganda"@cs,
+        "Uganda"@da,
+        "Uganda"@de,
+        "Ουγκάντα"@el,
+        "Uganda"@en,
+        "Uganda"@es,
+        "Uganda"@et,
+        "Uganda"@fi,
+        "Ouganda (l’)"@fr,
+        "Uganda"@ga,
+        "Uganda"@hr,
+        "Uganda"@hu,
+        "Uganda"@it,
+        "Uganda"@lt,
+        "Uganda"@lv,
+        "l-Uganda"@mt,
+        "Uganda"@nl,
+        "Uganda"@pl,
+        "Uganda"@pt,
+        "Uganda"@ro,
+        "Uganda"@sk,
+        "Uganda"@sl,
+        "Uganda"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/UM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/UM>,
+        <http://publications.europa.eu/resource/authority/country/UMI>,
+        <http://sws.geonames.org/5854968/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "UM" ;
+    skos:prefLabel "United States Minor Outlying Islands",
+        "Малки отдалечени острови на Съединените щати"@bg,
+        "Menší odlehlé ostrovy USA"@cs,
+        "USA’s mindre øbesiddelser"@da,
+        "die Kleineren Amerikanischen Überseeinseln"@de,
+        "Απομακρυσμένες Νησίδες των Ηνωμένων Πολιτειών"@el,
+        "United States Minor Outlying Islands"@en,
+        "Islas menores alejadas de los Estados Unidos"@es,
+        "Ühendriikide hajasaared"@et,
+        "Yhdysvaltain pienet erillissaaret"@fi,
+        "Îles mineures éloignées des États-Unis (les)"@fr,
+        "Oileáin Bheaga Fhorimeallacha na Stát Aontaithe"@ga,
+        "Mali udaljeni otoci SAD-a"@hr,
+        "Az Amerikai Egyesült"@hu,
+        "Isole minori periferiche degli Stati Uniti (le)"@it,
+        "Mažosios Tolimosios Salos (JAV)"@lt,
+        "ASV Mazās Aizjūras Salas"@lv,
+        "il-Gżejjer Minuri Mbiegħda tal-Istati Uniti"@mt,
+        "verafgelegen eilandjes van de Verenigde Staten"@nl,
+        "Małe Oddalone Wyspy Stanów Zjednoczonych"@pl,
+        "Ilhas Menores Afastadas dos Estados Unidos"@pt,
+        "Insulele Minore Îndepărtate ale Statelor Unite"@ro,
+        "Menšie odľahlé ostrovy Spojených štátov"@sk,
+        "Stranski zunanji otoki Združenih držav"@sl,
+        "Förenta staternas mindre öar"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/US> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/United_States>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/US>,
+        <http://publications.europa.eu/resource/authority/country/USA>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/US>,
+        <http://sws.geonames.org/6252001/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "US" ;
+    skos:prefLabel "United States of America",
+        "Съединени щати"@bg,
+        "Spojené státy/USA"@cs,
+        "USA"@da,
+        "die Vereinigten Staaten"@de,
+        "Ηνωμένες Πολιτείες"@el,
+        "United States"@en,
+        "Estados Unidos"@es,
+        "Ameerika Ühendriigid"@et,
+        "Yhdysvallat"@fi,
+        "États-Unis (les)"@fr,
+        "na Stáit Aontaithe"@ga,
+        "Sjedinjene Države"@hr,
+        "Egyesült Államok"@hu,
+        "Stati Uniti"@it,
+        "Jungtinės Valstijos"@lt,
+        "ASV"@lv,
+        "l-Istati Uniti"@mt,
+        "Verenigde Staten"@nl,
+        "Stany Zjednoczone"@pl,
+        "Estados Unidos"@pt,
+        "Statele Unite"@ro,
+        "Spojené štáty"@sk,
+        "Združene države"@sl,
+        "Förenta staterna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/UY> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/UY>,
+        <http://publications.europa.eu/resource/authority/country/URY>,
+        <http://sws.geonames.org/3439705/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "UY" ;
+    skos:prefLabel "Uruguay",
+        "Уругвай"@bg,
+        "Uruguay"@cs,
+        "Uruguay"@da,
+        "Uruguay"@de,
+        "Ουρουγουάη"@el,
+        "Uruguay"@en,
+        "Uruguay"@es,
+        "Uruguay"@et,
+        "Uruguay"@fi,
+        "Uruguay (l’)"@fr,
+        "Uragua"@ga,
+        "Urugvaj"@hr,
+        "Uruguay"@hu,
+        "Uruguay"@it,
+        "Urugvajus"@lt,
+        "Urugvaja"@lv,
+        "l-Urugwaj"@mt,
+        "Uruguay"@nl,
+        "Urugwaj"@pl,
+        "Uruguai"@pt,
+        "Uruguay"@ro,
+        "Uruguaj"@sk,
+        "Urugvaj"@sl,
+        "Uruguay"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/UZ> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Uzbekistan>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/UZB>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/UZ>,
+        <http://publications.europa.eu/resource/authority/country/UZB>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/UZ>,
+        <http://rod.eionet.europa.eu/spatial/107>,
+        <http://sws.geonames.org/1512440/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "UZ" ;
+    skos:prefLabel "Uzbekistan",
+        "Узбекистан"@bg,
+        "Uzbekistán"@cs,
+        "Usbekistan"@da,
+        "Usbekistan"@de,
+        "Ουζμπεκιστάν"@el,
+        "Uzbekistan"@en,
+        "Uzbekistán"@es,
+        "Usbekistan"@et,
+        "Uzbekistan"@fi,
+        "Ouzbékistan (l’)"@fr,
+        "an Úisbéiceastáin"@ga,
+        "Uzbekistan"@hr,
+        "Üzbegisztán"@hu,
+        "Uzbekistan"@it,
+        "Uzbekistanas"@lt,
+        "Uzbekistāna"@lv,
+        "l-Uzbekistan"@mt,
+        "Oezbekistan"@nl,
+        "Uzbekistan"@pl,
+        "Usbequistão"@pt,
+        "Uzbekistan"@ro,
+        "Uzbekistan"@sk,
+        "Uzbekistan"@sl,
+        "Uzbekistan"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/VA> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/Vatican_City>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/VA>,
+        <http://publications.europa.eu/resource/authority/country/VAT>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/VA>,
+        <http://rod.eionet.europa.eu/spatial/121>,
+        <http://sws.geonames.org/3164670/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "VA" ;
+    skos:prefLabel "Vatican City",
+        "Светия престол/"@bg,
+        "Svatý stolec / Vatikánský městský stát"@cs,
+        "Hellige Stol, Den/Vatikanstaten"@da,
+        "der Heilige Stuhl/Vatikan"@de,
+        "Αγία Έδρα/το Κράτος της Πόλεως του Βατικανού"@el,
+        "the Holy See/Vatican City State"@en,
+        "Santa Sede"@es,
+        "Püha Tool / Vatikani Linnriik"@et,
+        "Pyhä istuin / Vatikaanivaltio"@fi,
+        "Saint-Siège (le)/État de la Cité du Vatican (l’)"@fr,
+        "an Suí Naofa/Cathair na Vatacáine"@ga,
+        "Sveta Stolica/Država Grada Vatikana"@hr,
+        "Apostoli Szentszék/Vatikán"@hu,
+        "Santa Sede/Stato della Città del Vaticano"@it,
+        "Šventasis Sostas / Vatikanas"@lt,
+        "Svētais Krēsls / Vatikāns"@lv,
+        "is-Santa Sede / l-Istat tal-Belt tal-Vatikan"@mt,
+        "de Heilige Stoel/Vaticaanstad"@nl,
+        "Stolica Apostolska / Państwo Watykańskie"@pl,
+        "Santa Sé / Estado da Cidade do Vaticano"@pt,
+        "Sfântul Scaun/Vatican"@ro,
+        "Svätá stolica/ Vatikánsky mestský štát"@sk,
+        "Sveti sedež / Vatikan"@sl,
+        "Heliga stolen/Vatikanstaten"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/VC> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/VC>,
+        <http://publications.europa.eu/resource/authority/country/VCT>,
+        <http://sws.geonames.org/3577815/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "VC" ;
+    skos:prefLabel "Saint Vincent and the Grenadines",
+        "Сейнт Винсънт и Гренадини"@bg,
+        "Svatý Vincenc a Grenadiny"@cs,
+        "Saint Vincent og Grenadinerne"@da,
+        "St. Vincent und die Grenadinen"@de,
+        "Άγιος Βικέντιος και Γρεναδίνες"@el,
+        "Saint Vincent and the Grenadines"@en,
+        "San Vicente y las Granadinas"@es,
+        "Saint Vincent"@et,
+        "Saint Vincent ja Grenadiinit"@fi,
+        "Saint-Vincent-"@fr,
+        "San Uinseann agus na Greanáidíní"@ga,
+        "Sveti Vincent i Grenadini"@hr,
+        "Saint Vincent és Grenadine-szigetek"@hu,
+        "Saint Vincent e Grenadine"@it,
+        "Sent Vinsentas ir Grenadinai"@lt,
+        "Sentvinsenta un Grenadīnas"@lv,
+        "Saint Vincent u l-Grenadini"@mt,
+        "Saint Vincent en de Grenadines"@nl,
+        "Saint Vincent i Grenadyny"@pl,
+        "São Vicente e Granadinas"@pt,
+        "Saint Vincent și Grenadine"@ro,
+        "Svätý Vincent a Grenadíny"@sk,
+        "Saint Vincent in Grenadine"@sl,
+        "Saint Vincent"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/VE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/VE>,
+        <http://publications.europa.eu/resource/authority/country/VEN>,
+        <http://sws.geonames.org/3625428/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "VE" ;
+    skos:prefLabel "Venezuela",
+        "Венецуела"@bg,
+        "Venezuela"@cs,
+        "Venezuela"@da,
+        "Venezuela"@de,
+        "Βενεζουέλα"@el,
+        "Venezuela"@en,
+        "Venezuela"@es,
+        "Venezuela"@et,
+        "Venezuela"@fi,
+        "Venezuela (le)"@fr,
+        "Veiniséala"@ga,
+        "Venezuela"@hr,
+        "Venezuela"@hu,
+        "Venezuela"@it,
+        "Venesuela"@lt,
+        "Venecuēla"@lv,
+        "il-Venezwela"@mt,
+        "Venezuela"@nl,
+        "Wenezuela"@pl,
+        "Venezuela"@pt,
+        "Venezuela"@ro,
+        "Venezuela"@sk,
+        "Venezuela"@sl,
+        "Venezuela"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/VG> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/VGB>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/VG>,
+        <http://publications.europa.eu/resource/authority/country/VGB>,
+        <http://sws.geonames.org/3577718/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "VG" ;
+    skos:prefLabel "Virgin Islands, British",
+        "Британски Вирджински острови"@bg,
+        "Britské Panenské ostrovy"@cs,
+        "Britiske Jomfruøer, De"@da,
+        "die Britischen Jungferninseln"@de,
+        "Βρετανικές Παρθένοι Νήσοι"@el,
+        "British Virgin Islands"@en,
+        "Islas Vírgenes Británicas"@es,
+        "Briti Neitsisaared"@et,
+        "Brittiläiset Neitsytsaaret"@fi,
+        "Îles Vierges britanniques (les)"@fr,
+        "Oileáin Bhriotanacha na Maighdean"@ga,
+        "Britanski Djevičanski Otoci"@hr,
+        "Brit Virgin-szigetek"@hu,
+        "Isole Vergini britanniche (le)"@it,
+        "Mergelių Salos (Didžioji Britanija)"@lt,
+        "Britu Virdžīnas"@lv,
+        "il-Gżejjer Verġni Brittaniċi"@mt,
+        "Britse Maagdeneilanden"@nl,
+        "Brytyjskie Wyspy Dziewicze"@pl,
+        "Ilhas Virgens Britânicas"@pt,
+        "Insulele Virgine Britanice"@ro,
+        "Britské Panenské ostrovy"@sk,
+        "Britanski Deviški otoki"@sl,
+        "Brittiska Jungfruöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/VI> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/VI>,
+        <http://publications.europa.eu/resource/authority/country/VIR>,
+        <http://sws.geonames.org/4796775/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "VI" ;
+    skos:prefLabel "Virgin Islands, U.S.",
+        "Американски Вирджински острови"@bg,
+        "Americké Panenské ostrovy"@cs,
+        "Amerikanske Jomfruøer, De"@da,
+        "die Amerikanischen Jungferninseln"@de,
+        "Αμερικανικές Παρθένοι Νήσοι"@el,
+        "US Virgin Islands"@en,
+        "Islas Vírgenes de los Estados Unidos"@es,
+        "USA Neitsisaared"@et,
+        "Yhdysvaltain Neitsytsaaret"@fi,
+        "Îles Vierges américaines (les)"@fr,
+        "Oileáin Mheiriceánacha na Maighdean"@ga,
+        "Američki Djevičanski Otoci"@hr,
+        "Amerikai Virgin-szigetek"@hu,
+        "Isole Vergini americane (le)"@it,
+        "Mergelių Salos (JAV)"@lt,
+        "ASV Virdžīnas"@lv,
+        "il-Gżejjer Verġni Amerikani"@mt,
+        "Amerikaanse Maagdeneilanden"@nl,
+        "Wyspy Dziewicze Stanów Zjednoczonych"@pl,
+        "Ilhas Virgens Americanas"@pt,
+        "Insulele Virgine Americane"@ro,
+        "Americké Panenské ostrovy"@sk,
+        "Ameriški Deviški otoki"@sl,
+        "Amerikanska Jungfruöarna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/VN> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/VN>,
+        <http://publications.europa.eu/resource/authority/country/VNM>,
+        <http://sws.geonames.org/1562822/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "VN" ;
+    skos:prefLabel "Vietnam",
+        "Виетнам"@bg,
+        "Vietnam"@cs,
+        "Vietnam"@da,
+        "Vietnam"@de,
+        "Βιετνάμ"@el,
+        "Vietnam"@en,
+        "Vietnam"@es,
+        "Vietnam"@et,
+        "Vietnam"@fi,
+        "Viêt Nam (le)"@fr,
+        "Vítneam"@ga,
+        "Vijetnam"@hr,
+        "Vietnam"@hu,
+        "Vietnam"@it,
+        "Vietnamas"@lt,
+        "Vjetnama"@lv,
+        "il-Vjetnam"@mt,
+        "Vietnam"@nl,
+        "Wietnam"@pl,
+        "Vietname"@pt,
+        "Vietnam"@ro,
+        "Vietnam"@sk,
+        "Vietnam"@sl,
+        "Vietnam"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/VU> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/VU>,
+        <http://publications.europa.eu/resource/authority/country/VUT>,
+        <http://sws.geonames.org/2134431/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "VU" ;
+    skos:prefLabel "Vanuatu",
+        "Вануату"@bg,
+        "Vanuatu"@cs,
+        "Vanuatu"@da,
+        "Vanuatu"@de,
+        "Βανουάτου"@el,
+        "Vanuatu"@en,
+        "Vanuatu"@es,
+        "Vanuatu"@et,
+        "Vanuatu"@fi,
+        "Vanuatu (le)"@fr,
+        "Vanuatú"@ga,
+        "Vanuatu"@hr,
+        "Vanuatu"@hu,
+        "Vanuatu"@it,
+        "Vanuatu"@lt,
+        "Vanuatu"@lv,
+        "il-Vanwatu"@mt,
+        "Vanuatu"@nl,
+        "Vanuatu"@pl,
+        "Vanuatu"@pt,
+        "Vanuatu"@ro,
+        "Vanuatu"@sk,
+        "Vanuatu"@sl,
+        "Vanuatu"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/WF> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/WLF>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/WF>,
+        <http://publications.europa.eu/resource/authority/country/WLF>,
+        <http://sws.geonames.org/4034749/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "WF" ;
+    skos:prefLabel "Wallis and Futuna Islands",
+        "Уолис и Футуна"@bg,
+        "Wallis a Futuna"@cs,
+        "Wallis og Futuna"@da,
+        "Wallis und Futuna"@de,
+        "Ουάλις και Φουτούνα"@el,
+        "Wallis and Futuna"@en,
+        "Wallis y Futuna"@es,
+        "Wallis ja Futuna"@et,
+        "Wallis ja Futuna"@fi,
+        "Wallis-et-Futuna"@fr,
+        "Vailís agus Futúna"@ga,
+        "Wallis and Futuna"@hr,
+        "Wallis és Futuna"@hu,
+        "Wallis e Futuna"@it,
+        "Volisas ir Futūna"@lt,
+        "Volisa un Futunas Salas"@lv,
+        "Wallis u Futuna"@mt,
+        "Wallis en Futuna"@nl,
+        "Wallis i Futuna"@pl,
+        "Wallis e Futuna"@pt,
+        "Wallis și Futuna"@ro,
+        "Wallis a Futuna"@sk,
+        "Wallis in Futuna"@sl,
+        "Wallis och Futuna"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/WS> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/WS>,
+        <http://publications.europa.eu/resource/authority/country/WSM>,
+        <http://sws.geonames.org/4034894/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "WS" ;
+    skos:prefLabel "Samoa",
+        "Самоа"@bg,
+        "Samoa"@cs,
+        "Samoa"@da,
+        "Samoa"@de,
+        "Σαμόα"@el,
+        "Samoa"@en,
+        "Samoa"@es,
+        "Samoa"@et,
+        "Samoa"@fi,
+        "Samoa (le)"@fr,
+        "Samó"@ga,
+        "Samoa"@hr,
+        "Szamoa"@hu,
+        "Samoa"@it,
+        "Samoa"@lt,
+        "Samoa"@lv,
+        "Samoa"@mt,
+        "Samoa"@nl,
+        "Samoa"@pl,
+        "Samoa"@pt,
+        "Samoa"@ro,
+        "Samoa"@sk,
+        "Samoa"@sl,
+        "Samoa"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/XK> a skos:Concept ;
+    skos:definition "As established under UNSCR 1244/99" ;
+    skos:exactMatch <http://dbpedia.org/resource/Kosovo>,
+        <http://dd.eionet.europa.eu/vocabulary/cdda/regions/XKX>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/XK>,
+        <http://dd.eionet.europa.eu/vocabulary/worldbank/country/KV>,
+        <http://publications.europa.eu/resource/authority/country/1A0>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/XK>,
+        <http://rod.eionet.europa.eu/spatial/42>,
+        <http://sws.geonames.org/831053/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "XK" ;
+    skos:prefLabel "Kosovo (under UNSCR 1244/99)" ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/YE> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/YE>,
+        <http://publications.europa.eu/resource/authority/country/YEM>,
+        <http://sws.geonames.org/69543/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "YE" ;
+    skos:prefLabel "Yemen",
+        "Йемен"@bg,
+        "Jemen"@cs,
+        "Yemen"@da,
+        "Jemen"@de,
+        "Υεμένη"@el,
+        "Yemen"@en,
+        "Yemen"@es,
+        "Jeemen"@et,
+        "Jemen"@fi,
+        "Yémen (le)"@fr,
+        "Éimin"@ga,
+        "Jemen"@hr,
+        "Jemen"@hu,
+        "Yemen"@it,
+        "Jemenas"@lt,
+        "Jemena"@lv,
+        "il-Jemen"@mt,
+        "Jemen"@nl,
+        "Jemen"@pl,
+        "Iémen"@pt,
+        "Yemen"@ro,
+        "Jemen"@sk,
+        "Jemen"@sl,
+        "Jemen"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/YT> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/cdda/regions/MYT>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/YT>,
+        <http://publications.europa.eu/resource/authority/country/MYT>,
+        <http://sws.geonames.org/1024031/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "YT" ;
+    skos:prefLabel "Mayotte",
+        "Майот"@bg,
+        "Mayotte"@cs,
+        "Mayotte"@da,
+        "Mayotte"@de,
+        "Μαγιότ (το)"@el,
+        "Mayotte"@en,
+        "Mayotte"@es,
+        "Mayotte"@et,
+        "Mayotte"@fi,
+        "Mayotte"@fr,
+        "Mayotte"@ga,
+        "Mayotte"@hr,
+        "Mayotte"@hu,
+        "Mayotte"@it,
+        "Majotas"@lt,
+        "Majota"@lv,
+        "il-Majott"@mt,
+        "Mayotte"@nl,
+        "Majotta"@pl,
+        "Maiote"@pt,
+        "Mayotte"@ro,
+        "Mayotte"@sk,
+        "Mayotte"@sl,
+        "Mayotte"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ZA> a skos:Concept ;
+    skos:exactMatch <http://dbpedia.org/resource/South_Africa>,
+        <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ZA>,
+        <http://publications.europa.eu/resource/authority/country/ZAF>,
+        <http://rdfdata.eionet.europa.eu/eea/countries/ZA>,
+        <http://sws.geonames.org/953987/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ZA" ;
+    skos:prefLabel "South Africa",
+        "Южна Африка"@bg,
+        "Jižní Afrika"@cs,
+        "Sydafrika"@da,
+        "Südafrika"@de,
+        "Νότια Αφρική"@el,
+        "South Africa"@en,
+        "Sudáfrica"@es,
+        "Lõuna-Aafrika"@et,
+        "Etelä-Afrikka"@fi,
+        "Afrique du Sud (l’)"@fr,
+        "an Afraic Theas"@ga,
+        "Južnoafrička Republika"@hr,
+        "Dél-Afrika"@hu,
+        "Sud Africa"@it,
+        "Pietų Afrika"@lt,
+        "Dienvidāfrika"@lv,
+        "l-Afrika t’Isfel"@mt,
+        "Zuid-Afrika"@nl,
+        "Republika Południowej Afryki"@pl,
+        "África do Sul"@pt,
+        "Africa de Sud"@ro,
+        "Južná Afrika"@sk,
+        "Južna Afrika"@sl,
+        "Sydafrika"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ZM> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ZM>,
+        <http://publications.europa.eu/resource/authority/country/ZMB>,
+        <http://sws.geonames.org/895949/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ZM" ;
+    skos:prefLabel "Zambia",
+        "Замбия"@bg,
+        "Zambie"@cs,
+        "Zambia"@da,
+        "Sambia"@de,
+        "Ζάμπια"@el,
+        "Zambia"@en,
+        "Zambia"@es,
+        "Sambia"@et,
+        "Sambia"@fi,
+        "Zambie (la)"@fr,
+        "an tSaimbia"@ga,
+        "Zambia"@hr,
+        "Zambia"@hu,
+        "Zambia"@it,
+        "Zambija"@lt,
+        "Zambija"@lv,
+        "iż-Żambja"@mt,
+        "Zambia"@nl,
+        "Zambia"@pl,
+        "Zâmbia"@pt,
+        "Zambia"@ro,
+        "Zambia"@sk,
+        "Zambija"@sl,
+        "Zambia"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/ZW> a skos:Concept ;
+    skos:exactMatch <http://dd.eionet.europa.eu/vocabulary/eurostat/geo/ZW>,
+        <http://publications.europa.eu/resource/authority/country/ZWE>,
+        <http://sws.geonames.org/878675/> ;
+    skos:inScheme <http://dd.eionet.europa.eu/vocabulary/common/countries/> ;
+    skos:notation "ZW" ;
+    skos:prefLabel "Zimbabwe",
+        "Зимбабве"@bg,
+        "Zimbabwe"@cs,
+        "Zimbabwe"@da,
+        "Simbabwe"@de,
+        "Ζιμπάμπουε"@el,
+        "Zimbabwe"@en,
+        "Zimbabue"@es,
+        "Zimbabwe"@et,
+        "Zimbabwe"@fi,
+        "Zimbabwe (le)"@fr,
+        "an tSiombáib"@ga,
+        "Zimbabve"@hr,
+        "Zimbabwe"@hu,
+        "Zimbabwe"@it,
+        "Zimbabvė"@lt,
+        "Zimbabve"@lv,
+        "iż-Żimbabwe"@mt,
+        "Zimbabwe"@nl,
+        "Zimbabwe"@pl,
+        "Zimbabué"@pt,
+        "Zimbabwe"@ro,
+        "Zimbabwe"@sk,
+        "Zimbabve"@sl,
+        "Zimbabwe"@sv ;
+    adms:status <http://dd.eionet.europa.eu/vocabulary/datadictionary/status/valid> .
+
+<http://dd.eionet.europa.eu/vocabulary/common/countries/> a skos:ConceptScheme ;
+    rdfs:label "Strict ISO-3166 country codes. I.e. United Kingdom is GB and Greece is GR." ;
+    dcterms:isPartOf <http://dd.eionet.europa.eu/vocabulary/common/> ;
+    skos:notation "countries" .


### PR DESCRIPTION
Based off ISO 3166-1

Downloaded from http://dd.eionet.europa.eu/vocabulary/common/countries/view
converted rdf -> ttl using https://rdf-translator.appspot.com/
removed validation fails around multiple prefLabels per language.

Required for migration of Party data
