### PR TITLE
PGGD updates

### DIFF
--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -108,7 +108,7 @@ bhpur:oil-shale a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
 bhpur:water a skos:Concept ;
-    skos:definition "Wells and bores drilled under permits governed by the Queensland Water Act 2000 and Petroleum and Gas (Production and Safety) Act 2004"@en ;
+    skos:definition "Wells and bores drilled under permits governed by the Queensland Water Act 2000"@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
     skos:prefLabel "Water"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
@@ -143,8 +143,6 @@ bhpur:pggd a skos:Collection ;
     skos:member bhpur:conventional-petroleum,
             bhpur:coal-seam-gas,
             bhpur:unconventional-petroleum,
-            bhpur:water,
             bhpur:geothermal,
-            bhpur:greenhouse-gas-storage, 
-            bhpur:non-industry;
+            bhpur:greenhouse-gas-storage;
     skos:prefLabel "PGGD selection"@en .

--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -108,7 +108,8 @@ bhpur:oil-shale a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
 bhpur:water a skos:Concept ;
-    skos:definition "Wells and bores drilled under permits governed by the Queensland Water Act 2000"@en ;
+    skos:definition "Wells and bores drilled under permits governed by the Queensland Water Act 2000. Additional rights, obligations, and responsibilities may be conferred by intersecting legislation on wells and bores drilled by mineral and coal permit holders and petroleum and gas permit holders under the Mineral Resources Act 1989 and the Petroleum and Gas (Production and Safety) Act 2004 respectively."@en ;
+
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
     skos:prefLabel "Water"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .

--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -144,5 +144,6 @@ bhpur:pggd a skos:Collection ;
             bhpur:coal-seam-gas,
             bhpur:unconventional-petroleum,
             bhpur:geothermal,
-            bhpur:greenhouse-gas-storage;
+            bhpur:greenhouse-gas-storage,
+            bhpur:water;
     skos:prefLabel "PGGD selection"@en .

--- a/vocabularies/borehole-sub-purpose.ttl
+++ b/vocabularies/borehole-sub-purpose.ttl
@@ -408,7 +408,7 @@ bhfunc:gas-management a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .
 
 bhfunc:pggd-functions a skos:Collection ;
-    skos:definition "The functions of boreholes specific to petroleum, greenhouse gas, and geothermal wells and bores i.e. those that require a PGGD-01 notification in Queensland regulation."@en ;
+    skos:definition "The functions of boreholes specific to petroleum, greenhouse gas, and geothermal wells and bores i.e. those that require a statutory notification in Queensland regulation."@en ;
     skos:member bhfunc:water-supply,
         bhfunc:water-injection,
         bhfunc:stratigraphic,

--- a/vocabularies/borehole-sub-purpose.ttl
+++ b/vocabularies/borehole-sub-purpose.ttl
@@ -11,7 +11,7 @@
     dcterms:created "2020-01-23"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2020-07-13"^^xsd:date ;
+    dcterms:modified "2020-09-16"^^xsd:date ;
     dcterms:source "Compiled by the Geological Survey of Queensland" ;
     skos:definition "The intended function of a borehole."@en ;
     skos:hasTopConcept bhfunc:blasthole,
@@ -126,11 +126,11 @@ bhfunc:goaf-drainage a skos:Concept ;
     skos:prefLabel "goaf drainage"@en .
 
 bhfunc:heat-flow a skos:Concept ;
-    skos:altLabel "geothermal heat flow"@en ;
+    skos:altLabel "Heat flow"@en ;
     skos:broader bhfunc:resource-assessment ;
     skos:definition "purposely drilled to directly measure downhole temperature gradient as well as collecting core samples (to measure thermal conductivity of formations intersected), then to be able to calculate / determine heat flow in the drilled section of the borehole."@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
-    skos:prefLabel "Heat flow"@en .
+    skos:prefLabel "Geothermal heat flow"@en .
 
 bhfunc:intrusion-delineation a skos:Concept ;
     skos:broader bhfunc:structure ;
@@ -183,16 +183,9 @@ bhfunc:penetrometer a skos:Concept ;
 
 bhfunc:petroleum-reservoir-characterisation a skos:Concept ;
     skos:broader bhfunc:resource-assessment ;
