### PR TITLE
fix inScheme items for data quality

### DIFF
--- a/vocabularies/dq-iso-19157.ttl
+++ b/vocabularies/dq-iso-19157.ttl
@@ -12,7 +12,7 @@
 @prefix sdo: <http://www.schema.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dq-iso-19157:Dimensions
+<http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions>
   a skos:ConceptScheme ;
   dcterms:source "ISO 19157"@en ;
   rdfs:label "Dimensions of data quailty (ISO 19157)"@en ;
@@ -36,7 +36,7 @@ dq-iso-19157:AbsoluteExternalPositionalAccuracy
   rdfs:label "AbsoluteExternalPositionalAccuracy"@en ;
   skos:broader dq-iso-19157:PositionalAccuracy ;
   skos:definition "Closeness of reported coordinate values to values accepted as or being true"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Absolute External Positional Accuracy"@en .
 
 dq-iso-19157:AccuracyOfATimeMeasurement
@@ -45,7 +45,7 @@ dq-iso-19157:AccuracyOfATimeMeasurement
   rdfs:label "AccuracyOfATimeMeasurement"@en ;
   skos:broader dq-iso-19157:TemporalQuality ;
   skos:definition "Correctness of the temporal references of an item (reporting of error in time measurement)"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Accuracy of a Time Measurement"@en .
 
 dq-iso-19157:Completeness
@@ -53,7 +53,7 @@ dq-iso-19157:Completeness
   a skos:Concept ;
   rdfs:label "Completeness (ISO19157)"@en ;
   skos:definition "Presence and absence of features, their attributes and their relationships"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:completeness ;
   skos:prefLabel "Completeness (ISO19157)"@en .
 
@@ -63,7 +63,7 @@ dq-iso-19157:CompletenessCommission
   rdfs:label "CompletenessCommission"@en ;
   skos:broader dq-iso-19157:Completeness ;
   skos:definition "Excess data present in the data set, as described by the scope"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Completeness Commission"@en .
 
 dq-iso-19157:CompletenessOmission
@@ -72,7 +72,7 @@ dq-iso-19157:CompletenessOmission
   rdfs:label "CompletenessOmission"@en ;
   skos:broader dq-iso-19157:Completeness ;
   skos:definition "Data absent from the data set, as described by the scope"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:exactMatch dq-iso-25012:completeness ;
   skos:prefLabel "Completeness Omission"@en .
 
@@ -82,7 +82,7 @@ dq-iso-19157:ConceptualConsistency
   rdfs:label "ConceptualConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Adherence to rules of the conceptual schema"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Conceptual Consistency"@en .
   
 dq-iso-19157:DomainConsistency
@@ -91,7 +91,7 @@ dq-iso-19157:DomainConsistency
   rdfs:label "DomainConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Adherence of values to the value domains"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Domain Consistency"@en .
 
 dq-iso-19157:FormatConsistency
@@ -100,7 +100,7 @@ dq-iso-19157:FormatConsistency
   rdfs:label "FormatConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Degree to which data are stored in accordance with the physical structure of the data set, as described by the scope"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Format Consistency"@en .
 
 dq-iso-19157:GriddedDataPositionalAccuracy
@@ -109,7 +109,7 @@ dq-iso-19157:GriddedDataPositionalAccuracy
   rdfs:label "GriddedDataPositionalAccuracy"@en ;
   skos:broader dq-iso-19157:PositionalAccuracy ;
   skos:definition "Closeness of gridded data position values to values accepted as or being true"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ; 
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ; 
   skos:prefLabel "Gridded Data Positional Accuracy"@en .
 
 dq-iso-19157:LogicalConsistency
@@ -117,7 +117,7 @@ dq-iso-19157:LogicalConsistency
   a skos:Concept ;
   rdfs:label "LogicalConsistency"@en ;
   skos:definition "Degree of adherence to logical rules of data structure, attribution and relationships (data structure can be conceptual, logical or physical)"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:consistency ;
   skos:prefLabel "Logical Consistency"@en .
   
@@ -126,7 +126,7 @@ dq-iso-19157:Metaquality
   a skos:Concept ;
   rdfs:label "Metaquality"@en ;
   skos:definition "Information about the reliability of data quality results Use obligation from referencing object"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Metaquality"@en .
 
 dq-iso-19157:NonQuantitativeAttributeCorrectness
