### PR TITLE
fixing 2.5.8 deployment errors

### DIFF
--- a/vocabularies/geological-observation-instrument.ttl
+++ b/vocabularies/geological-observation-instrument.ttl
@@ -461,7 +461,7 @@ obsin:electromagnetic a skos:Collection ;
         obsin:geotem-3,
         obsin:helitem,
         obsin:helitem-other,
-        obsin:helitem3,
+        obsin:helitem30,
         obsin:hoistem,
         obsin:questem,
         obsin:reptem,

--- a/vocabularies/georesources-report-types.ttl
+++ b/vocabularies/georesources-report-types.ttl
@@ -135,6 +135,15 @@ grt:article a skos:Concept ;
     skos:prefLabel "Article"@en ;
     skos:topConceptOf <https://linked.data.gov.au/def/georesource-report> .
 
+grt:collaborative-drilling-initiative-proposals a skos:Concept ;
+    skos:altLabel "Collaborative Drilling Initiative - Proposals"@en ;
+    skos:definition "A propsal detailing the activities and results of a project that received support from the Collaborative Drilling Initiative. The details of which have been defined as a part of the terms and conditions of that initiative."@en ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/georesource-report> ;
+    skos:inScheme <https://linked.data.gov.au/def/georesource-report> ;
+    skos:notation "CDIPRO" ;
+    skos:prefLabel "Collaborative Drilling Initiative - Proposals"@en ;
+    skos:topConceptOf <https://linked.data.gov.au/def/georesource-report> .
+
 grt:collaborative-drilling-initiative-final a skos:Concept ;
     skos:altLabel "Collaborative Drilling Initiative - Final (Completed)"@en ;
     skos:definition "A report detailing the activities and results of a project that received support from the Collaborative Drilling Initiative. The details of which have been defined as a part of the terms and conditions of that initiative."@en ;


### PR DESCRIPTION
This PR fixes issues with the VorPrez display of two Collections:

1. <https://linked.data.gov.au/def/geological-observation-instrument/electromagnetic>
2. <https://linked.data.gov.au/def/georesource-report/exploration-grants>