### PR TITLE
Fix qg-data-licenses URI errors

### DIFF
--- a/vocabularies/qg-data-licenses.ttl
+++ b/vocabularies/qg-data-licenses.ttl
@@ -14,11 +14,11 @@
         skos:definition "Licenses for use of software, data, documents and other resources within Queensland Government"@en ;
         dcterms:created "2020-12-02"^^xsd:date ;
         dcterms:creator <https://linked.data.gov.au/org/des> ;
-        dcterms:modified "2021-03-03"^^xsd:date ;
+        dcterms:modified "2021-06-30"^^xsd:date ;
         dcterms:publisher <https://linked.data.gov.au/org/des> ;
         dcterms:provenance "Vocabulary built from original sourced from http://registry.it.csiro.au/_licence." .
 
-<https://linked.data.gov.au/def/licence-document/cc-by-nd-4.0>
+<https://linked.data.gov.au/def/qld-data-licenses/cc-by-nd-4.0>
         a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/qld-data-licenses> ;
         skos:inScheme <https://linked.data.gov.au/def/qld-data-licenses> ;
@@ -27,7 +27,7 @@
         skos:prefLabel        "Creative Commons Attribution-NoDerivatives 4.0 International"@en ;
         skos:definition       """You are free to: Share - copy and redistribute the material in any medium or format for any purpose, even commercially. The licensor cannot revoke these freedoms as long as you follow the licence terms. Under the following terms: Attribution - You must give appropriate credit, provide a link to the licence, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use. NoDerivatives - If you remix, transform, or build upon the material, you may not distribute the modified material. No additional restrictions - You may not apply legal terms or technological measures that legally restrict others from doing anything the licence permits Notices - You do not have to comply with the licence for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation. No warranties are given. The licence may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material."""@en .
        
-<https://linked.data.gov.au/def/licence-document/cc-by-4.0>
+<https://linked.data.gov.au/def/qld-data-licenses/cc-by-4.0>
         a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/qld-data-licenses> ;
         skos:inScheme <https://linked.data.gov.au/def/qld-data-licenses> ;
@@ -36,7 +36,7 @@
         skos:prefLabel        "Creative Commons Attribution 4.0 International"@en ;
         skos:definition       """You are free to: Share - copy and redistribute the material in any medium or format Adapt - remix, transform, and build upon the material for any purpose, even commercially. The licensor cannot revoke these freedoms as long as you follow the licence terms. Under the following terms: Attribution - You must give appropriate credit, provide a link to the licence, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use. No additional restrictions - You may not apply legal terms or technological measures that legally restrict others from doing anything the licence permits. Notices - You do not have to comply with the licence for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation. No warranties are given. The licence may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material."""@en .
        
-<https://linked.data.gov.au/def/licence-document/cc-by-sa-4.0>
+<https://linked.data.gov.au/def/qld-data-licenses/cc-by-sa-4.0>
         a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/qld-data-licenses> ;
         skos:inScheme <https://linked.data.gov.au/def/qld-data-licenses> ;


### PR DESCRIPTION
Changes to the URIs were not completed properly in migrating the schema name.

Simple find and replace done.
