### PR TITLE
Update gsq-alias.ttl

### DIFF
--- a/vocabularies-gsq/geological-properties.ttl
+++ b/vocabularies-gsq/geological-properties.ttl
@@ -1,0 +1,176 @@
+@prefix gprp: <http://linked.data.gov.au/def/geological-properties/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://linked.data.gov.au/def/geological-properties> a owl:Ontology ,
+        skos:ConceptScheme ;
+    dcterms:created "2022-09-13"^^xsd:date ;
+    dcterms:creator <http://linked.data.gov.au/org/gsq> ;
+    dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
+    dcterms:modified "2022-09-13"^^xsd:date ;
+    dcterms:provenance "Construction by the GSQ. Initial version derived from rock unit properties" ;
+    skos:definition "The geological properties that can be interpreted or concluded about a geological feature based on the analysis of observations and results of that feature."@en ;
+    skos:hasTopConcept gprp:AgeChrono,
+        gprp:AgeAbsolute,
+        gprp:DepthMax,
+        gprp:DominantRock,
+        gprp:DominantMineral,
+        gprp:DominantElement,
+        gprp:Extent,
+        gprp:RockUnitRank,
+        gprp:Thickness,
+        gprp:TypeLocality ;
+    skos:prefLabel "Geological Properties"@en .
+
+<http://linked.data.gov.au/org/gsq>
+    a sdo:Organization ;
+    sdo:name "Geological Survey of Queensland" ;
+    sdo:url "https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq"^^xsd:anyURI ;
+.
+
+gprp:AgeChrono a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The named age of the geological feature as per the international chronostratigraphic chart."@en ;
+    skos:prefLabel "Chronological Age"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties>.
+
+gprp:AgeChronoLower a skos:Concept ;
+    skos:altLabel "Age From"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The named age of the lowest and oldest chronological layer or section of a geological feature as per the international chronostratigraphic chart."@en ;
+    skos:prefLabel "Lower Age"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:AgeChrono .
+
+gprp:AgeChronoUpper a skos:Concept ;
+    skos:altLabel "Age To"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The age of the upper-most and youngest chronological layer or section of a geological feature as per the international chronostratigraphic chart."@en ;
+    skos:prefLabel "Upper Age"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:AgeChrono .
+
+gprp:AgeAbsolute a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The numeric age of the geological feature, typically represented in thousands, millions, or billions of years, with millions of years (MA) being the most common."@en ;
+    skos:prefLabel "Absolute Age"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties>.
+
+gprp:AgeAbsoluteMax a skos:Concept ;
+    skos:altLabel "Max Age"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The numeric age of the oldest chronological layer or section of a geological feature."@en ;
+    skos:prefLabel "Maximum Absolute Age"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:AgeAbsolute .
+
+gprp:AgeAbsoluteMin a skos:Concept ;
+    skos:altLabel "Min Age"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The numeric age of the youngest chronological layer or section of a geological feature."@en ;
+    skos:prefLabel "Minimum Absolute Age"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:AgeAbsolute .
+
+gprp:DominantRock a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The most prevalent rock type present in the geological feature."@en ;
+    skos:prefLabel "Dominant Rock"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties> .
+
+gprp:DominantMineral a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The most prevalent mineral species present in the geological feature."@en ;
+    skos:prefLabel "Dominant Mineral"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties> .
+
+gprp:DominantElement a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The most prevalent element present in the geological feature."@en ;
+    skos:prefLabel "Dominant Element"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties> .
+
+gprp:Extent a skos:Concept ;
+    skos:altLabel "Area"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The spatial extent or area covered by a feature at the surface of the Earth."@en ;
+    skos:prefLabel "Extent"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties>.
+
+gprp:DepthMax a skos:Concept ;
+    skos:altLabel "Max Depth"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The maximum depth of a geological feature. This may be to underlying 'basement' rock or a defined boundary. Traditionally this is measured in distance (feet, metres, miles, kilometres) or time from seismic acquisition techniques represented as 1-way or 2-way time (seconds, milliseconds)"@en ;
+    skos:prefLabel "Maximum Depth"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> .
+
+gprp:ResourceProspectivity a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The potential or maturity of a resource accumulation (Mineral Occurrence, Coal Deposit, Petroleum Play) to be progressed to economic development. The progress from discovery or lead, to prospect, to opportunity. Related to the resource project lifecycle."@en ;
+    skos:prefLabel "Resource Prospectivity"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties>.
+
+gprp:RockUnitRank a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The rank of a rock unit in as defined by its type, extent, and relationships to other rock units. For example, in stratigraphic rock units: Supergroup, group, subgroup, formation, member, bed, and in igneous rock units: Supersuite, suite etc."@en ;
+    skos:prefLabel "Rock Unit Rank"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties>.
+
+gprp:Thickness a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The thickness of the geological feature."@en ;
+    skos:scopeNote "This unspecified level categorisation should only be used where the thickness is not at the type location and not numerically specific (average, maximuim, or minimum)."@en ;
+    skos:prefLabel "Thickness"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties>.
+
+gprp:ThicknessAverage a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The average thickness of the feature."@en ;
+    skos:prefLabel "Average Thickness"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:Thickness .
+
+gprp:ThicknessMin a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The minimum thickness of the feature."@en ;
+    skos:prefLabel "Minimum Thickness"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:Thickness .
+
+gprp:ThicknessMax a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The maximum thickness of the feature."@en ;
+    skos:prefLabel "Maximum Thickness"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:Thickness .
+
+gprp:ThicknessAtTypeSection a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The thickness of the feature at the type section of representative site."@en ;
+    skos:prefLabel "Type Section Thickness"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:broader gprp:Thickness .
+
+gprp:TypeLocality a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geological-properties> ;
+    skos:definition "The location of the type section or representative site. This may be a property name, outcrop name, coordinates, or associated geomorpholgical feature."@en ;
+    skos:scopeNote "The locality is used as the defining site that pertains to the feature description."@en ;
+    skos:prefLabel "Type Locality"@en ;
+    skos:inScheme <http://linked.data.gov.au/def/geological-properties> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geological-properties>.

