### PR TITLE
reclassification - dimension stone and tectonite

### DIFF
--- a/vocabularies/lithology.ttl
+++ b/vocabularies/lithology.ttl
@@ -3789,7 +3789,7 @@ lith:comenditic-trachyte a skos:Concept ;
 lith:dimension-stone a skos:Concept ;
     skos:altLabel "Commercial Rock"@en,
         "Building Stone"@en ;
-    skos:broader lith:rock ;
+    skos:broader lith:unclassified-rock ;
     skos:definition "A general term for quarried and cut building stone."@en ;
     skos:inScheme <http://linked.data.gov.au/def/lithotype> ;
     skos:notation "COMM" ;
@@ -15071,7 +15071,7 @@ lith:tautirite a skos:Concept ;
     skos:prefLabel "Tautirite"@en .
 
 lith:tectonite a skos:Concept ;
-    skos:broader lith:rock ;
+    skos:broader lith:unclassified-rock ;
     skos:definition "In modern usage tectonites are metamorphic or tectonically deformed rocks whose fabric reflects the history of their deformation, or rocks with a penetrative fabric that clearly displays coordinated geometric features that indicate continuous solid (ductile) flow during formation."@en ;
     skos:inScheme <http://linked.data.gov.au/def/lithotype> ;
     skos:notation "TECT" ;


### PR DESCRIPTION
Reclassification of Dimension Stone and Tectonite into the Non-Specific Rock Grouping (lith:unclassified-rock) that accounts for rocks that may be best described by a non-specific term but compositionally may belong to multiple other groupings.

Just a small focused tidy up for two obvious errors/improvements.

- [x]  Vocab Owner @SalEdwards01 

- [x] Tech Check @LukeHauck 

- [x] SME @geoderekh or @CourteneyD

FYI - @johnmckellar 