### PR TITLE
Update reports - relabel mineral associated water reports

### DIFF
--- a/vocabularies/georesources-report-types.ttl
+++ b/vocabularies/georesources-report-types.ttl
@@ -367,11 +367,12 @@ grt:permit-report-partial-relinquishment-higher-tenure a skos:Concept ;
 
 grt:permit-report-mineral-associated-water a skos:Concept ;
     skos:altLabel "Mineral Associated Water"@en,
-        "Permit Report - Mineral Associated Water"@en ;
+        "Permit Report - Mineral Associated Water"@en,
+	"Coal or Mineral Permit Report - Mineral Associated Water"@en;
     skos:definition "A report detailing the total water produced from a Mining Lease, defined as per the Mineral Resources Act."@en ;
     skos:inScheme <http://linked.data.gov.au/def/georesource-report> ;
     skos:notation "MINAW" ;
-    skos:prefLabel "Coal or Mineral Permit Report - Mineral Associated Water"@en ;
+    skos:prefLabel "Water Report - Mineral Associated Water"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/georesource-report> .
 
 grt:permit-report-six-month a skos:Concept ;


### PR DESCRIPTION
Update name of report as per request from L1 Support

FROM Coal or Mineral Report - Mineral Associated Water
TO Water Report - Mineral Associated Water

Retire old label to altLabels

- [ ] Tech, General, Refresh @DavidCrosswellGSQ 
- [x] Vocab Owner and Lodgement SME @talebib 
- [x] SKOS check @LukeHauck 
