### PR TITLE
Update dq-iso-19157.ttl

### DIFF
--- a/vocabularies/dq-iso-19157.ttl
+++ b/vocabularies/dq-iso-19157.ttl
@@ -16,7 +16,7 @@
   a skos:ConceptScheme ;
   dcterms:source "ISO 19157"@en ;
   rdfs:label "ISO19157 Data Quality Dimensions"@en ;
-  skos:prefLabel "Dimensions of data quality (ISO 19157)"@en ;
+  skos:prefLabel "ISO19157 Data Quality Dimensions"@en ;
   dcterms:created "2020-11-16"^^xsd:date ;
   dcterms:creator <http://linked.data.gov.au/org/des> ;
 dcterms:modified "2021-01-28"^^xsd:date ;

--- a/vocabularies/dq-iso-19157.ttl
+++ b/vocabularies/dq-iso-19157.ttl
@@ -15,11 +15,11 @@
 <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions>
   a skos:ConceptScheme ;
   dcterms:source "ISO 19157"@en ;
-  rdfs:label "Dimensions of data quailty (ISO 19157)"@en ;
-  skos:prefLabel "Dimensions of data quailty (ISO 19157)"@en ;
+  rdfs:label "Dimensions of data quality (ISO 19157)"@en ;
+  skos:prefLabel "Dimensions of data quality (ISO 19157)"@en ;
   dcterms:created "2020-11-16"^^xsd:date ;
   dcterms:creator <http://linked.data.gov.au/org/des> ;
-dcterms:modified "2021-01-19"^^xsd:date ;
+dcterms:modified "2021-01-28"^^xsd:date ;
 dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
 
   skos:hasTopConcept dq-iso-19157:Completeness ;

--- a/vocabularies/dq-iso-19157.ttl
+++ b/vocabularies/dq-iso-19157.ttl
@@ -15,7 +15,7 @@
 <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions>
   a skos:ConceptScheme ;
   dcterms:source "ISO 19157"@en ;
-  rdfs:label "Dimensions of data quality (ISO 19157)"@en ;
+  rdfs:label "ISO19157 Data Quality Dimensions"@en ;
   skos:prefLabel "Dimensions of data quality (ISO 19157)"@en ;
   dcterms:created "2020-11-16"^^xsd:date ;
   dcterms:creator <http://linked.data.gov.au/org/des> ;

--- a/vocabularies/dq-iso-19157.ttl
+++ b/vocabularies/dq-iso-19157.ttl
@@ -19,8 +19,8 @@
   skos:prefLabel "ISO19157 Data Quality Dimensions"@en ;
   dcterms:created "2020-11-16"^^xsd:date ;
   dcterms:creator <http://linked.data.gov.au/org/des> ;
-dcterms:modified "2021-01-28"^^xsd:date ;
-dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
+dcterms:modified "2021-02-09"^^xsd:date ;
+dcterms:publisher <http://linked.data.gov.au/org/des> ;
 
   skos:hasTopConcept dq-iso-19157:Completeness ;
   skos:hasTopConcept dq-iso-19157:LogicalConsistency ;
@@ -33,7 +33,6 @@ dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
 dq-iso-19157:AbsoluteExternalPositionalAccuracy
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "AbsoluteExternalPositionalAccuracy"@en ;
   skos:broader dq-iso-19157:PositionalAccuracy ;
   skos:definition "Closeness of reported coordinate values to values accepted as or being true"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -42,7 +41,6 @@ dq-iso-19157:AbsoluteExternalPositionalAccuracy
 dq-iso-19157:AccuracyOfATimeMeasurement
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "AccuracyOfATimeMeasurement"@en ;
   skos:broader dq-iso-19157:TemporalQuality ;
   skos:definition "Correctness of the temporal references of an item (reporting of error in time measurement)"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -51,7 +49,6 @@ dq-iso-19157:AccuracyOfATimeMeasurement
 dq-iso-19157:Completeness
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "Completeness (ISO19157)"@en ;
   skos:definition "Presence and absence of features, their attributes and their relationships"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:completeness ;