@@ -135,7 +135,7 @@ dq-iso-19157:NonQuantitativeAttributeCorrectness
   rdfs:label "NonQuantitativeAttributeCorrectness"@en ;
   skos:broader dq-iso-19157:ThematicAccuracy ;
   skos:definition "Correctness of non-quantitative attributes"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "NonQuantitative Attribute Correctness"@en .
 
 dq-iso-19157:PositionalAccuracy
@@ -143,7 +143,7 @@ dq-iso-19157:PositionalAccuracy
   a skos:Concept ;
   rdfs:label "PositionalAccuracy"@en ;
   skos:definition "Accuracy of the position of features"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:accuracy ;
   skos:prefLabel "Positional Accuracy"@en .
 
@@ -152,7 +152,7 @@ dq-iso-19157:QuantitativeAttributeAccuracy
   rdfs:label "QuantitativeAttributeAccuracy"@en ;
   skos:broader dq-iso-19157:ThematicAccuracy ;
   skos:definition "Accuracy of quantitative attributes"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Quantitative Attribute Accuracy"@en ;
 .
 dq-iso-19157:RelativeInternalPositionalAccuracy
@@ -160,7 +160,7 @@ dq-iso-19157:RelativeInternalPositionalAccuracy
   rdfs:label "RelativeInternalPositionalAccuracy"@en ;
   skos:broader dq-iso-19157:PositionalAccuracy ;
   skos:definition "Closeness of the relative positions of features in the scope to their respective relative positions accepted as or being true"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Relative Internal Positional Accuracy"@en ;
 .
 dq-iso-19157:TemporalConsistency
@@ -168,14 +168,14 @@ dq-iso-19157:TemporalConsistency
   rdfs:label "TemporalConsistency"@en ;
   skos:broader dq-iso-19157:TemporalQuality ;
   skos:definition "Correctness of ordered events or sequences, if reported"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Temporal Consistency"@en ;
 .
 dq-iso-19157:TemporalQuality
   a dqv:Dimension ; a skos:Concept ;
   rdfs:label "TemporalQuality"@en ;
   skos:definition "Accuracy of the temporal attributes and temporal relationships of features"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Temporal Quality"@en ;
 .
 dq-iso-19157:TemporalValidity
@@ -183,14 +183,14 @@ dq-iso-19157:TemporalValidity
   rdfs:label "TemporalValidity"@en ;
   skos:broader dq-iso-19157:TemporalQuality ;
   skos:definition "Validity of data specified by the scope with respect to time"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Temporal Validity"@en ;
 .
 dq-iso-19157:ThematicAccuracy
   a dqv:Dimension ; a skos:Concept ;
   rdfs:label "ThematicAccuracy"@en ;
   skos:definition "Accuracy of quantitative attributes and the correctness of non-quantitative attributes and of the classifications of features and their relationships"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:accuracy ;
   skos:relatedMatch dq-iso-25012:precision ;
   skos:prefLabel "Thematic Accuracy"@en ;
@@ -200,7 +200,7 @@ dq-iso-19157:ThematicClassificationCorrectness
   rdfs:label "ThematicClassificationCorrectness"@en ;
   skos:broader dq-iso-19157:ThematicAccuracy ;
   skos:definition "Comparison of the classes assigned to features or their attributes to a universe of discourse"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Thematic Classification Correctness"@en ;
 .
 dq-iso-19157:TopologicalConsistency
@@ -208,14 +208,14 @@ dq-iso-19157:TopologicalConsistency
   rdfs:label "TopologicalConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Correctness of the explicitly encoded topological characteristics of the data set as described by the scope"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Topological Consistency"@en ;
 .
 dq-iso-19157:UsabilityElement
   a dqv:Dimension ; a skos:Concept ;
   rdfs:label "UsabilityElement"@en ;
   skos:definition "Degree of adherence of a data set to a specific set of requirements"@en ;
-  skos:inScheme dq-iso-19157:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:compliance ;
   skos:prefLabel "Usability Element"@en ;
 .

--- a/vocabularies/dq-iso-19157.ttl
+++ b/vocabularies/dq-iso-19157.ttl
@@ -19,7 +19,7 @@
   skos:prefLabel "Dimensions of data quailty (ISO 19157)"@en ;
   dcterms:created "2020-11-16"^^xsd:date ;
   dcterms:creator <http://linked.data.gov.au/org/des> ;
