### PR TITLE
sample material update for LPX

### DIFF
--- a/uat-vocabularies/sample-material.ttl
+++ b/uat-vocabularies/sample-material.ttl
@@ -9,14 +9,17 @@
 <http://linked.data.gov.au/def/sample-material> a owl:Ontology , skos:ConceptScheme ;
     dcterms:created "2020-02-08"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2022-01-10"^^xsd:date ;
+    dcterms:modified "2022-02-10"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:provenance "Compiled by the Geological Survey of Queensland" ;
     skos:definition "Types of materials of which samples can consist of in Geoscience."@en ;
     skos:hasTopConcept spmt:air,
+        spmt:earth-material,
         spmt:digital,
         spmt:fluid,
+        spmt:metallic-material,
         spmt:mineral,
+        spmt:non-metallic-material,
         spmt:organic-material,
         spmt:regolith,
         spmt:rock,
@@ -27,40 +30,35 @@
     sdo:name "Geological Survey of Queensland" ;
     sdo:url "http://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq"^^xsd:anyURI .
 
-spmt:cement a skos:Concept ;
-    skos:broader spmt:fluid ;
-    skos:definition "A cement is a binder, a substance used for construction that sets, hardens, and adheres to other materials to bind them together."@en ;
+spmt:aerated-mud a skos:Concept ;
+    skos:broader spmt:mud ;
+    skos:definition "Fluid consisting of a mud whose density has been decreased by the process of aeration. Typically used as a drilling fluid."@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Cement"@en .
+    skos:prefLabel "Aerated Mud"@en .
 
-spmt:fungi a skos:Concept ;
-    skos:broader spmt:biological ;
-    skos:definition "Any part of a fungus."@en ;
+spmt:alluvial-wash a skos:Concept ;
+    skos:altLabel "Alluvial Ore"@en ;
+    skos:broader spmt:alluvium ;
+    skos:definition "Unconsolidated sediment primarily deposited by the action of fluid flow that contains, or is suspected to contain, an economic quantity of a commodity. Typically associated with Gold, Tin, and Corundum"@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Fungi"@en .
+    skos:prefLabel "Alluvial Wash"@en .
 
-spmt:hydraulic-fracturing-fluid a skos:Concept ;
-    skos:broader spmt:fluid ;
-    skos:definition "Fluid used in the hydraulic fracturing process."@en ;
+spmt:alluvium a skos:Concept ;
+    skos:broader spmt:sediment ;
+    skos:definition "Unconsolidated sediment primarily deposited by the action of fluid flow in a non-marine setting."@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Hydraulic Fracturing Fluid"@en .
+    skos:prefLabel "Alluvium"@en .
 
-spmt:leachate a skos:Concept ;
-    skos:broader spmt:fluid ;
-    skos:definition "The substance recovered from a material subsequent to its leaching."@en ;
+spmt:air a skos:Concept ;
+    skos:definition "The composite gas comprising the Earth's atmosphere."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/air> ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Leachate"@en .
-
-spmt:microbiological-material a skos:Concept ;
-    skos:broader spmt:biological ;
-    skos:definition "Any sample of a microbial organism or organisms."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Microbiological Material"@en .
+    skos:prefLabel "Air"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
 
 spmt:animal-material a skos:Concept ;
     skos:broader spmt:biological ;
@@ -70,6 +68,13 @@ spmt:animal-material a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Animal Material"@en .
 
+spmt:biological a skos:Concept ;
+    skos:broader spmt:organic-material ;
+    skos:definition "Any carbon-based material of a living or recently living organism."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Biological"@en .
+
 spmt:bitumen a skos:Concept ;
     skos:broader spmt:hydrocarbon-material ;
     skos:definition "Solid organic material that forms part of a rock. It can usually be extracted from the rock with organic solvent."@en ;