--- a/vocabularies-gsq/gsq-alias.ttl
+++ b/vocabularies-gsq/gsq-alias.ttl
@@ -2,7 +2,7 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix sdo: <http://schema.org/> .
+@prefix sdo: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -12,34 +12,82 @@
     dcterms:created "2020-03-23"^^xsd:date ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2022-04-12"^^xsd:date ;
+    dcterms:modified "2022-09-20"^^xsd:date ;
     dcterms:provenance "Compiled by the Geological Survey of Queensland" ;
     skos:definition "Sources for any alternate names for features, sites, surveys, or samples catalogued by the Geological Survey of Queensland."@en ;
     skos:hasTopConcept als:colloquial,
         als:des,
+        als:firstNations,
+        als:formal,
         als:geoscience-australia,
-        als:legacy,
+        als:gsq-legacy,
         als:igsn,
+        als:informal,
+        als:invalid,
+        als:misspelt,
         als:mmol,
+        als:obsolete,
         als:ogia,
         als:rshq,
-        als:informal,
-        als:formal,
-        als:treasury ;
+        als:operator,
+        als:service-provider,
+        als:treasury,
+        als:unnamed ;
     skos:prefLabel "GSQ Alias"@en .
 
 <http://linked.data.gov.au/org/gsq> a sdo:Organization ;
     sdo:name "Geological Survey of Queensland" ;
