### PR TITLE
Update borehole-purpose.ttl

### DIFF
--- a/vocabularies/borehole-purpose.ttl
+++ b/vocabularies/borehole-purpose.ttl
@@ -93,12 +93,10 @@ bhpur:mineral a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
 bhpur:non-industry a skos:Concept ;
-    skos:altLabel "Collaborative Drilling"@en,
-        "Collaborative Exploration"@en,
-        "Non-Industry"@en ;
+    skos:altLabel "Non-Industry"@en ;
     skos:definition "Wells and bores drilled by non-industry agents outside of the State Resources Acts"@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-purpose> ;
-    skos:prefLabel "Non-Industry and Collaborative Drilling"@en ;
+    skos:prefLabel "Non-Industry"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-purpose> .
 
 bhpur:oil-shale a skos:Concept ;


### PR DESCRIPTION
the description, altlabel, and preflabel for non-industry should not reference CEI. See borehole mapping v1.2 for the CA and DM approved mapping