@@ -77,6 +82,51 @@ spmt:bitumen a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Bitumen"@en .
+
+spmt:bulk-metal a skos:Concept ;
+    skos:altLabel "Ingot"@en ;
+    skos:broader spmt:metal ;
+    skos:definition "Bulk Metal is refined ferrous or non-ferrous metal that is not necessarily to the high elemental purity required for bullion. Typically non-precious metals sold and transacted in larger volumes than bullion.."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Bulk Metal"@en .
+
+spmt:bulk-mineral a skos:Concept ;
+    skos:altLabel "Bulk Minerals"@en ;
+    skos:broader spmt:mineral ;
+    skos:definition "Bulk minerals are minerals that are not derived from mineral sand deposits and may be sold in bulk as a refined product. Bulk minerals include agricultural lime, gypsum, perlite, and wollastonite."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Bulk Mineral"@en .
+
+spmt:bulk-rock a skos:Concept ;
+    skos:altLabel "Bulk Rocks"@en ;
+    skos:broader spmt:rock ;
+    skos:definition "Bulk rock is a rock sold in bulk but not as construction material such as aggregate, raw stone, or dimension stone. Bulk rock is primarily mined and sold due to its chemcial and physical properties, such as limestone, peat, phosphate rock, diatomite, and lump silica."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Bulk Rock"@en .
+
+spmt:bullion a skos:Concept ;
+    skos:broader spmt:metal ;
+    skos:definition "Bullion is non-ferrous metal, typically Gold or Silver, that has been refined to a high standard of elemental purity."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Bullion"@en .
+
+spmt:cement a skos:Concept ;
+    skos:broader spmt:fluid ;
+    skos:definition "A cement is a binder, a substance used for construction that sets, hardens, and adheres to other materials to bind them together."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Cement"@en .
+
+spmt:clay a skos:Concept ;
+    skos:broader spmt:mineral ;
+    skos:definition "A fine-grained natural sediment that comprises mostly one or more clay minerals or clays such as kaolinite, smectite and illite. Or a refined material consisting of a purified clay mineral or minerals."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Clay"@en .
 
 spmt:coal a skos:Concept ;
     skos:broader spmt:organic-material,
@@ -130,6 +180,13 @@ spmt:coke a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Coke"@en .
 
+spmt:colluvium a skos:Concept ;
+    skos:broader spmt:sediment ;
+    skos:definition "Unconsolidated sediment primarily deposited by the action of gravity, such as sheetwash, rainwash, and downslop creep."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Colluvium"@en .
+
 spmt:condensate a skos:Concept ;
     skos:broader spmt:fluid-hydrocarbon ;
     skos:definition "A material that exists as gas in the subsurface but condenses into liquid at the surface."@en ;
@@ -153,12 +210,35 @@ spmt:digital a skos:Concept ;
     skos:prefLabel "Digital"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
 
-spmt:aerated-mud a skos:Concept ;
-    skos:broader spmt:mud ;
-    skos:definition "Fluid consisting of a mud whose density has been decreased by the process of aeration. Typically used as a drilling fluid."@en ;
+spmt:dimension-stone a skos:Concept ;
+    skos:broader spmt:stone ;
+    skos:definition "Natural rock selected and extracted from the earth and has been fabricated (i.e., trimmed, cut, drilled, ground, or otherwised processed) into specific sizes or shapes."@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Aerated Mud"@en .
+    skos:prefLabel "Dimension Stone"@en .
+
+spmt:direct-shipping-ore a skos:Concept ;
+    skos:broader spmt:ore ;
+    skos:definition "An ore that can be shipped and sold as a product in its raw and unprocessed form. Typically limited to bauxite, iron ores, and manganese ore."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Direct Shipping Ore"@en .
+
+spmt:dross a skos:Concept ;
+    skos:broader spmt:metal ;
+    skos:definition "A material mass of solid impurities generated by floation on a molten metal during metal refining. Depending on composition, dross may be a waste material or may be recovered for secondary processes or metal production such as Lead and Aluminium."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Dross"@en .
+
+spmt:earth-material a skos:Concept ;
+    skos:altLabel "Bulk Material"@en,
+        "Earth Material"@en ;
+    skos:definition "Solid materials in a natural or minimially altered state derived from the earth. Encompasses minerals, organic material, regolith, ock, and specifically includes undifferentiated material derived from the solid earth that may contain economic quantities of a commodity."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Bulk Earth Material"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
 
 spmt:estuarine-water a skos:Concept ;
     skos:broader spmt:water ;
