### PR TITLE
Removing Petroleum Report - Infrastructure and Petroleum Report - Cum…

### DIFF
--- a/vocabularies/georesources-report-types.ttl
+++ b/vocabularies/georesources-report-types.ttl
@@ -419,28 +419,12 @@ grt:petroleum-report-annual a skos:Concept ;
     skos:prefLabel "Petroleum Report - Annual"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
-grt:petroleum-report-cumulative-water-production a skos:Concept ;
-    skos:altLabel "Cumulative Prod/CSG Water Readings - Petroleum"@en ;
-    skos:definition "A report detailing the cumulative total of water produced from a well, as mandatory in the Petroleum and Gas Act."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
-    skos:notation "CUMPRD" ;
-    skos:prefLabel "Petroleum Report - Cumulative Water Production"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
-
 grt:petroleum-report-field-information a skos:Concept ;
     skos:altLabel "Petroleum Field Reports"@en ;
     skos:definition "A report detailing the quantity, quality and other parameters of the reserves of petroleum and gas in a petroleum field that may cover one permit, multiple permits, and/or unpermitted areas."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "PETFLD" ;
     skos:prefLabel "Petroleum Report - Field Information"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
-
-grt:petroleum-report-infrastructure a skos:Concept ;
-    skos:altLabel "Petroleum Infrastructure Reports"@en ;
-    skos:definition "A report detailing the infrastructure installed for the purpose of gathering, processing and storage of petroleum and gas on a permit or permits. Defined in detail as a part of the Petroleum and Gas (Production and Safety) Act."@en ;
-    skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
-    skos:notation "PETIR" ;
-    skos:prefLabel "Petroleum Report - Infrastructure"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:petroleum-report-relinquishment a skos:Concept ;


### PR DESCRIPTION
…ulative Water Production

Petroleum Report - Infrastructure, was removed from reporting requirements in 2018 under the MWOLA Act 2018.

Petroleum Report – Cumulative Water Production is no longer required. This report is lodged with the Petroleum Production Report in the LP as part of petroleum production reporting requirements under the Petroleum and Gas (General Provisions) Regulation 2017 Section 42(3)(d) and (f).