-    sdo:url "http://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq"^^xsd:anyURI .
-
-als:agso a skos:Concept ;
-    skos:altLabel "AGSO"@en,
-        "AGSO_GEODX_ID"@en ;
-    skos:definition "An historic code used by Geoscience Australia (formerly Australian Geological Survey Organisation), for the identification of rock units in the Australian Stratigraphic Units Database (ASUD)"@en ;
+    sdo:url "https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq"^^xsd:anyURI .
+    
+    als:formal a skos:Concept ;
+    skos:altLabel "defined"@en ;
+    skos:definition "The standing that is attributed to a formal name, with non-current usage, that has been formally replaced, if only partially, by another formal name, such as with the change in the ending of the name of a lithologic rock unit (e.g., from ‘Formation’ to Sandstone’ or similar) or a formal name has been replaced, if only partially, by an informal name (e.g., Stanwell Coal Measures to Stanwell 'Formation'/formation). This applies to other types of rock units, such as biostratigraphic units, which are rocks characterized by their fossil content, not their lithologic attributes."@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
     skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "Australian Geological Survey Organisation Rock Codes"@en ;
-    skos:broader als:geoscience-australia .
+    skos:prefLabel "Formal"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
+           
+    als:informal a skos:Concept ;
+    skos:definition "The standing that is attributed to a name that has not been formally instituted or recognized, such as under a national or international code or protocol (e.g., the International Stratigraphic Guide), and does not have current usage, as it has been replaced (superseded) by a formal name or another informal name. An example of the latter, in terms of lithologic rock units, embraces the name change from the ‘Taroom beds’ to the ‘Chong beds' (Hettangian/basal Jurassic), as the former name is preoccupied by the Taroom Coal Measures."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:prefLabel "Informal"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
+
+    als:firstNations a skos:Concept ;
+    skos:definition "The informal standing (in terms of an overriding code or protocol) that is attributed to the current First Nations name of a feature, such a lithologic rock unit, under the dual naming policy for Aboriginal and Torres Strait Islander place names, e.g., the Mount Warning Central Complex being named Wollumbin (fighting chief of the mountains)."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:prefLabel "First Nations"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
+
+    als:obsolete a skos:Concept ;
+    skos:definition "The standing that is attributed to a name or term through lack of use and/or persistent change of use and that has been replaced by another name or term, either as a simple equal replacement or in a complicated, unequal (not one-to-one) process."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:prefLabel "Obsolete"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
+
+    als:invalid a skos:Concept ;
+    skos:definition "The standing attributed to a rock unit the name and parameters of which have been published, but not in accordance with a national, international and/or other code or protocol that applies thereto (e.g., the International Stratigraphic Guide), rendering the unit with invalid status (as opposed to informal status). A yet-to-be corrected (replaced) rock unit example of this (as at 09.08.2022) is represented by the current name ‘Balfes Creek beds’, as the name ‘Balfes Creek Granodiorite’ has precedence (see ASUD Stratigraphic Number 36156). Upon replacement by a new name (with current status), the Balfes Creek beds will then be regarded as an alias (with invalid standing) of the new name of the rock unit that then has currency."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:prefLabel "Invalid"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
+    
+    als:unnamed a skos:Concept ;
+    skos:definition "The previous standing of a geological feature that was recorded in published or unpublished reports, records, maps, etc., and was not then named but now is named or part of it is named. The previously unnamed feature may have had a composite label, but not a true name, e.g., a complex rock unit that was comprised of multiple other rock units, one or more of which is now named."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:prefLabel "Unnamed"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
+
+    als:misspelt a skos:Concept ;
+    skos:definition "The standing of a geologic feature, such as a lithologic rock unit, the name of which has been misspelt or seemingly misspelt."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:prefLabel "Misspelt"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
 als:colloquial a skos:Concept ;
     skos:altLabel "Common"@en,
@@ -49,47 +97,6 @@ als:colloquial a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
     skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
     skos:prefLabel "Colloquial"@en ;