@@ -167,6 +247,63 @@ spmt:estuarine-water a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Estuarine Water"@en .
+
+spmt:fluid a skos:Concept ;
+    skos:definition "A substance that has no fixed shape and yields easily to external pressure."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/fluid> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Fluid"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+
+spmt:fluid-hydrocarbon a skos:Concept ;
+    skos:broader spmt:hydrocarbon-material,
+        spmt:fluid ;
+    skos:definition "Any carbon-hydrogen fluid material"@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/fluid_hydrocarbon> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Fluid Hydrocarbon"@en .
+
+spmt:foam a skos:Concept ;
+    skos:broader spmt:fluid ;
+    skos:definition "A sample of foam. A mass of small bubbles from an aerated fluid."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Foam"@en .
+
+spmt:fungi a skos:Concept ;
+    skos:broader spmt:biological ;
+    skos:definition "Any part of a fungus."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Fungi"@en .
+
+spmt:gemstone a skos:Concept ;
+    skos:altLabel "Gemstones"@en,
+        "Gem"@en,
+        "Gems"@en,
+        "Precious Stone"@en,
+        "Precious Stones"@en,
+        "Semi-Precious Stone"@en,
+        "Semi-Precious Stones"@en,
+        "Jewel"@en,
+        "Jewels"@en ;
+    skos:broader spmt:mineral ;
+    skos:definition "A gemstone or gem (also called a precious or semi-precious stone, a fine gem, or jewel) is a piece of mineral, which, in cut and polished form, is used to make jewelry or other adornments"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Gemstone"@en .
+
+spmt:gem-rock a skos:Concept ;
+    skos:altLabel "Gem Rock"@en,
+        "Gem Ore"@en,
+        "Gem Bearing Rock"@en ;
+    skos:broader spmt:ore ;
+    skos:definition "Any rock containing gemstones."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Gem-Bearing Rock"@en .
 
 spmt:groundwater a skos:Concept ;
     skos:altLabel "Formation Water"@en ;
@@ -177,6 +314,21 @@ spmt:groundwater a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Groundwater"@en .
 
+spmt:heavy-mineral a skos:Concept ;
+    skos:altLabel "Heavy Minerals"@en ;
+    skos:broader spmt:mineral ;
+    skos:definition "Heavy minerals are minerals with a high density and found in mineral sand deposits as a source of of zirconium, titanium, thorium, tungsten, rare-earth elements, and industrial minerals such as corundum and garnet."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Heavy Mineral"@en .
+
+spmt:hydraulic-fracturing-fluid a skos:Concept ;
+    skos:broader spmt:fluid ;
+    skos:definition "Fluid used in the hydraulic fracturing process."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Hydraulic Fracturing Fluid"@en .
+
 spmt:hydrocarbon-gas a skos:Concept ;
     skos:altLabel "Gas"@en,
         "Natural Gas"@en ;
@@ -186,6 +338,14 @@ spmt:hydrocarbon-gas a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Hydrocarbon Gas"@en .
+
+spmt:hydrocarbon-material a skos:Concept ;
+    skos:broader spmt:organic-material ;
+    skos:definition "Any carbon-hydrogen based material."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/hydrocarbon_material> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Hydrocarbon Material"@en .
 
 spmt:kerogen a skos:Concept ;
     skos:broader spmt:hydrocarbon-material ;