-dcterms:modified "2021-01-06"^^xsd:date ;
+dcterms:modified "2021-01-19"^^xsd:date ;
 dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
 
   skos:hasTopConcept dq-iso-19157:Completeness ;

--- a/vocabularies/dq-iso-25012.ttl
+++ b/vocabularies/dq-iso-25012.ttl
@@ -18,7 +18,7 @@
   skos:prefLabel "Dimensions of data quality (ISO 25012)"@en ;
   dcterms:created "2020-11-16"^^xsd:date ;
 dcterms:creator <http://linked.data.gov.au/def/gsq-alias/des> ;
-dcterms:modified "2021-01-06"^^xsd:date ;
+dcterms:modified "2021-01-19"^^xsd:date ;
 dcterms:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
   skos:hasTopConcept dq-iso-25012:inherentDataQuality ;
   skos:hasTopConcept dq-iso-25012:inherentSystemDependentDataQuality ;

--- a/vocabularies/dq-iso-25012.ttl
+++ b/vocabularies/dq-iso-25012.ttl
@@ -12,7 +12,7 @@
 @prefix sdo: <http://www.schema.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dq-iso-25012:Dimensions
+<http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions>
   a skos:ConceptScheme ;
   rdfs:label "Dimensions of data quality (ISO 25012)"@en ;
   skos:prefLabel "Dimensions of data quality (ISO 25012)"@en ;
@@ -29,7 +29,7 @@ dq-iso-25012:accessibility
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Accessibility (ISO25012)"@en ;
   skos:definition "The degree to which data can be accessed in a specific context of use, particularly by people who need supporting technology or special configuration because of some disability."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Accessibility (ISO25012)"@en ;
   dqv:inCategory dq-iso-25012:inherentSystemDependentDataQuality ;
   skos:broader dq-iso-25012:inherentSystemDependentDataQuality ;
@@ -39,7 +39,7 @@ dq-iso-25012:accuracy
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Accuracy (ISO25012)"@en ;
   skos:definition "The degree to which data has attributes that correctly represent the true value of the intended attribute of a concept or event in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Accuracy (ISO25012)"@en ;
   skos:closeMatch dq-iso-19157:PositionalAccuracy ;
   skos:closeMatch dq-iso-19157:ThematicAccuracy ;
@@ -51,7 +51,7 @@ dq-iso-25012:availability
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Availability"@en ;
   skos:definition "The degree to which data has attributes that enable it to be retrieved by authorized users and/or applications in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Availability"@en ;
   dqv:inCategory dq-iso-25012:systemDependentDataQuality ;
   skos:broader dq-iso-25012:systemDependentDataQuality ;
@@ -61,7 +61,7 @@ dq-iso-25012:completeness
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Completeness (ISO25012)"@en ;
   skos:definition "The degree to which subject data associated with an entity has values for all expected attributes and related entity instances in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Completeness (ISO25012)"@en ;
   skos:closeMatch dq-iso-19157:completeness ;
   skos:exactMatch dq-iso-19157:CompletenessOmission ;
@@ -73,7 +73,7 @@ dq-iso-25012:compliance
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Compliance"@en ;
   skos:definition "The degree to which data has attributes that adhere to standards, conventions or regulations in force and similar rules relating to data quality in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Compliance"@en ;
   skos:closeMatch dq-iso-19157:UsabilityElement ;
   dqv:inCategory dq-iso-25012:inherentSystemDependentDataQuality ;
@@ -84,7 +84,7 @@ dq-iso-25012:confidentiality
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Confidentiality"@en ;
   skos:definition "The degree to which data has attributes that ensure that it is only accessible and interpretable by authorized users in a specific context of use. Confidentiality is an aspect of information security (together with availability, integrity) as defined in ISO/IEC 13335-1:2004."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Confidentiality"@en ;
   dqv:inCategory dq-iso-25012:inherentSystemDependentDataQuality ;
   skos:broader dq-iso-25012:inherentSystemDependentDataQuality ;
@@ -94,7 +94,7 @@ dq-iso-25012:consistency
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Consistency"@en ;
   skos:definition "The degree to which data has attributes that are free from contradiction and are coherent with other data in a specific context of use. It can be either or both among data regarding one entity and across similar data for comparable entities."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Consistency"@en ;
   skos:closeMatch dq-iso-19157:LogicalConsistency ;
   dqv:inCategory dq-iso-25012:inherentDataQuality ;