-    skos:broader als:informal .
-
-als:des a skos:Concept ;
-    skos:altLabel "Department of Environment and Science"@en ;
-    skos:definition "An identifier used by the Department of Environment and Science"@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "DES"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
-
-als:informal a skos:Concept ;
-    skos:definition "Any identifier used informally outside standardised naming conventions, such as colloquial, local, and company terms."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "Informal"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
-
-als:first-nations a skos:Concept ;
-    skos:altLabel "Indigenous Name"@en,
-        "Aboriginal or Torres Strait Island Name"@en,
-        "Aboriginal Name"@en,
-        "Torres Strait Islands Name"@en ; 
-    skos:definition "Any name given to a feature by first nations groups."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "First Nations Name"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
-
-als:formal a skos:Concept ;
-    skos:definition "Any identifying name used officially by a governing body for the subject matter."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "Formal"@en ;
-    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
-
-als:geoscience-australia a skos:Concept ;
-    skos:altLabel "GA"@en ;
-    skos:definition "An identifier used by Geoscience Australia"@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "Geoscience Australia"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
 als:gsq-legacy a skos:Concept ;
@@ -97,7 +104,7 @@ als:gsq-legacy a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
     skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
     skos:prefLabel "GSQ Legacy"@en ;
-    skos:broader als:legacy .
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
 als:igsn a skos:Concept ;
     skos:altLabel "International Geo Sample Number"@en ;
@@ -107,21 +114,20 @@ als:igsn a skos:Concept ;
     skos:prefLabel "IGSN"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
-als:invalid a skos:Concept ;
-    skos:definition "Published name that has not been reserved, and is potentially or actually confusing, due to similarity with existing, longer standing terminology."@en ;
+als:des a skos:Concept ;
+    skos:altLabel "Department of Environment and Science"@en ;
+    skos:definition "An identifier used by the Department of Environment and Science"@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
     skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "Invalid"@en ;
+    skos:prefLabel "DES"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
-als:legacy a skos:Concept ;
-    skos:altLabel "Obsolete"@en,
-        "Historic"@en,
-        "Superseded"@en ;
-    skos:definition "Any superseded identifier, code, or name."@en ;
+als:geoscience-australia a skos:Concept ;
+    skos:altLabel "GA"@en ;
+    skos:definition "An identifier used by Geoscience Australia"@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
     skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "Legacy"@en ;
+    skos:prefLabel "Geoscience Australia"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
 als:mmol a skos:Concept ;
@@ -141,13 +147,6 @@ als:ogia a skos:Concept ;
     skos:prefLabel "QWRC"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
-als:operator a skos:Concept ;
-    skos:definition "An identifier used by the company who originally owned or operated an asset or activity."@en ;
-    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
-    skos:prefLabel "Operator"@en ;
-    skos:broader als:informal .
-
 als:rshq a skos:Concept ;
     skos:altLabel "Resources Safety and Health Queensland"@en ;
     skos:definition "An identifier used by Resources Safety and Health Queensland."@en ;
@@ -156,13 +155,20 @@ als:rshq a skos:Concept ;
     skos:prefLabel "RSHQ"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
+als:operator a skos:Concept ;
+    skos:definition "An identifier used by the company who originally owned or operated an asset or activity."@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
+    skos:prefLabel "Operator"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
+
 als:service-provider a skos:Concept ;
     skos:altLabel "Contractor"@en ;
     skos:definition "An identifier used by the company who originally conducted activity on behalf of the operator."@en ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/gsq-alias> ;
     skos:inScheme <http://linked.data.gov.au/def/gsq-alias> ;
     skos:prefLabel "Service Provider"@en ;
-    skos:broader als:informal .
+    skos:topConceptOf <http://linked.data.gov.au/def/gsq-alias> .
 
 als:treasury a skos:Concept ;
     skos:altLabel "Queensland Treasury"@en ;
@@ -182,7 +188,6 @@ als:government a skos:Collection ;
     skos:definition "Aliases used by other groups within the Department, other departments within Queensland Government, or other Government Agencies."@en ;
     skos:member als:des,
         als:geoscience-australia,
-        als:agso,
         als:mmol,
         als:ogia,
         als:treasury ;