@@ -202,6 +362,163 @@ spmt:lag a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Lag"@en .
+
+spmt:lateritic-ore a skos:Concept ;
+    skos:altLabel "Laterite Ore"@en ;
+    skos:broader spmt:ore ;
+    skos:definition "Laterite ores are formed by the process of weathering and normally found in tropical regions where weathering extracts and deposits minerals of value in layers at varying depths below the ground surface."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Lateritic Ore"@en .
+
+spmt:leachate a skos:Concept ;
+    skos:broader spmt:fluid ;
+    skos:definition "The substance recovered from a material subsequent to its leaching."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Leachate"@en .
+
+spmt:metal a skos:Concept ;
+    skos:definition "A material that is a pure or close-to-pure form of a metallic element such as Gold, Copper, and Lead."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metal"@en ;
+    skos:broader spmt:metallic-material .
+
+spmt:metallic-material a skos:Concept ;
+    skos:definition "A substance that has an economically useful high metal content as a result of refining and beneficiation. Including pure and close-to-pure materials such as bullion, and concentrates and compounds that have been processed from a raw material to yield a metal-rich substance."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metallic Material"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+
+spmt:metallic-ore a skos:Concept ;
+    skos:altLabel "Mineral Ore"@en ;
+    skos:broader spmt:ore ;
+    skos:definition "Natural rock that contains one or more valuable minerals, typically containing metals, that can be mined, processed, and sold at a profit."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metalic Ore"@en .
+
+spmt:metal-cathode a skos:Concept ;
+    skos:altLabel "Cathode"@en ;
+    skos:broader spmt:metal ;
+    skos:definition "A high purity metal refined by electrolysis and precipitation of a target metal from solution or molten metal. Most commonly associated with Copper Cathode."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metal Cathode"@en .
+
+spmt:metal-compound a skos:Concept ;
+    skos:altLabel "Metallic Compound"@en ;
+    skos:broader spmt:metallic-material ;
+    skos:definition "A compound that contains one or more metal elements bonded to another element."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metal Compound"@en .
+
+spmt:metal-concentrate a skos:Concept ;
+    skos:altLabel "Concentrate"@en,
+        "Ore Concentrate"@en,
+        "Dressed Ore"@en ;
+    skos:broader spmt:metallic-material ;
+    skos:definition """A substance generated by the processing of a metallic ore to remove waste (gangue) and concentrate the metallic content. Used as a transportable intermediary product for transport to further physical and chemical processing and refining techniques."""@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metal Concentrate"@en .
+
+spmt:metal-hydroxide a skos:Concept ;
+    skos:altLabel "Hydroxide"@en ;
+    skos:broader spmt:metal-compound ;
+    skos:definition "A compound that contains one or more metal elements bonded to a hydroxide anion."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metal Hydroxide"@en .
+
+spmt:metal-sulphate a skos:Concept ;
+    skos:altLabel "Sulphate"@en,
+        "Sulfate"@en,
+        "Metal Sulfate"@en ;
+    skos:broader spmt:metal-compound ;
+    skos:definition "A compound that contains one or more metal elements bonded to a sulphate anion."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Metal Sulphate"@en .
+
+spmt:microbiological-material a skos:Concept ;
+    skos:broader spmt:biological ;
+    skos:definition "Any sample of a microbial organism or organisms."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Microbiological Material"@en .
+
+spmt:mineral a skos:Concept ;
+    skos:definition "A naturally occurring inorganic, crystalline, element or compound"@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/mineral> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Mineral"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+
+spmt:mineral-sand a skos:Concept ;
+    skos:altLabel "Mineral Sands"@en,
+        "Heavy Mineral Sand"@en,
+        "Heavy Mineral Sands"@en,
+        "Heavy Mineral Sands Ore Deposits"@en ;
+    skos:broader spmt:alluvium ;
+    skos:definition "Unconsolidated sediment primarily deposited as placer deposits formed in beach environments where the density of heavy minerals increases their concentration within the sediment to economically significant levels. Less commonly resulting from fluvial action. A primary source of heavy minerals."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Mineral Sand"@en .
+
+spmt:mist a skos:Concept ;
+    skos:broader spmt:fluid ;
+    skos:definition "A suspension of liquid droplets in a gas. Typically water droplets suspended in air."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Mist"@en .
+
+spmt:mud a skos:Concept ;
+    skos:broader spmt:fluid ;
+    skos:definition "A mixture of water, clay, and/or chemicals."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Mud"@en .
+
+spmt:non-metallic-material a skos:Concept ;
+    skos:definition "A material that has an economically useful high non-metal content as a result of refining and beneficiation. Includes any material used as a source for non-metals such as Bromine, Iodine, Phosphorus and Sulfur including pure forms of non-metallic elements."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Non-Metallic Material"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+
+spmt:non-metal a skos:Concept ;
+    skos:definition "A material that is a pure or close-to-pure form of a non-metallic element such as Bromine, Iodine, Phosphorus and Sulfur."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Non-Metal"@en ;
+    skos:broader spmt:non-metallic-material .
+
+spmt:oil a skos:Concept ;
+    skos:broader spmt:fluid-hydrocarbon ;
+    skos:definition "A naturally occuring liquid hydrocarbon."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Oil"@en .
+
+spmt:ore a skos:Concept ;
+    skos:broader spmt:rock ;
+    skos:definition "A deposit in Earth's crust of one or more valuable minerals. Within the context of material types this is constrained to solid rock ores. Alluvial wash, also known as alluvial ore, is economically considered an ore, but is within a separate material category."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Ore"@en .
+
+spmt:organic-material a skos:Concept ;
+    skos:definition "Any carbon-based material."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/organic_material> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Organic Material"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
 
 spmt:pitch a skos:Concept ;
     skos:broader spmt:hydrocarbon-material ;
