### PR TITLE
Update observation-detail-type.ttl

### DIFF
--- a/uat-vocabularies/observation-detail-type.ttl
+++ b/uat-vocabularies/observation-detail-type.ttl
@@ -10,12 +10,14 @@
         skos:ConceptScheme ;
     dcterms:created "2020-03-30"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2022-01-04"^^xsd:date ;
+    dcterms:modified "2022-02-04"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:provenance "Compiled by the Geological Survey of Queensland" ;
     skos:definition "Miscellaneous details that describe samples that are outside the common core observation profile."@en ;
     skos:prefLabel "Observation Detail Type"@en ;
     skos:hasTopConcept obsdt:blended,
+        obsdt:software,
+        obsdt:processing-date,
         obsdt:reading-interval-hz,
         obsdt:reading-interval-m,
         obsdt:survey-configuration .
@@ -40,6 +42,21 @@ obsdt:reading-interval-m a skos:Concept ;
     skos:definition "Distance between readings or observations in metres"@en ;
     skos:inScheme <http://linked.data.gov.au/def/observation-detail-type> ;
     skos:prefLabel "Reading Interval (m)"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/observation-detail-type> .
+
+obsdt:processing-date a skos:Concept ;
+    skos:altLabel "Processing End Date"@en ;
+    skos:definition "The date, or effective date, of any processing performed on the observed data. The date that processing was completed."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/observation-detail-type> ;
+    skos:prefLabel "Processing Date"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/observation-detail-type> .
+
+obsdt:software a skos:Concept ;
+    skos:altLabel "Firmware"@en,
+        "Software Version"@en ;
+    skos:definition "The software or firmware used by the instrument for acquisition, or the software used for data processing."@en ;
+    skos:inScheme <http://linked.data.gov.au/def/observation-detail-type> ;
+    skos:prefLabel "Software"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/observation-detail-type> .
 
 obsdt:survey-configuration a skos:Concept ;


### PR DESCRIPTION
Additions to Observation Details
Processing Date
Software

Hylogger specific notes: 
Scanned date to be recorded as the Observation Date (in main observation table - Date selector)
Hylogger instrument to be input into Observation Instrument (in main observation table - Free text)

@katewd please check content is as discussed.
@LukeHauck please check content and pass through the file validation tools.