--- a/vocabularies-gsq/qualitative-confidence.ttl
+++ b/vocabularies-gsq/qualitative-confidence.ttl
@@ -1,0 +1,378 @@
+@prefix qcon: <http://linked.data.gov.au/def/qualitative-confidence/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://linked.data.gov.au/def/qualitative-confidence> a owl:Ontology ,
+        skos:ConceptScheme ;
+    dcterms:created "2022-09-16"^^xsd:date ;
+    dcterms:creator <http://linked.data.gov.au/org/gsq> ;
+    dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
+    dcterms:modified "2022-09-16"^^xsd:date ;
+    dcterms:provenance """Constructed by the GSQ, from common terminology, JORC Mineral Resource and Ore Reserves Classification, the Petroleum Resource Management System, and the IPCC Uncertainty Guidance Note (IPCC AR5).""" ;
+    skos:definition """Qualitative descriptors to indicate the confidence in a value or interpretation. Some qualitative descriptions may be based on quantitative criteria."""@en ;
+    skos:hasTopConcept
+        qcon:approximate,
+        qcon:contingent,
+        qcon:indicated,
+        qcon:inferred,
+        qcon:measured,
+        qcon:possible,
+        qcon:probable,
+        qcon:prospective,
+        qcon:proved,
+        qcon:uncertain,
+        qcon:high-u,
+        qcon:high-e,
+        qcon:high-v,
+        qcon:high,
+        qcon:moderate,
+        qcon:low,
+        qcon:low-v,
+        qcon:low-e,
+        qcon:low-u ;
+    skos:prefLabel "Qualitative Confidence"@en .
+
+<http://linked.data.gov.au/org/gsq>
+    a sdo:Organization ;
+    sdo:name "Geological Survey of Queensland" ;
+    sdo:url "https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq"^^xsd:anyURI ;
+.
+
+qcon:approximate a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    prov:wasDerivedFrom <http://linked.data.gov.au/org/gsq> ;
+    skos:definition """An indication that an interpretation is an approximation, typically (but not exclusively) used for numerical values."""@en ;
+    skos:prefLabel "Approximate"@en ;
+    skos:notation """~""" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:contingent a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """Those quantities of petroleum estimated, as of a given date, to be potentially recoverable from known accumulations by application of development projects, but which are not currently considered to be commercially recoverable owing to one or more contingencies.
+    
+    An estimate deemed to be potentially correct but with caveats on related influences and applicability."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Contingent"@en ;
+    skos:notation "C" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:contingent-one a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """The low-range volume estimate of petroleum quantities, as of a given date, to be potentially recoverable from known accumulations by application of development projects, but which are not currently considered to be commercially recoverable owing to one or more contingencies. The low volume corresponding to a higher probability that the full volume is recoverable.
+    
+    A low-range estimate deemed to be potentially correct but with caveats on related influences and applicability."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Contingent - Low Estimate"@en ;
+    skos:notation "1C" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:broader qcon:contingent .
+
+qcon:contingent-two a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """The best volume estimate of petroleum quantities, as of a given date, to be potentially recoverable from known accumulations by application of development projects, but which are not currently considered to be commercially recoverable owing to one or more contingencies. The best estimate corresponding to the most probable fully recoverable volume.
+    
+    The best estimate deemed to be potentially correct but with caveats on related influences and applicability."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Contingent - Best Estimate"@en ;
+    skos:notation "2C" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:broader qcon:contingent .
+
+qcon:contingent-three a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """The high-range volume estimate of petroleum quantities, as of a given date, to be potentially recoverable from known accumulations by application of development projects, but which are not currently considered to be commercially recoverable owing to one or more contingencies. The high volume corresponding to a lower probability that the full volume is recoverable.
+    
+    A high-range estimate deemed to be potentially correct but with caveats on related influences and applicability."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Contingent - High Estimate"@en ;
+    skos:notation "3C" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:broader qcon:contingent .
+
+qcon:high a skos:Concept ;
+    skos:altLabel "Likely"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 66-100% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "High"@en ;
+    skos:notation "H" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:high-v a skos:Concept ;
+    skos:altLabel "Very Likely"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 90-100% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Very High"@en ;
+    skos:notation "VH" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:high-e a skos:Concept ;
+    skos:altLabel "Extremely Likely"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 95-100% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Extremely High"@en ;
+    skos:notation "EH" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:high-u a skos:Concept ;
+    skos:altLabel "Virtually Certain"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 99-100% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Ultra High"@en ;
+    skos:notation "UH" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:indicated a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """A part of a mineral resource for which quantity, grade, densities, shape, and physical characteristics are estimated with confidence sufficient to allow application of modifying factors to support preliminary mine planning and evaluation of the economic viability of the deposit. - JORC
+    
+    A classification corresponding with a moderately defined confidence of primary attributes for a conclusion or interpretation but prior to consideration of modifying factors."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Indicated"@en ;
+    skos:notation "IND" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:inferred a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """A part of a mineral resource for which quantity, grade, densities, shape, and physical characteristics are estimated based on limited geological evidence and sampling. Evidence is sufficient to imply but not verify grade and continuity. - JORC
+    
+    A classification corresponding with a poorly defined confidence of primary attributes for a conclusion or interpretation prior to consideration of modifying factors."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Inferred"@en ;
+    skos:notation "INF" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:low a skos:Concept ;
+    skos:altLabel "Unlikely"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 0-33% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Low"@en ;
+    skos:notation "L" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:low-v a skos:Concept ;
+    skos:altLabel "Very Unlikely"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 0-10% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Very Low"@en ;
+    skos:notation "VL" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:low-e a skos:Concept ;
+    skos:altLabel "Extremely Unlikely"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 95-100% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Extremely Low"@en ;
+    skos:notation "EL" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:low-u a skos:Concept ;
+    skos:altLabel "Exceptionally Unlikely"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication of 0-1% probability that an interpretation is accurate or outcome will occur."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Ultra Low"@en ;
+    skos:notation "UL" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:measured a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """A part of a mineral resource for which quantity, grade, densities, shape, and physical characteristics are estimated with confidence sufficient to allow application of modifying factors to support detailed mine planning and final evaluation of the economic viability of the deposit. - JORC
+    
+    A classification corresponding with a well defined confidence of primary attributes for a conclusion or interpretation but prior to consideration of modifying factors."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Measured"@en ;
+    skos:notation "MEA" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:moderate a skos:Concept ;
+    skos:altLabel "About As Likely As Not"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition "An indication of 33-66% probability that an interpretation is accurate or outcome will occur."@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:prefLabel "Moderate"@en ;
+    skos:notation "M" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:possible a skos:Concept ;
+    skos:altLabel "3P Reserves"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An incremental category of estimated recoverable quantities associated with a defined degree of uncertainty. Possible Reserves are those additional reserves that analysis of geoscience and engineering data suggest are less likely to be recoverable than Probable Reserves. The total quantities ultimately recovered from the project have a low probability to exceed the sum of Proved plus Probable plus Possible (3P), which is equivalent to the high estimate scenario. When probabilistic methods are used, there should be at least a 10% probability that the actual quantities recovered will equal or exceed the 3P estimate. - PRMS
+        
+    A classification corresponding with a low feasible level of confidence for a conclusion or interpretation."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Possible"@en ;
+    skos:notation "3P" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:probable a skos:Concept ;
+    skos:altLabel "2P Reserves"@en,
+        "More likely than not"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An incremental category of estimated recoverable quantities associated with a defined degree of uncertainty. Probable Reserves are those additional Reserves that are less likely to be recovered than Proved Reserves but more certain to be recovered than Possible Reserves. It is equally likely that actual remaining quantities recovered will be greater than or less than the sum of the estimated Proved plus Probable Reserves (2P). In this context, when probabilistic methods are used, there should be at least a 50% probability that the actual quantities recovered will equal or exceed the 2P estimate. - PRMS
+    
+    A Probable Ore Reserve has a lower level of confidence than a Proved Ore Reserve but is of sufficient quality to serve as the basis for a decision on the development of the deposit. - JORC
+    
+    A classification corresponding with a moderate level of confidence for a conclusion or interpretation, or where the statement is more likely than not to be true (50-100%)."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Probable"@en ;
+    skos:notation "2P" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:prospective a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """Those quantities of petroleum estimated, as of a given date, to be potentially recoverable from undiscovered accumulations by application of future development projects.
+    
+    A speculative estimate with caveats on related influences or applicability, and without an assessment of risk."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Prospective"@en ;
+    skos:notation "U" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:prospective-one a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """The low-range volume estimate of unrisked petroleum quantities estimated, as of a given date, to be potentially recoverable from undiscovered accumulations by application of future development projects. The low volume corresponding to a higher probability that the full volume is present.
+    
+    A speculative low-range estimate with caveats on related influences or applicability, and without an assessment of risk."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Prospective - Low Estimate"@en ;
+    skos:notation "1U" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:broader qcon:prospective .
+
+qcon:prospective-two a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """The best volume estimate of unrisked petroleum quantities estimated, as of a given date, to be potentially recoverable from undiscovered accumulations by application of future development projects. The best estimate corresponding to the most probable volume.
+    
+    A speculative best estimate with caveats on related influences or applicability, and without an assessment of risk."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Prospective - Best Estimate"@en ;
+    skos:notation "2U" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:broader qcon:prospective .
+
+qcon:prospective-three a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """The high-range volume estimate of unriskedpetroleum quantities estimated, as of a given date, to be potentially recoverable from undiscovered accumulations by application of future development projects. The high volume corresponding to a lower probability that the full volume is present.
+    
+    A speculative high-range estimate with caveats on related influences or applicability, and without an assessment of risk."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Prospective - High Estimate"@en ;
+    skos:notation "3U" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:broader qcon:prospective .
+
+qcon:proved a skos:Concept ;
+    skos:altLabel "Proven"@en,
+        "1P Reserves"@en ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An incremental category of estimated recoverable volumes associated with a defined degree of uncertainty Proved Reserves are those quantities of petroleum which, by analysis of geoscience and engineering data, can be estimated with reasonable certainty to be commercially recoverable, from a given date forward, from known reservoirs and underdefined economic conditions, operating methods, and government regulations. If deterministic methods are used, the term reasonable certainty is intended to express a high degree of confidence that the quantities will be recovered. If probabilistic methods are used, there should be at least a 90% probability that the quantities actually recovered will equal or exceed the estimate. Often referred to as 1P, also as Proven. - PRMS
+    
+    The highest confidence category of ore reserve estimate and implies a high degree of confidence in geological and grade continuity, and the consideration of the modifying factors. The sytle of mineralisation or other factors could mean that Proved Ore Reserves are not achieveable in some deposits. - JORC
+    
+    A classification corresponding with the highest feasible level of confidence for a conclusion or interpretation."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:prefLabel "Proved"@en ;
+    skos:notation "1P" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+qcon:uncertain a skos:Concept ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:definition """An indication that an interpretation is the best available based on current evidence but with significant uncertainty."""@en ;
+    prov:wasDerivedFrom <http://linked.data.gov.au/org/gsq> ;
+    skos:prefLabel "Uncertain"@en ;
+    skos:notation """?""" ;
+    skos:inScheme <http://linked.data.gov.au/def/qualitative-confidence> ;
+    skos:topConceptOf <http://linked.data.gov.au/def/qualitative-confidence> .
+
+
+
+qcon:chronage a skos:Collection ;
+    skos:prefLabel "Chronotstratigraphic Age Confidence"@en ;
+    prov:wasDerivedFrom <http://linked.data.gov.au/org/gsq> ;
+    skos:definition """Confidence categories for the determination of assigned ages as per the International Chronostratigraphic Chart."""@en ;
+    skos:member
+        qcon:uncertain,
+        qcon:approximate .
+
+qcon:jorc a skos:Collection ;
+    skos:prefLabel "Joint Ore Reserves Committee Classification"@en ;
+    skos:definition """Confidence categories for Mineral Resources and Ore Reserves as defined by the JORC classification framework."""@en ;
+    prov:wasDerivedFrom <https://www.jorc.org/docs/jorc_code2012.pdf> ;
+    skos:member
+        qcon:proved,
+        qcon:probable,
+        qcon:measured,
+        qcon:indicated,
+        qcon:inferred .
+
+qcon:prms a skos:Collection ;
+    skos:prefLabel "Petroleum Resources Management System Classifications"@en ;
+    skos:definition """Confidence categories for Petroleum Resource and Reserve Management as defined by the PRMS classification framework."""@en ;
+    prov:wasDerivedFrom <https://www.spe.org/en/industry/petroleum-resources-management-system-2018/> ;
+    skos:member
+        qcon:proved,
+        qcon:probable,
+        qcon:possible,
+        qcon:contingent-one,
+        qcon:contingent-two,
+        qcon:contingent-three,
+        qcon:prospective-one,
+        qcon:prospective-two,
+        qcon:prospective-three .
+
+qcon:likelihood a skos:Collection ;
+    skos:prefLabel "Likelihood Scale"@en ;
+    skos:definition """Confidence categories based on probability of outcome."""@en ;
+    prov:wasDerivedFrom <https://www.ipcc.ch/site/assets/uploads/2017/08/AR5_Uncertainty_Guidance_Note.pdf> ;
+    skos:member
+        qcon:high-u,
+        qcon:high-e,
+        qcon:high-v,
+        qcon:high,
+        qcon:moderate,
+        qcon:probable,
+        qcon:low,
+        qcon:low-v,
+        qcon:low-e,
+        qcon:low-u .
+
+qcon:georelationships a skos:Collection ;
+    skos:prefLabel "Geological Relationship Confidence"@en ;
+    skos:definition """Confidence associated with the relationship between geological features."""@en ;
+    skos:member
+        qcon:proved,
+        qcon:probable,
+        qcon:possible.

--- a/vocabularies-gsq/site-relationships.ttl
+++ b/vocabularies-gsq/site-relationships.ttl
@@ -10,7 +10,7 @@
 <http://linked.data.gov.au/def/site-relationships> a owl:Ontology , skos:ConceptScheme ;
     dcterms:creator <http://linked.data.gov.au/org/gsq> ;
     dcterms:created "2020-01-21"^^xsd:date ;
-    dcterms:modified "2022-02-17"^^xsd:date ;
+    dcterms:modified "2022-09-20"^^xsd:date ;
     dcterms:publisher <http://linked.data.gov.au/org/gsq> ;
     dcterms:provenance "Compiled by the Geological Survey of Queensland" ;
     skos:definition """The relationships between sites both topological and functional. See https://pro.arcgis.com/en/pro-app/latest/tool-reference/big-data-analytics/spatial-relationships-with-big-data.htm for visual representations of spatial relationships."""@en ;


### PR DESCRIPTION
New vocabularies to support LPX+ @LukeHauck @GSQ-AI 
Have also rolled in your alias edits @johnmckellar 


[Geological Properties (gsq.digital)](https://vocabs.uat.gsq.digital/object?uri=http://linked.data.gov.au/def/geological-properties) - This is just a starting point for SRA to point to

[Qualitative Confidence (gsq.digital)](https://vocabs.uat.gsq.digital/object?uri=http://linked.data.gov.au/def/qualitative-confidence) - a look up for qualitative confidence

[Site Relationship - Wellbore Collection (gsq.digital)](https://vocabs.uat.gsq.digital/object?uri=http%3A//linked.data.gov.au/def/site-relationships/wellbore) - addition of collection for wellbores for LPX+. After this has passed review, @johnmckellar please submit a new pull request with updates for geological relationships as per our recent discussion.

[GSQ Alias (gsq.digital)](https://vocabs.uat.gsq.digital/object?uri=http://linked.data.gov.au/def/gsq-alias) - as per previous edits by @johnmckellar to support rock unit migration