@@ -227,6 +544,14 @@ spmt:rain-water a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Rain Water"@en .
 
+spmt:regolith a skos:Concept ;
+    skos:definition "Typically unconsolidated or fragmental material, either transported or residual origin, which covers bedrock. Includes surficial duricrusts that cap bedrock."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/regolith> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Regolith"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+
 spmt:refined-oil a skos:Concept ;
     skos:broader spmt:oil ;
     skos:definition "Oil that has been processed in an oil refinery."@en ;
@@ -242,130 +567,6 @@ spmt:resin a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Resin"@en .
-
-spmt:sea-water a skos:Concept ;
-    skos:broader spmt:water ;
-    skos:definition "Saline water from the Earth's seas and oceans."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/sea_water> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Sea Water"@en .
-
-spmt:sediment a skos:Concept ;
-    skos:broader spmt:regolith ;
-    skos:definition "Unconsolidated sedimentary material."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/sediment> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Sediment"@en .
-
-spmt:soil a skos:Concept ;
-    skos:broader spmt:regolith ;
-    skos:definition "Unconsolidated mineral or organic material on the Earth's surface that serves as a natural medium for the growth of land plants."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/soil> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Soil"@en .
-
-spmt:surface-water a skos:Concept ;
-    skos:broader spmt:water ;
-    skos:definition "Fresh or brackish water which occurs on the surface of a land mass (eg, rivers, creeks, lakes)."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/surface_water> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Surface Water"@en .
-
-spmt:vegetation a skos:Concept ;
-    skos:broader spmt:biological ;
-    skos:definition "Any part of a plant whether it be moss, grass, sedge, or the roots, bark, twigs or leaves of trees and shrubs."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/vegetation> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Vegetation"@en .
-
-spmt:wax a skos:Concept ;
-    skos:broader spmt:hydrocarbon-material ;
-    skos:definition "A light coloured solid precipitated from either a hydrocarbon gas or oil"@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/wax> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Wax"@en .
-
-spmt:air a skos:Concept ;
-    skos:definition "The composite gas comprising the Earth's atmosphere."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/air> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Air"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
-
-spmt:mineral a skos:Concept ;
-    skos:definition "A naturally occurring inorganic, crystalline, element or compound"@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/mineral> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Mineral"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
-
-spmt:oil a skos:Concept ;
-    skos:broader spmt:fluid-hydrocarbon ;
-    skos:definition "A naturally occuring liquid hydrocarbon."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Oil"@en .
-
-spmt:unknown a skos:Concept ;
-    skos:definition "Material type is unknown"@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/unknown> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Unknown"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
-
-spmt:biological a skos:Concept ;
-    skos:broader spmt:organic-material ;
-    skos:definition "Any carbon-based material of a living or recently living organism."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Biological"@en .
-
-spmt:fluid-hydrocarbon a skos:Concept ;
-    skos:broader spmt:hydrocarbon-material,
-        spmt:fluid ;
-    skos:definition "Any carbon-hydrogen fluid material"@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/fluid_hydrocarbon> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Fluid Hydrocarbon"@en .
-
-spmt:foam a skos:Concept ;
-    skos:broader spmt:fluid ;
-    skos:definition "A sample of foam. A mass of small bubbles from an aerated fluid."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Foam"@en .
-
-spmt:mist a skos:Concept ;
-    skos:broader spmt:fluid ;
-    skos:definition "A suspension of liquid droplets in a gas. Typically water droplets suspended in air."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Mist"@en .
-
-spmt:mud a skos:Concept ;
-    skos:broader spmt:fluid ;
-    skos:definition "A mixture of water, clay, and/or chemicals."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Mud"@en .
-
-spmt:organic-material a skos:Concept ;
-    skos:definition "Any carbon-based material."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/organic_material> ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
-    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Organic Material"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
 
 spmt:rock a skos:Concept ;
     skos:hiddenLabel "Rock (Undiff.)"@en ;
