### PR TITLE
Create security-classifications.ttl

### DIFF
--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -39,7 +39,6 @@ qgiscf:official-public a skos:Concept ;
  skos:definition "As per OFFICIAL with the Dissemination Limiting Marking (DLM) applied to indicates the information is publically available and may be accessed by or released to the public."@en ;
  skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
  skos:notation "ofp" ;
- rdfs:label "OFFICIAL-PUBLIC"@en ;
  skos:prefLabel "OFFICIAL-PUBLIC"@en  .
 
 qgiscf:sensitive a skos:Concept ;  

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -16,7 +16,7 @@ dct:modified "2020-11-11"^^xsd:date ;
 dct:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
 dct:source "Queensland Government Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)"@en ;
 skos:definition "This is a vocabulary collection used by the Queensland Government to determine the security classifications for the dataset.  It is used by the dataset classification and access restrictions property."@en ;
-skos:prefLabel "QG Information Security Classifications"@en ;
+skos:prefLabel "Queensland Government Information Security Classifications"@en ;
 skos:hasTopConcept 
     qgiscf:official ,
     qgiscf:sensitive  ,

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -14,7 +14,7 @@ dct:created "2020-11-11"^^xsd:date ;
 dct:creator <http://linked.data.gov.au/def/gsq-alias/des> ;
 dct:modified "2020-11-11"^^xsd:date ;
 dct:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
-dct:source "Qld Govt Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)"@en ;
+dct:source "Queensland Government Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)"@en ;
 skos:definition "This is a vocabulary collection used by the DES data catalogue to determine the security classifications for the dataset.  It is utlised by the dataset: classifcation and access restrictions property."@en ;
 skos:prefLabel "QG Information Security Classifications"@en ;
 rdfs:label   "Qld Gov Information Security Classification"@en ;

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -55,7 +55,6 @@ qgiscf:protected a skos:Concept ;
  skos:definition "A pre-existing related resource that is substantially the same as the described resource, but in another format."@en ;
  skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
  skos:notation "prtc" ;
- rdfs:label "PROTECTED"@en ;
  skos:prefLabel "PROTECTED"@en  .
 
 qgiscf:qgiscf a skos:Collection  ;

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -10,7 +10,6 @@
  @prefix sdo: <http://www.schema.org/> .
  @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
-
 <http://linked.data.gov.au/def/qg-security-classifications> a owl:Ontology , skos:ConceptScheme ;
 dct:created "2020-11-11"^^xsd:date ;
 dct:creator <http://linked.data.gov.au/def/gsq-alias/des> ;
@@ -21,7 +20,7 @@ skos:definition "This is a vocabulary collection used by the DES data catalogue 
 skos:prefLabel "QG Information Security Classifications"@en ;
 rdfs:label   "Qld Gov Information Security Classification"@en ;
 skos:hasTopConcept 
-    qgiscf:official , 
+    qgiscf:official ,
     qgiscf:sensitive  ,
     qgiscf:protected .
 
@@ -36,6 +35,14 @@ qgiscf:official a skos:Concept ;
  skos:notation "off" ;
  rdfs:label "OFFICIAL"@en ;
  skos:prefLabel "OFFICIAL"@en  .
+
+qgiscf:official-public a skos:Concept ; 
+ skos:broader qgiscf:official ;
+ skos:definition "As per OFFICIAL with the Dissemination Limiting Marking (DLM) applied to indicates the information is publically available and may be accessed by or released to the public."@en ;
+ skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
+ skos:notation "off" ;
+ rdfs:label "OFFICIAL-PUBLIC"@en ;
+ skos:prefLabel "OFFICIAL-PUBLIC"@en  .
 
 qgiscf:sensitive a skos:Concept ;  
  skos:topConceptOf <http://linked.data.gov.au/def/qg-security-classifications> ; 
@@ -56,9 +63,9 @@ qgiscf:protected a skos:Concept ;
 qgiscf:qgiscf a skos:Collection  ;
  skos:prefLabel "QGISCF"@en ;
  rdfs:label "Qld Gov Information Security Classification"@en ;
- skos:definition "Collection for the QGISCF vocab for the standard terms in the framework. "@en ;
+ skos:definition "Collection for the QGISCF vocab for the standard terms in the framework."@en ;
  skos:member 
     qgiscf:official , 