@@ -105,7 +105,7 @@ dq-iso-25012:credibility
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Credibility"@en ;
   skos:definition "The degree to which data has attributes that are regarded as true and believable by users in a specific context of use. Credibility includes the concept of authenticity (the truthfulness of origins, attributions, commitments)."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Credibility"@en ;
   dqv:inCategory dq-iso-25012:inherentDataQuality ;
   skos:broader dq-iso-25012:inherentDataQuality ;
@@ -115,7 +115,7 @@ dq-iso-25012:currentness
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Currentness"@en ;
   skos:definition "The degree to which data has attributes that are of the right age in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Currentness"@en ;
   dqv:inCategory dq-iso-25012:inherentDataQuality ;
   skos:broader dq-iso-25012:inherentDataQuality ;
@@ -125,7 +125,7 @@ dq-iso-25012:efficiency
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Efficiency"@en ;
   skos:definition "The degree to which data has attributes that can be processed and provide the expected levels of performance by using the appropriate amounts and types of resources in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Efficiency"@en ;
   dqv:inCategory dq-iso-25012:inherentSystemDependentDataQuality ;
   skos:broader dq-iso-25012:inherentSystemDependentDataQuality ;
@@ -136,7 +136,7 @@ dq-iso-25012:inherentDataQuality
   skos:definition "Inherent data quality refers to the degree to which quality characteristics of data have the intrinsic potential to satisfy stated and implied needs when data is used under specified conditions."@en ;
   rdfs:label "Inherent data quality"@en ;
   skos:prefLabel "Inherent data quality"@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
 .
 dq-iso-25012:inherentSystemDependentDataQuality
   a dqv:Category ; a skos:Concept ;
@@ -145,7 +145,7 @@ dq-iso-25012:inherentSystemDependentDataQuality
   skos:related dq-iso-25012:inherentDataQuality ;
   skos:related dq-iso-25012:systemDependentDataQuality ;
   skos:definition "Data quality that is both in the inherent and system-dependent quality categories, inherent referes to the degree to which data has the intrinsic potential to satisfy needs and system-dependent is about the quality which is preserved by the system it is contained within."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Inherent and System-Dependent Data Quality"@en ;
 .
 dq-iso-25012:portability
@@ -153,7 +153,7 @@ dq-iso-25012:portability
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Portability"@en ;
   skos:definition "The degree to which data has attributes that enable it to be installed, replaced or moved from one system to another preserving the existing quality in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Portability"@en ;
   dqv:inCategory dq-iso-25012:systemDependentDataQuality ;
   skos:broader dq-iso-25012:systemDependentDataQuality ;
@@ -163,7 +163,7 @@ dq-iso-25012:precision
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Precision"@en ;
   skos:definition "The degree to which data has attributes that are exact or that provide discrimination in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Precision"@en ;
   skos:closeMatch dq-iso-19157:ThematicAccuracy ;
   dqv:inCategory dq-iso-25012:inherentSystemDependentDataQuality ;
@@ -174,7 +174,7 @@ dq-iso-25012:recoverability
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Recoverability"@en ;
   skos:definition "The degree to which data has attributes that enable it to maintain and preserve a specified level of operations and quality, even in the event of failure, in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Recoverability"@en ;
   dqv:inCategory dq-iso-25012:systemDependentDataQuality ;
   skos:broader dq-iso-25012:systemDependentDataQuality ;
@@ -184,7 +184,7 @@ dq-iso-25012:systemDependentDataQuality
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   skos:definition "System dependent data quality refers to the degree to which data quality is reached and preserved within a computer system when data is used under specified conditions."@en ;
   rdfs:label "System-dependent data quality"@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "System-Dependent Data Quality"@en ;
 .
 dq-iso-25012:traceability
@@ -192,7 +192,7 @@ dq-iso-25012:traceability
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Traceability"@en ;
   skos:definition "The degree to which data has attributes that provide an audit trail of access to the data and of any changes made to the data in a specific context of use."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Traceability"@en ;
   dqv:inCategory dq-iso-25012:inherentSystemDependentDataQuality ;
   skos:broader dq-iso-25012:inherentSystemDependentDataQuality ;