@@ -384,6 +585,22 @@ spmt:sandstone a skos:Concept ;
     skos:altLabel "Sand-grade-sedimentary-rock"@en ;
     skos:prefLabel "Sandstone"@en .
 
+spmt:sea-water a skos:Concept ;
+    skos:broader spmt:water ;
+    skos:definition "Saline water from the Earth's seas and oceans."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/sea_water> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Sea Water"@en .
+
+spmt:sediment a skos:Concept ;
+    skos:broader spmt:regolith ;
+    skos:definition "Unconsolidated sedimentary material."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/sediment> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Sediment"@en .
+
 spmt:shale a skos:Concept ;
     skos:definition "A fine-grained detrital sedimentary rock, formed by the consolidation (esp. by compression) of clay, silt, or mud. It is characterized by finely laminated structure, which imparts a fissility approx. parallel to the bedding, along which the rock breaks readily into thin layers, and by an appreciable content of clay minerals and detrital quartz; a thinly laminated or fissile claystone, siltstone, or mudstone."@en ;
     skos:broader spmt:rock ;
@@ -391,6 +608,17 @@ spmt:shale a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:altLabel "Schluffstein"@en ;
     skos:prefLabel "Shale"@en .
+
+spmt:silica-sand a skos:Concept ;
+    skos:altLabel "Silica Sands"@en,
+        "Quartz Sand"@en,
+        "White Sand"@en,
+        "Industrial Sand"@en ;
+    skos:broader spmt:alluvium ;
+    skos:definition "Unconsolidated sand that has very few impurities, with compositions of 90% silica or greater. Common uses of silica sand include glass making and as a feed stock for industrial processes."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Silica Sand"@en .
 
 spmt:siltstone a skos:Concept ;
     skos:definition "A mudstone with silt-grade clasts. An indurated silt having the texture and composition of shale but lacking its fine lamination or fissility; a massive mudstone in which the silt predominates over clay; a nonfissile silty shale. It tends to be flaggy, containing hard, durable, generally thin layers, and often showing various primary current structures."@en ;
@@ -400,21 +628,52 @@ spmt:siltstone a skos:Concept ;
     skos:altLabel "Siltite"@en ;
     skos:prefLabel "Siltstone"@en .
 