@@ -60,7 +57,6 @@ dq-iso-19157:Completeness
 dq-iso-19157:CompletenessCommission
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "CompletenessCommission"@en ;
   skos:broader dq-iso-19157:Completeness ;
   skos:definition "Excess data present in the data set, as described by the scope"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -69,7 +65,6 @@ dq-iso-19157:CompletenessCommission
 dq-iso-19157:CompletenessOmission
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "CompletenessOmission"@en ;
   skos:broader dq-iso-19157:Completeness ;
   skos:definition "Data absent from the data set, as described by the scope"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -79,7 +74,6 @@ dq-iso-19157:CompletenessOmission
 dq-iso-19157:ConceptualConsistency
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "ConceptualConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Adherence to rules of the conceptual schema"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -88,7 +82,6 @@ dq-iso-19157:ConceptualConsistency
 dq-iso-19157:DomainConsistency
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "DomainConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Adherence of values to the value domains"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -97,7 +90,6 @@ dq-iso-19157:DomainConsistency
 dq-iso-19157:FormatConsistency
   a dqv:Dimension ;
   a skos:Concept ;
-  rdfs:label "FormatConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Degree to which data are stored in accordance with the physical structure of the data set, as described by the scope"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -106,7 +98,6 @@ dq-iso-19157:FormatConsistency
 dq-iso-19157:GriddedDataPositionalAccuracy
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "GriddedDataPositionalAccuracy"@en ;
   skos:broader dq-iso-19157:PositionalAccuracy ;
   skos:definition "Closeness of gridded data position values to values accepted as or being true"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ; 
@@ -115,7 +106,6 @@ dq-iso-19157:GriddedDataPositionalAccuracy
 dq-iso-19157:LogicalConsistency
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "LogicalConsistency"@en ;
   skos:definition "Degree of adherence to logical rules of data structure, attribution and relationships (data structure can be conceptual, logical or physical)"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:consistency ;
@@ -124,7 +114,6 @@ dq-iso-19157:LogicalConsistency
 dq-iso-19157:Metaquality
   a dqv:Dimension ; 
   a skos:Concept ;
-  rdfs:label "Metaquality"@en ;
   skos:definition "Information about the reliability of data quality results Use obligation from referencing object"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:prefLabel "Metaquality"@en .
@@ -132,7 +121,6 @@ dq-iso-19157:Metaquality
 dq-iso-19157:NonQuantitativeAttributeCorrectness
   a dqv:Dimension ;
    a skos:Concept ;
-  rdfs:label "NonQuantitativeAttributeCorrectness"@en ;
   skos:broader dq-iso-19157:ThematicAccuracy ;
   skos:definition "Correctness of non-quantitative attributes"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -141,7 +129,6 @@ dq-iso-19157:NonQuantitativeAttributeCorrectness
 dq-iso-19157:PositionalAccuracy
   a dqv:Dimension ;
   a skos:Concept ;
-  rdfs:label "PositionalAccuracy"@en ;
   skos:definition "Accuracy of the position of features"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:accuracy ;
@@ -149,7 +136,6 @@ dq-iso-19157:PositionalAccuracy
 
 dq-iso-19157:QuantitativeAttributeAccuracy
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "QuantitativeAttributeAccuracy"@en ;
   skos:broader dq-iso-19157:ThematicAccuracy ;
   skos:definition "Accuracy of quantitative attributes"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
@@ -157,65 +143,78 @@ dq-iso-19157:QuantitativeAttributeAccuracy
 .
 dq-iso-19157:RelativeInternalPositionalAccuracy
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "RelativeInternalPositionalAccuracy"@en ;
   skos:broader dq-iso-19157:PositionalAccuracy ;
   skos:definition "Closeness of the relative positions of features in the scope to their respective relative positions accepted as or being true"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