@@ -202,7 +202,7 @@ dq-iso-25012:understandability
   dcterms:source <https://www.w3.org/TR/vocab-dqv/#DimentsionsMetricsHints> ;
   rdfs:label "Understandability"@en ;
   skos:definition "The degree to which data has attributes that enable it to be read and interpreted by users, and are expressed in appropriate languages, symbols and units in a specific context of use. Some information about data understandability are provided by metadata."@en ;
-  skos:inScheme dq-iso-25012:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-IEC-25012/quality-dimension/Dimensions> ;
   skos:prefLabel "Understandability"@en ;
   dqv:inCategory dq-iso-25012:inherentSystemDependentDataQuality ;
   skos:broader dq-iso-25012:inherentSystemDependentDataQuality ;

--- a/vocabularies/dq-nsw-data-quality-assessment.ttl
+++ b/vocabularies/dq-nsw-data-quality-assessment.ttl
@@ -11,7 +11,7 @@
 @prefix sdo: <http://www.schema.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dq-nsw:Dimensions
+<http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions>
   a skos:ConceptScheme ;
   rdfs:comment "Find out more about the quality assurance processes from the NSW Government Standard for Data Quality Reporting. https://data.nsw.gov.au/data-quality-reporting-tool"@en ;
   rdfs:label "NSW Government Standard for Data Quality Reporting"@en ;
@@ -32,21 +32,21 @@ dq-nsw:accessibility
   rdfs:label "ACCESSIBILITY"@en ;
   skos:prefLabel "Accessibility"@en ;
   skos:definition "A dimension of quality relating to the ease with which data or information can be retrieved, used and understood."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
 .
 dq-nsw:accuracy
   a dqv:Category ; a skos:Concept ;
   rdfs:label "ACCURACY"@en ;
   skos:prefLabel "Accuracy"@en ;
   skos:definition "A dimension of quality relating to the degree to which the data or information correctly describes that which it was designed to measure."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
 .
 dq-nsw:assurance
   a dqv:Dimension ; a skos:Concept ;
   rdfs:label "Data assurance"@en ;
   skos:prefLabel "Data assurance"@en ;
   skos:definition "This data has been subject to quality assurance processes. ie Checking for errors at each stage of data collection and processing, or verifying data entry and making corrections if necessary."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accuracy ;
   skos:broader dq-nsw:accuracy ;
 .
@@ -55,7 +55,7 @@ dq-nsw:authorized
   rdfs:label "Authorized data collection"@en ;
   skos:prefLabel "Authorized data collection"@en ;
   skos:definition "Data collection is mandated or required by a law, regulation or agreement"@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:institutional-environment ;
   skos:broader dq-nsw:institutional-environment ;
 .
@@ -64,14 +64,14 @@ dq-nsw:coherence
   rdfs:label "COHERENCE"@en ;
   skos:prefLabel "Coherence"@en ;
   skos:definition "A dimension of quality relating to the degree to which data or information can be compared with itself and other information over time."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
 .
 dq-nsw:comparable
   a dqv:Dimension ; a skos:Concept ;
   rdfs:label "Elements can be compared"@en ;
   skos:prefLabel "Elements can be compared"@en ;
   skos:definition "Elements within the data can be meaningfully compared."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:coherence ;
   skos:broader dq-nsw:coherence ;
 .
@@ -80,7 +80,7 @@ dq-nsw:complete
   rdfs:label "Data complete"@en ;
   skos:prefLabel "Data complete"@en ;
   skos:definition "There are no known gaps in the data. (For example: non-responses, missing records, data not collected.). Or gaps are identified in caveats attached to the dataset or data source."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accuracy ;
   skos:broader dq-nsw:accuracy ;
 .
@@ -90,7 +90,7 @@ dq-nsw:concepts
   rdfs:label "Concept explanations"@en ;
   skos:prefLabel "Concept explanations"@en ;
   skos:definition "Information is available to explain concepts, help users correctly interpret the data and understand how it can be used."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:interpretability ;
   skos:broader dq-nsw:interpretability ;
 .
@@ -99,7 +99,7 @@ dq-nsw:consistent
   rdfs:label "Consistent with related datasets"@en ;
   skos:prefLabel "Consistent with related datasets"@en ;
   skos:definition "This data is generally consistent with similar or related data sources."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:coherence ;
   skos:broader dq-nsw:coherence ;
 .