-spmt:regolith a skos:Concept ;
-    skos:definition "Typically unconsolidated or fragmental material, either transported or residual origin, which covers bedrock. Includes surficial duricrusts that cap bedrock."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/regolith> ;
+spmt:slime a skos:Concept ;
+    skos:altLabel "Slime"@en ;
+    skos:broader spmt:fluid ;
+    skos:definition "A by-product of metal processing consisting of a fluid, commonly water, with a large concentration of suspended and dissolved waste material."@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Regolith"@en ;
+    skos:prefLabel "Tankhouse Slime"@en .
+
+spmt:soil a skos:Concept ;
+    skos:broader spmt:regolith ;
+    skos:definition "Unconsolidated mineral or organic material on the Earth's surface that serves as a natural medium for the growth of land plants."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/soil> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Soil"@en .
+
+spmt:stone a skos:Concept ;
+    skos:broader spmt:rock ;
+    skos:definition "Natural rock selected and extracted from the earth to be used as cut stone in building and construction, excluding aggregates and crushed material."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Stone"@en .
+
+spmt:surface-water a skos:Concept ;
+    skos:broader spmt:water ;
+    skos:definition "Fresh or brackish water which occurs on the surface of a land mass (eg, rivers, creeks, lakes)."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/surface_water> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Surface Water"@en .
+
+spmt:unknown a skos:Concept ;
+    skos:definition "Material type is unknown"@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/unknown> ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
+    skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
+    skos:prefLabel "Unknown"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
 
-spmt:hydrocarbon-material a skos:Concept ;
-    skos:broader spmt:organic-material ;
-    skos:definition "Any carbon-hydrogen based material."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/hydrocarbon_material> ;
+spmt:vegetation a skos:Concept ;
+    skos:broader spmt:biological ;
+    skos:definition "Any part of a plant whether it be moss, grass, sedge, or the roots, bark, twigs or leaves of trees and shrubs."@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/vegetation> ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Hydrocarbon Material"@en .
+    skos:prefLabel "Vegetation"@en .
 
 spmt:water a skos:Concept ;
     skos:broader spmt:fluid ;
@@ -424,13 +683,13 @@ spmt:water a skos:Concept ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Water"@en .
 
-spmt:fluid a skos:Concept ;
-    skos:definition "A substance that has no fixed shape and yields easily to external pressure."@en ;
-    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/fluid> ;
+spmt:wax a skos:Concept ;
+    skos:broader spmt:hydrocarbon-material ;
+    skos:definition "A light coloured solid precipitated from either a hydrocarbon gas or oil"@en ;
+    skos:exactMatch <http://pid.geoscience.gov.au/def/voc/ga/materialtype/wax> ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Fluid"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+    skos:prefLabel "Wax"@en .
 
 spmt:drilling-fluid a skos:Collection ;
     skos:definition "Fluid used for drill bit lubrication and return of ground rock material from the drill bit, e.g. mud."@en ;
@@ -441,3 +700,67 @@ spmt:drilling-fluid a skos:Collection ;
         spmt:mist,
         spmt:air ;
     skos:prefLabel "Drilling Fluid"@en .
+
+spmt:drilling-fluid a skos:Collection ;
+    skos:definition "Fluid used for drill bit lubrication and return of ground rock material from the drill bit, e.g. mud."@en ;
+    skos:member spmt:mud,
+        spmt:water,
+        spmt:aerated-mud,
+        spmt:foam,
+        spmt:mist,
+        spmt:air ;
+    skos:prefLabel "Drilling Fluid"@en .
+
+spmt:coal-materials a skos:Collection ;
+    skos:definition "Types of coal that describe different stages in the coal mining, processing, and sales lifecycle."@en ;
+    skos:member spmt:coal-raw,
+        spmt:coal-washed,
+        spmt:coal-unwashed,
+        spmt:coal-sales ;
+    skos:prefLabel "Coal Mining Materials"@en .
+
+spmt:min-raw-materials a skos:Collection ;
+    skos:definition "Types of raw materials extracted from the earth by mineral miners and operators under Mineral Resources legislation and regulation."@en ;
+    skos:member spmt:alluvial-wash,
+        spmt:clay,
+        spmt:earth-material,
+        spmt:gem-rock,
+        spmt:lateritic-ore,
+        spmt:metallic-ore,  
+        spmt:mineral-sand,
+        spmt:stone ;
+    skos:prefLabel "Mineral Mining Raw Materials"@en .
+
+
+spmt:min-products a skos:Collection ;
+    skos:definition "Types of saleable product materials that result from the processing of extracted raw material by mineral miners and operators under Mineral Resources legislation and regulation."@en ;
+    skos:member spmt:bulk-metal,
+        spmt:bulk-mineral,
+        spmt:bulk-rock,
+        spmt:bullion,
+        spmt:clay,
+        spmt:dimension-stone,
+        spmt:direct-shipping-ore,
+        spmt:dross,
+        spmt:gemstone,
+        spmt:heavy-mineral,
+        spmt:metal-cathode,
+        spmt:metal-concentrate,
+        spmt:metal-hydroxide,
+        spmt:metal-sulphate,
+        spmt:non-metal,
+        spmt:silica-sand,
+        spmt:slime ;
+    skos:prefLabel "Mineral Mining Product Materials"@en .
+
+
+spmt:petroleum-materials a skos:Collection ;
+    skos:definition "Petroleum resurce material types from the extraction, processing, and sales lifecycle."@en ;
+    skos:member spmt:bitumen,
+        spmt:condensate,
+        spmt:crude-oil,
+        spmt:hydrocarbon-gas,
+        spmt:refined-oil,
+        spmt:water,
+        spmt:wax ;
+    skos:prefLabel "Petroleum Materials"@en .

