### PR TITLE
update RPL Add scheme scopenote and EoL concept

### DIFF
--- a/vocabularies/resource-project-lifecycle.ttl
+++ b/vocabularies/resource-project-lifecycle.ttl
@@ -10,17 +10,19 @@
         skos:ConceptScheme ;
     dcterms:created "2020-02-28"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2020-03-09"^^xsd:date ;
+    dcterms:modified "2020-11-27"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:source "Compiled by the Geological Survey of Queensland" ;
     skos:definition "The stage in the lifecycle of a project (e.g. mine site, petroleum field, quarry) that describes the maturity of resource defintion and production."@en ;
+    skos:scopeNote "The lifecycle of a project of interelated activities. Each individual activity will typically be associated with a specific individual site with its own status, whereas the project lifecycle encompasses the collective status of multiple sites under a single coordinated body of work."@en ;
     skos:hasTopConcept plife:appraisal,
         plife:closed,
         plife:closed-with-near-field-exploration,
         plife:development,
         plife:development-with-near-field-exploration,
         plife:exploration,
-        plife:rehabilitation ;
+        plife:rehabilitation,
+        plife:end-of-life;
     skos:prefLabel "Resource Project Lifecycle"@en .
 
 <http://linked.data.gov.au/org/gsq> a sdo:Organization ;
@@ -71,14 +73,21 @@ plife:exploration a skos:Concept ;
     skos:topConceptOf <http://linked.data.gov.au/def/resource-project-lifecycle> .
 
 plife:rehabilitation a skos:Concept ;
-    skos:definition "The stage in the life-cycle of a resource where the resources have been extracted and the site is being, or has been, rehabilitated back to its original condition or an acceptable environmental standard."@en ;
+    skos:definition "The stage in the life-cycle of a resource where the resources have been extracted and the site is being rehabilitated back to its original condition or an acceptable environmental standard."@en ;
     skos:inScheme <http://linked.data.gov.au/def/resource-project-lifecycle> ;
     skos:notation "RHB" ;
     skos:prefLabel "Rehabilitation"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/resource-project-lifecycle> .
 
+plife:end-of-life a skos:Concept ;
+    skos:definition "The stage in the life-cycle of a resource where the resources have been extracted and the site has been rehabilitated back to its original condition or an acceptable environmental standard. The final state of the lifecycle where no further work is intended or required and the project can be considered defunct and no longer extant."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/resource-project-lifecycle> ;
+    skos:notation "END" ;
+    skos:prefLabel "Project Abandoned"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/resource-project-lifecycle> .
+
 plife:borehole-class a skos:Collection ;
-    skos:definition "The stage in the lifecycle of a borehole. Commonly used by regulatory agencies to define specific obligations for reporting, construction, or abandonment."@en ;
+    skos:definition "The stage in the lifecycle of a petroleum field, of which a borehole is part. Commonly used by regulatory agencies to define specific obligations for reporting, construction, or abandonment."@en ;
     skos:member plife:appraisal,
         plife:development,
         plife:exploration ;

--- a/vocabularies/site-status.ttl
+++ b/vocabularies/site-status.ttl
@@ -8,7 +8,7 @@
 <http://linked.data.gov.au/def/site-status> a owl:Ontology, skos:ConceptScheme ;
     dcterms:created "2020-02-28"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2020-03-11"^^xsd:date ;
+    dcterms:modified "2020-11-27"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:source "Compiled by the Geological Survey of Queensland. Mapped to GeoSciML Mine Status and amalgamation with Borehole status." ;
     skos:definition "The status of an individual site (e.g. mine, well) or single activity (e.g.survey) describing the current state within the lifecycle from proposed through operational through to abandonment. Lifecycle stages are commonly related to regulatory conditions administered by government agencies."@en ;

--- a/vocabularies/site-status.ttl
+++ b/vocabularies/site-status.ttl
@@ -12,7 +12,8 @@
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:source "Compiled by the Geological Survey of Queensland. Mapped to GeoSciML Mine Status and amalgamation with Borehole status." ;
     skos:definition "The status of an individual site (e.g. mine, well) or single activity (e.g.survey) describing the current state within the lifecycle from proposed through operational through to abandonment. Lifecycle stages are commonly related to regulatory conditions administered by government agencies."@en ;
-    skos:scopeNote "Site status describes the lifecycle of asingle discrete activity, Whereas teh resource project lifecycle describes the collective lifecycle status of a body of work that typically consists of multiple activities and sites"@en ;
+    skos:scopeNote "Site status describes the lifecycle of a single discrete activity, Whereas the resource project lifecycle describes the collective lifecycle status of a body of work that typically consists of multiple activities and sites"@en ;
+
     skos:hasTopConcept ststs:abandoned,
         ststs:active,
         ststs:construction,

--- a/vocabularies/site-status.ttl
+++ b/vocabularies/site-status.ttl
@@ -11,7 +11,8 @@
     dcterms:modified "2020-03-11"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:source "Compiled by the Geological Survey of Queensland. Mapped to GeoSciML Mine Status and amalgamation with Borehole status." ;
-    skos:definition "The status of a project (e.g. mine, well) or activity (e.g.survey) describing the current state within the lifecycle from proposed through operational through to abandonment. Lifecycle stages are commonly related to regulatory conditions administered by government agencies."@en ;
+    skos:definition "The status of an individual site (e.g. mine, well) or single activity (e.g.survey) describing the current state within the lifecycle from proposed through operational through to abandonment. Lifecycle stages are commonly related to regulatory conditions administered by government agencies."@en ;
+    skos:scopeNote "Site status describes the lifecycle of asingle discrete activity, Whereas teh resource project lifecycle describes the collective lifecycle status of a body of work that typically consists of multiple activities and sites"@en ;
     skos:hasTopConcept ststs:abandoned,
         ststs:active,
         ststs:construction,


### PR DESCRIPTION
Addition of scope note to RPL to more clearly define the difference between a site status and a project status
Addition of corresponding scope note in site status.
Addition of Project Abandoned and edit to rehabilitation status for increased clarity.

Review 
@DavidCrosswellGSQ 
@geoderekh (or whomever you want to nominate now that you're not Dr. GeoProperties)

FYI @daniel-nieuwenburg @broughd-qld @UbuntuScott 