### PR TITLE
Add Investigation sub-purpose (function)

### DIFF
--- a/vocabularies/borehole-sub-purpose.ttl
+++ b/vocabularies/borehole-sub-purpose.ttl
@@ -326,7 +326,6 @@ bhfunc:petroleum-injection a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .
 
 bhfunc:stratigraphic a skos:Concept ;
-    skos:altLabel "Exploration"@en ;
     skos:definition "A well determining the lithological intervals present at a location. Typically to determine on the presence, location and extent of a potential resource. Most commonly associated with the Exploration stage of the resource lifecycle."@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
     skos:notation "STRAT" ;

--- a/vocabularies/borehole-sub-purpose.ttl
+++ b/vocabularies/borehole-sub-purpose.ttl
@@ -11,7 +11,7 @@
     dcterms:created "2020-01-23"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2020-09-16"^^xsd:date ;
+    dcterms:modified "2020-10-14"^^xsd:date ;
     dcterms:source "Compiled by the Geological Survey of Queensland" ;
     skos:definition "The intended function of a borehole."@en ;
     skos:hasTopConcept bhfunc:blasthole,
@@ -26,6 +26,7 @@
         bhfunc:service,
         bhfunc:stimulation,
         bhfunc:stratigraphic,
+        bhfunc:investigation,
         bhfunc:structure,
         bhfunc:water-injection,
         bhfunc:water-supply ;
@@ -333,7 +334,7 @@ bhfunc:stratigraphic a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .
 
 bhfunc:investigation a skos:Concept ;
-    skos:definition "A well drilled with scant or nil prior knowledge of an area's geology to identify the presence of any lithologic, structural, hydrological, geochemical, or other geologic properties of interest."@en ;
+    skos:definition "A well drilled with scant or nil prior knowledge of the geology of an area to identify the presence of any lithologic, structural, hydrological, geochemical, or other geologic properties of interest."@en ;
     skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
     skos:prefLabel "Investigation"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .

--- a/vocabularies/borehole-sub-purpose.ttl
+++ b/vocabularies/borehole-sub-purpose.ttl
@@ -332,6 +332,12 @@ bhfunc:stratigraphic a skos:Concept ;
     skos:prefLabel "Stratigraphic"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .
 
+bhfunc:investigation a skos:Concept ;
+    skos:definition "A well drilled with scant or nil prior knowledge of an area's geology to identify the presence of any lithologic, structural, hydrological, geochemical, or other geologic properties of interest."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
+    skos:prefLabel "Investigation"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .
+
 bhfunc:water-injection a skos:Concept ;
     skos:altLabel "Water Storage"@en ;
     skos:definition "A well in which water is injected rather than produced, where the primary objective is to store water in a reservoir or aquifer for later production."@en ;


### PR DESCRIPTION
Added _Investigation_ sub-purpose as discussed by @CourteneyD and @LizDerrington 
Accounts for the very early "lets just see what is there" wells.

- [x] Technical Check @LukeHauck 

- [x] Borehole Owner Check @LizDerrington 

- [x] Content Authority Check @CourteneyD 

`bhfunc:investigation a skos:Concept ;
    skos:definition "A well drilled with scant or nil prior knowledge of the geology of an area to identify the presence of any lithologic, structural, hydrological, geochemical, or other geologic properties of interest."@en ;
    skos:inScheme <http://linked.data.gov.au/def/borehole-sub-purpose> ;
    skos:prefLabel "Investigation"@en ;
    skos:topConceptOf <http://linked.data.gov.au/def/borehole-sub-purpose> .`