@@ -109,7 +109,7 @@ dq-nsw:data-dictionary
   rdfs:label "Data dictionary provided"@en ;
   skos:prefLabel "Data dictionary provided"@en ;
   skos:definition "A data dictionary is available to explain the meaning of data elements, their origin, format and relationships."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:interpretability ;
   skos:broader dq-nsw:interpretability ;
 .
@@ -118,7 +118,7 @@ dq-nsw:data-quality-framework
   rdfs:label "Data quality framework"@en ;
   skos:prefLabel "Data quality framework"@en ;
   skos:definition "Data is collected and managed according to a data quality framework."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:institutional-environment ;
   skos:broader dq-nsw:institutional-environment ;
 .
@@ -127,7 +127,7 @@ dq-nsw:custodian
   rdfs:label "Custodian"@en ;
   skos:prefLabel "Custodian"@en ;
   skos:definition "Agency publishing this data is the recognised data custodian."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:institutional-environment ;
   skos:broader dq-nsw:institutional-environment ;
 .
@@ -136,7 +136,7 @@ dq-nsw:evaluation
   rdfs:label "Accuracy evaluation"@en ;
   skos:prefLabel "Accuracy evaluation"@en ;
   skos:definition "Information is available to help users evaluate the accuracy of the data and any level of error."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:interpretability ;
   skos:broader dq-nsw:interpretability ;
 .
@@ -145,7 +145,7 @@ dq-nsw:governance
   rdfs:label "governance roles"@en ;
   skos:prefLabel "governance roles"@en ;
   skos:definition "Data governance roles and responsibilities are clearly assigned for this dataset or data source."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:institutional-environment ;
   skos:broader dq-nsw:institutional-environment ;
 .
@@ -154,21 +154,21 @@ dq-nsw:institutional-environment
   rdfs:label "INSTITUTIONAL ENVIRONMENT"@en ;
   skos:prefLabel "Institutional Environment"@en ;
   skos:definition "A dimension of quality relating to the institutional and organisational factors which may have a significant influence on the effectiveness and credibility of the agency producing the data or information."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
 .
 dq-nsw:interpretability
   a dqv:Category ; a skos:Concept ;
   rdfs:label "INTERPRETABILITY"@en ;
   skos:prefLabel "Interpretability"@en ;
   skos:definition "A dimension of quality relating to the degree to which data or information can be understood, explained and used."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
 .
 dq-nsw:license
   a dqv:Dimension ; a skos:Concept ;
   rdfs:label "Open license"@en ;
   skos:prefLabel "Open license"@en ;
   skos:definition "This dataset or data source is available online with an open licence."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accessibility ;
   skos:broader dq-nsw:accessibility ;
 .
@@ -177,7 +177,7 @@ dq-nsw:linked
   rdfs:label "Links to data and context"@en ;
   skos:prefLabel "Links to data and context"@en ;
   skos:definition "This dataset or data source is linked to other data, to provide context."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accessibility ;
   skos:broader dq-nsw:accessibility ;
 .
@@ -186,7 +186,7 @@ dq-nsw:methodology
   rdfs:label "Consistent methodology"@en ;
   skos:prefLabel "Consistent methodology"@en ;
   skos:definition "This dataset is a single collection. It is not impacted by changes in methodology or external events over time. Or this data is part of a time series. There have not been any significant changes in the way data items are defined, classified or counted since the start of the series."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:coherence ;
   skos:broader dq-nsw:coherence ;
 .
@@ -195,7 +195,7 @@ dq-nsw:no-changes
   rdfs:label "No changes or flaws not explained"@en ;
   skos:prefLabel "No changes or flaws not explained"@en ;
   skos:definition "There have been no adjustments, changes or other factors that could impact the validity of the data. (For example: weighting, rounding, de-identification of data; changes or flaws in data collection or verification methods.). Or adjustments are identified in caveats attached to the dataset or data source"@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accuracy ;
   skos:broader dq-nsw:accuracy ;
 .
@@ -204,7 +204,7 @@ dq-nsw:no-conflict
   rdfs:label "No commercial interest or conflict"@en ;
   skos:prefLabel "No commercial interest or conflict"@en ;
   skos:definition "Custodian has no commercial interest or conflict of interest in the data – or, has declared any interest in the data."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:institutional-environment ;
   skos:broader dq-nsw:institutional-environment ;
 .