-  skos:prefLabel "Relative Internal Positional Accuracy"@en ;
-.
+  skos:prefLabel "Relative Internal Positional Accuracy"@en .
+
 dq-iso-19157:TemporalConsistency
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "TemporalConsistency"@en ;
   skos:broader dq-iso-19157:TemporalQuality ;
   skos:definition "Correctness of ordered events or sequences, if reported"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
-  skos:prefLabel "Temporal Consistency"@en ;
-.
+  skos:prefLabel "Temporal Consistency"@en .
+
 dq-iso-19157:TemporalQuality
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "TemporalQuality"@en ;
   skos:definition "Accuracy of the temporal attributes and temporal relationships of features"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
-  skos:prefLabel "Temporal Quality"@en ;
-.
+  skos:prefLabel "Temporal Quality"@en .
+
 dq-iso-19157:TemporalValidity
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "TemporalValidity"@en ;
   skos:broader dq-iso-19157:TemporalQuality ;
   skos:definition "Validity of data specified by the scope with respect to time"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
-  skos:prefLabel "Temporal Validity"@en ;
-.
+  skos:prefLabel "Temporal Validity"@en .
+
 dq-iso-19157:ThematicAccuracy
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "ThematicAccuracy"@en ;
   skos:definition "Accuracy of quantitative attributes and the correctness of non-quantitative attributes and of the classifications of features and their relationships"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:accuracy ;
   skos:relatedMatch dq-iso-25012:precision ;
-  skos:prefLabel "Thematic Accuracy"@en ;
-.
+  skos:prefLabel "Thematic Accuracy"@en .
+
 dq-iso-19157:ThematicClassificationCorrectness
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "ThematicClassificationCorrectness"@en ;
   skos:broader dq-iso-19157:ThematicAccuracy ;
   skos:definition "Comparison of the classes assigned to features or their attributes to a universe of discourse"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
-  skos:prefLabel "Thematic Classification Correctness"@en ;
-.
+  skos:prefLabel "Thematic Classification Correctness"@en .
+
 dq-iso-19157:TopologicalConsistency
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "TopologicalConsistency"@en ;
   skos:broader dq-iso-19157:LogicalConsistency ;
   skos:definition "Correctness of the explicitly encoded topological characteristics of the data set as described by the scope"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
-  skos:prefLabel "Topological Consistency"@en ;
-.
+  skos:prefLabel "Topological Consistency"@en .
+
 dq-iso-19157:UsabilityElement
   a dqv:Dimension ; a skos:Concept ;
-  rdfs:label "UsabilityElement"@en ;
   skos:definition "Degree of adherence of a data set to a specific set of requirements"@en ;
   skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
   skos:closeMatch dq-iso-25012:compliance ;
-  skos:prefLabel "Usability Element"@en ;
-.
+  skos:prefLabel "Usability Element"@en .
+
+dq-iso-19157:Confidence
+  a dqv:Dimension ;   a skos:Concept ;
+  skos:broader dq-iso-19157:Metaquality ;
+  skos:definition "Trustworthiness of a data quality result "@en ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
+  skos:prefLabel "Confidence"@en .
+
+dq-iso-19157:Homogeneity
+  a dqv:Dimension ;   a skos:Concept ;
+  skos:broader dq-iso-19157:Metaquality ;
+  skos:definition "Expected or tested uniformity of the results obtained for a data quality evaluation"@en ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
+  skos:prefLabel "Homogeneity"@en .
+
+dq-iso-19157:Representativity 
+  a dqv:Dimension ;   a skos:Concept ;
+  skos:broader dq-iso-19157:Metaquality ;
+  skos:definition "Degree to which the sample used has produced a result which is representative of the data within the data quality scope "@en ;
+  skos:inScheme <http://linked.data.gov.au/def/ISO-19157/quality-dimension/Dimensions> ;
+  skos:prefLabel "Representativity "@en .
+


### PR DESCRIPTION
Vocprez is showing an "invalid vocab id' for the Dimensions of Data Quality vocab.  
Found a spelling error in the rdfs and skos labels. 

Wondering if this is the cause of the issue.