### PR TITLE
Update georesources-report-types.ttl

### DIFF
--- a/vocabularies/georesources-report-types.ttl
+++ b/vocabularies/georesources-report-types.ttl
@@ -881,7 +881,6 @@ grt:water-reports a skos:Collection ;
         grt:greenhouse-gas-report-storage-capacity,
         grt:greenhouse-gas-report-storage-injection,
         grt:mine-plan-lodgement,
-        grt:petroleum-report-field-information,
         grt:petroleum-report-non-associated-water,
         grt:petroleum-report-annual,
         grt:petroleum-end-authority,


### PR DESCRIPTION
"Petroleum Report - Field information" is a very old report type and should be removed from the LP.