@@ -213,7 +213,7 @@ dq-nsw:non-proprietary
   rdfs:label "Non-proprietary format"@en ;
   skos:prefLabel "Non-proprietary format"@en ;
   skos:definition "This dataset or data source is available in a non-proprietary format."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accessibility ;
   skos:broader dq-nsw:accessibility ;
 .
@@ -222,7 +222,7 @@ dq-nsw:open-standards
   rdfs:label "Open standards"@en ;
   skos:prefLabel "Open standards"@en ;
   skos:definition "This dataset or data source is described using open standards and persistent identifiers."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accessibility ;
   skos:broader dq-nsw:accessibility ;
 .
@@ -231,7 +231,7 @@ dq-nsw:primary-user
   rdfs:label "Data met needs of primary user"@en ;
   skos:prefLabel "Data met needs of primary user"@en ;
   skos:definition "The data collection met the objectives of the primary user. The data correctly represents what it was designed to measure, monitor or report."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accuracy ;
   skos:broader dq-nsw:accuracy ;
 .
@@ -240,7 +240,7 @@ dq-nsw:revised
   rdfs:label "Revised when errors detected"@en ;
   skos:prefLabel "Revised when errors detected"@en ;
   skos:definition "Revision policy: If errors are identified, data is revised and the revision is publicised."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accuracy ;
   skos:broader dq-nsw:accuracy ;
 .
@@ -250,7 +250,7 @@ dq-nsw:sources
   rdfs:label "Data sources and methods"@en ;
   skos:prefLabel "Data sources and methods"@en ;
   skos:definition "Information is available about the primary data sources and methods of data collection. (For example: instruments, forms, instructions.)"@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:interpretability ;
   skos:broader dq-nsw:interpretability ;
 .
@@ -259,7 +259,7 @@ dq-nsw:standards
   rdfs:label "Standard definitions and practices"@en ;
   skos:prefLabel "Standard definitions and practices"@en ;
   skos:definition "Standard definitions, common concepts, classifications and data recording practices have been used."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:coherence ;
   skos:broader dq-nsw:coherence ;
 .
@@ -268,7 +268,7 @@ dq-nsw:structured
   rdfs:label "Structured data"@en ;
   skos:prefLabel "Structured data"@en ;
   skos:definition "This dataset or data source is available in a machine-processable, structured format."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:accessibility ;
   skos:broader dq-nsw:accessibility ;
 .
@@ -278,7 +278,7 @@ dq-nsw:technical
   rdfs:label "Technical explanations"@en ;
   skos:prefLabel "Technical explanations"@en ;
   skos:definition "Information is available to explain ambiguous or technical terms used in the data."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:interpretability ;
   skos:broader dq-nsw:interpretability ;
 .
@@ -287,7 +287,7 @@ dq-nsw:time
   rdfs:label "Consistent over time"@en ;
   skos:prefLabel "Consistent over time"@en ;
   skos:definition "This data is part of a time series. It is consistent with previous releases. There have been no changes in methodology or external impacts since the last data release."@en ;
-  skos:inScheme dq-nsw:Dimensions ;
+  skos:inScheme <http://linked.data.gov.au/def/NSW-Data/quality-dimension/Dimensions> ;
   dqv:inCategory dq-nsw:coherence ;
   skos:broader dq-nsw:coherence ;
 .

--- a/vocabularies/dq-nsw-data-quality-assessment.ttl
+++ b/vocabularies/dq-nsw-data-quality-assessment.ttl
@@ -19,7 +19,7 @@
   rdfs:seeAlso <https://data.nsw.gov.au/data-quality-reporting-tool> ;
   dcterms:created "2020-11-16"^^xsd:date ;
 dcterms:creator <http://linked.data.gov.au/def/gsq-alias/des> ;
-dcterms:modified "2021-01-06"^^xsd:date ;
+dcterms:modified "2021-01-19"^^xsd:date ;
 dcterms:publisher <http://linked.data.gov.au/def/gsq-alias/des> ;
   skos:hasTopConcept dq-nsw:accessibility ;
   skos:hasTopConcept dq-nsw:accuracy ;


### PR DESCRIPTION
Added explicit inScheme items for the 3 data quality vocabularies. Items were there, but included the full URL.