### PR TITLE
Update georesources-report-types.ttl

### DIFF
--- a/vocabularies/georesources-report-types.ttl
+++ b/vocabularies/georesources-report-types.ttl
@@ -979,5 +979,7 @@ grt:water-reports a skos:Collection ;
         grt:petroleum-report-other,
         grt:presentation,
         grt:queensland-government-mining-journal,
+	grt:any-other-report,
+	grt:technical-report,
         grt:water-report-other;   
     skos:prefLabel "Internal Lodgement Portal"@en .


### PR DESCRIPTION
Adding missing internal report types "Any other report" and "Technical report" to the internal report collection.