+    qgiscf:official-public ,
     qgiscf:sensitive  ,
     qgiscf:protected .
-    

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -12,7 +12,7 @@
 <http://linked.data.gov.au/def/qg-security-classifications> a owl:Ontology , skos:ConceptScheme ;
 dct:created "2020-11-11"^^xsd:date ;
 dct:creator <http://linked.data.gov.au/def/gsq-alias/des> ;
-dct:modified "2020-11-11"^^xsd:date ;
+dct:modified "2020-12-07"^^xsd:date ;
 dct:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
 dct:source "Queensland Government Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)"@en ;
 skos:definition "This is a vocabulary collection used by the Queensland Government to determine the security classifications for the dataset.  It is used by the dataset classification and access restrictions property."@en ;

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -17,7 +17,6 @@ dct:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
 dct:source "Queensland Government Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)"@en ;
 skos:definition "This is a vocabulary collection used by the Queensland Government to determine the security classifications for the dataset.  It is used by the dataset classification and access restrictions property."@en ;
 skos:prefLabel "QG Information Security Classifications"@en ;
-rdfs:label   "Qld Gov Information Security Classification"@en ;
 skos:hasTopConcept 
     qgiscf:official ,
     qgiscf:sensitive  ,

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -48,7 +48,6 @@ qgiscf:sensitive a skos:Concept ;
  skos:definition "The use of the SENSITIVE indicates that information requires additional handling care due to its sensitivity or moderate business impact if compromised or lost.  SENSITIVE information must be labelled.  Examples of SENSITIVE information may include: government or agency business, whose compromise could affect the government's capacity to make decisions or operate, the public's confidence in government, the stability of the market place and so on commercial interests, whose compromise could significantly affect the competitive process and provide the opportunity for unfair advantage legal professional privilege law enforcement operations whose compromise could adversely affect crime prevention strategies, particular investigations or adversely affect personal safety personal information, which is required to be safeguarded under the Information Privacy Act 2009 (Qld), or other legislation."@en ;
  skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
  skos:notation "sns" ;