-    skos:definition "A well drilled to determine how to develop a hydrocarbon field most efficiently or quantify reservoir characteristics such as pay zone thickness, porosity, permeability, saturation, fluid column heights, and the presence of cap rock."@en ;
+    skos:definition "A well drilled to determine how to develop a hydrocarbon field most efficiently or quantify reservoir characteristics such as pay zone thickness, porosity, permeability, saturation, fluid column heights, and the presence of cap rock. Most commonly associated with the Appraisal stage of the resource lifecycle."@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
-    skos:prefLabel "Petroleum Reservoir Characterisation"@en .
-
-bhfunc:petroleum-prod-test a skos:Concept ;
-    skos:broader bhfunc:resource-assessment ;
-    skos:definition "A well drilled primarily to test the ability of a target reservoir to  produce hydrocarbons, and to measure production parameters such as flow rates, well interference, pressure decline etc."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
-    skos:prefLabel "Petroleum Production Testing"@en .
-
+    skos:prefLabel "Petroleum Resource Characterisation"@en .
 
 bhfunc:plug a skos:Concept ;
     skos:broader bhfunc:service ;
@@ -327,7 +320,7 @@ bhfunc:petroleum-injection a skos:Concept ;
 
 bhfunc:stratigraphic a skos:Concept ;
     skos:altLabel "Exploration"@en ;
-    skos:definition "A well determining the lithological intervals present at a location. Typically to determine on the presence, location and extent of a potential resource"@en ;
+    skos:definition "A well determining the lithological intervals present at a location. Typically to determine on the presence, location and extent of a potential resource. Most commonly associated with the Exploration stage of the resource lifecycle."@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
     skos:notation "STRAT" ;
     skos:prefLabel "Stratigraphic"@en ;
@@ -403,7 +396,22 @@ bhfunc:service a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .
 
 bhfunc:gas-management a skos:Concept ;
-    skos:definition "Borehole drilled for gas analysis. Typical applications include exploration, compliance and greenhouse gas emissions."@en ;
+    skos:definition "Borehole drilled for gas analysis and management. Typical applications include exploration, management of gas in coal mines, compliance and greenhouse gas emissions."@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
     skos:prefLabel "Gas Management"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .
+
+bhfunc:pggd-functions a skos:Collection ;
+    skos:definition "The functions of boreholes specific to petroleum, greenhouse gas, and geothermal wells and bores i.e. those that require a PGGD-01 notification in Queensland regulation."@en ;
+    skos:member bhfunc:water-supply,
+        bhfunc:water-injection,
+        bhfunc:stratigraphic,
+        bhfunc:stimulation,
+        bhfunc:petroleum-reservoir-characterisation,
+        bhfunc:petroleum-production,
+        bhfunc:petroleum-prod-test,
+        bhfunc:petroleum-injection,
+        bhfunc:observation,
+        bhfunc:disposal,
+        bhfunc:heat-flow ;
+    skos:prefLabel "Petroleum Borehole Functions"@en .

--- a/vocabularies/borehole-sub-purpose.ttl
+++ b/vocabularies/borehole-sub-purpose.ttl
@@ -187,6 +187,12 @@ bhfunc:petroleum-reservoir-characterisation a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
     skos:prefLabel "Petroleum Resource Characterisation"@en .
 
+bhfunc:petroleum-prod-test a skos:Concept ;
+    skos:broader bhfunc:resource-assessment ;
+    skos:definition "A well drilled primarily to test the ability of a target reservoir to  produce hydrocarbons, and to measure production parameters such as flow rates, well interference, pressure decline etc."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
+    skos:prefLabel "Petroleum Production Testing"@en .
+
 bhfunc:plug a skos:Concept ;
     skos:broader bhfunc:service ;
     skos:definition "Plug hole"@en ;


### PR DESCRIPTION
As per discussion with @LizDerrington 

Modification of _Borehole Purpose_ PGGD Selection collection, to focus on wells and bores that actually require PGGD form lodgement.

Creation of _Borehole Sub-Purpose_ PGGD Function collection to narrow the functions to those specific to Petroleum, Geothermal, and Greenhouse Gas. Deliberately high level to minimise chance for confusion during PGGD submission. higher level detail will be captured in the actual report and updated in GeoProperties at that later time.

PGGD-01 form will need to be modified to direct to the correct collections to populate the corresponding drop-down lists.