--- a/uat-vocabularies/sample-material.ttl
+++ b/uat-vocabularies/sample-material.ttl
@@ -9,7 +9,7 @@
 <http://linked.data.gov.au/def/sample-material> a owl:Ontology , skos:ConceptScheme ;
     dcterms:created "2020-02-08"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2022-02-10"^^xsd:date ;
+    dcterms:modified "2022-02-11"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:provenance "Compiled by the Geological Survey of Queensland" ;
     skos:definition "Types of materials of which samples can consist of in Geoscience."@en ;
@@ -18,11 +18,7 @@
         spmt:digital,
         spmt:fluid,
         spmt:metallic-material,
-        spmt:mineral,
         spmt:non-metallic-material,
-        spmt:organic-material,
-        spmt:regolith,
-        spmt:rock,
         spmt:unknown ;
     skos:prefLabel "Sample Material"@en .
 
@@ -457,7 +453,7 @@ spmt:mineral a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Mineral"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+    skos:broader spmt:earth-material .
 
 spmt:mineral-sand a skos:Concept ;
     skos:altLabel "Mineral Sands"@en,
@@ -518,7 +514,7 @@ spmt:organic-material a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Organic Material"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+    skos:broader spmt:earth-material .
 
 spmt:pitch a skos:Concept ;
     skos:broader spmt:hydrocarbon-material ;
@@ -550,7 +546,7 @@ spmt:regolith a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Regolith"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+    skos:broader spmt:earth-material .
 
 spmt:refined-oil a skos:Concept ;
     skos:broader spmt:oil ;
@@ -575,7 +571,7 @@ spmt:rock a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
     skos:prefLabel "Rock"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/sample-material> .
+    skos:broader spmt:earth-material .
 
 spmt:sandstone a skos:Concept ;
     skos:definition "A sand-grade clastic-sedimentary-rock."@en ;

--- a/uat-vocabularies/sample-material.ttl
+++ b/uat-vocabularies/sample-material.ttl
@@ -394,7 +394,7 @@ spmt:metallic-ore a skos:Concept ;
     skos:definition "Natural rock that contains one or more valuable minerals, typically containing metals, that can be mined, processed, and sold at a profit."@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/sample-material> ;
     skos:inScheme <http://linked.data.gov.au/def/sample-material> ;
-    skos:prefLabel "Metalic Ore"@en .
+    skos:prefLabel "Metallic Ore"@en .
 
 spmt:metal-cathode a skos:Concept ;
     skos:altLabel "Cathode"@en ;


### PR DESCRIPTION
Reordered and alphabetised concepts.
Added raw materials and product materials as pertains to minerals
Created collections for coal materials, mineral raw materials, mineral product materials, and petroleum materials.

loaded to [graphDB UAT sample material](https://vocabs.uat.gsq.digital/object?uri=http://linked.data.gov.au/def/sample-material ) for content checks