- rdfs:label "SENSITIVE"@en ;
  skos:prefLabel "SENSITIVE"@en  .
 
 qgiscf:protected a skos:Concept ;

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -1,0 +1,64 @@
+ @prefix qgiscf: <http://linked.data.gov.au/def/qg-security-classifications/> .
+
+ @prefix dc: <http://purl.org/dc/elements/1.1/> .
+ @prefix dct: <http://purl.org/dc/terms/> .
+ @prefix prov: <https://www.w3.org/TR/prov-o/> .
+ @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+ @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+ @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+ @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ @prefix sdo: <http://www.schema.org/> .
+ @prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+
+<http://linked.data.gov.au/def/qg-security-classifications> a owl:Ontology , skos:ConceptScheme ;
+dct:created "2020-11-11"^^xsd:date ;
+dct:creator <http://linked.data.gov.au/def/gsq-alias/des> ;
+dct:modified "2020-11-11"^^xsd:date ;
+dct:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
+dct:source "Qld Govt Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)"@en ;
+skos:definition "This is a vocabulary collection used by the DES data catalogue to determine the security classifications for the dataset.  It is utlised by the dataset: classifcation and access restrictions property."@en ;
+skos:prefLabel "QG Information Security Classifications"@en ;
+rdfs:label   "Qld Gov Information Security Classification"@en ;
+skos:hasTopConcept 
+    qgiscf:official , 
+    qgiscf:sensitive  ,
+    qgiscf:protected .
+
+<http://linked.data.gov.au/def/gsq-alias/des>
+    a sdo:Organization ;
+    sdo:name "Department of Environment and Science"@en .
+
+qgiscf:official a skos:Concept ; 
+ skos:topConceptOf <http://linked.data.gov.au/def/qg-security-classifications> ; 
+ skos:definition "OFFICIAL represents most Queensland Government information by volume, but lowest business impact per document if compromised or lost. However, where information is aggregated on an information asset such as an ICT server, the impact of compromise may increase and with it, the controls.  OFFICIAL information is routine information without special sensitivity or handling requirements. All routine public-sector business, operations and services is treated as OFFICIAL. At the OFFICIAL classification there is a general presumption that data may be shared across government. Security measures should be proportionate and driven by the business requirement.  Most OFFICIAL information is subject to the Public Records Act 2002 (Qld)."@en ;
+ skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
+ skos:notation "off" ;
+ rdfs:label "OFFICIAL"@en ;
+ skos:prefLabel "OFFICIAL"@en  .
+
+qgiscf:sensitive a skos:Concept ;  
+ skos:topConceptOf <http://linked.data.gov.au/def/qg-security-classifications> ; 
+ skos:definition "The use of the SENSITIVE indicates that information requires additional handling care due to its sensitivity or moderate business impact if compromised or lost.  SENSITIVE information must be labelled.  Examples of SENSITIVE information may include: government or agency business, whose compromise could affect the government's capacity to make decisions or operate, the public's confidence in government, the stability of the market place and so on commercial interests, whose compromise could significantly affect the competitive process and provide the opportunity for unfair advantage legal professional privilege law enforcement operations whose compromise could adversely affect crime prevention strategies, particular investigations or adversely affect personal safety personal information, which is required to be safeguarded under the Information Privacy Act 2009 (Qld), or other legislation."@en ;
+ skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
+ skos:notation "sns" ;
+ rdfs:label "SENSITIVE"@en ;
+ skos:prefLabel "SENSITIVE"@en  .
+
+qgiscf:protected a skos:Concept ;
+ skos:topConceptOf <http://linked.data.gov.au/def/qg-security-classifications> ;
+ skos:definition "A pre-existing related resource that is substantially the same as the described resource, but in another format."@en ;
+ skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
+ skos:notation "prtc" ;
+ rdfs:label "PROTECTED"@en ;
+ skos:prefLabel "PROTECTED"@en  .
+
+qgiscf:qgiscf a skos:Collection  ;
+ skos:prefLabel "QGISCF"@en ;
+ rdfs:label "Qld Gov Information Security Classification"@en ;
+ skos:definition "Collection for the QGISCF vocab for the standard terms in the framework. "@en ;
+ skos:member 
+    qgiscf:official , 
+    qgiscf:sensitive  ,
+    qgiscf:protected .
+    

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -15,7 +15,7 @@ dct:creator <http://linked.data.gov.au/def/gsq-alias/des> ;
 dct:modified "2020-11-11"^^xsd:date ;
 dct:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
 dct:source "Queensland Government Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)"@en ;
-skos:definition "This is a vocabulary collection used by the DES data catalogue to determine the security classifications for the dataset.  It is utlised by the dataset: classifcation and access restrictions property."@en ;
+skos:definition "This is a vocabulary collection used by the Queensland Government to determine the security classifications for the dataset.  It is used by the dataset classification and access restrictions property."@en ;
 skos:prefLabel "QG Information Security Classifications"@en ;
 rdfs:label   "Qld Gov Information Security Classification"@en ;
 skos:hasTopConcept 

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -40,7 +40,7 @@ qgiscf:official-public a skos:Concept ;
  skos:broader qgiscf:official ;
  skos:definition "As per OFFICIAL with the Dissemination Limiting Marking (DLM) applied to indicates the information is publically available and may be accessed by or released to the public."@en ;
  skos:inScheme <http://linked.data.gov.au/def/qg-security-classifications> ;
- skos:notation "off" ;
+ skos:notation "ofp" ;
  rdfs:label "OFFICIAL-PUBLIC"@en ;
  skos:prefLabel "OFFICIAL-PUBLIC"@en  .
 

--- a/vocabularies/security-classifications.ttl
+++ b/vocabularies/security-classifications.ttl
@@ -2,7 +2,6 @@
 
  @prefix dc: <http://purl.org/dc/elements/1.1/> .
  @prefix dct: <http://purl.org/dc/terms/> .
- @prefix prov: <https://www.w3.org/TR/prov-o/> .
  @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
  @prefix skos: <http://www.w3.org/2004/02/skos/core#> .


### PR DESCRIPTION
Creation of the core vocabulary terms Qld Govt Information Security Policy (IS18:2018) and the Queensland Government Information Security Classification Framework (QGSCIF)

Will need to update later to create a collection and additional terms for our catalogue such as PUBLIC (or a label  OFFICIAL – Public)as described by in the framework.  Also to include terms similar to PROTECTED-CABINET INFORMATION if or as they arise.   Departments and agencies currently have their own separate frameworks describing this labeling. 