### PR TITLE
Update geounits.ttl

### DIFF
--- a/vocabularies-gsq/geounits.ttl
+++ b/vocabularies-gsq/geounits.ttl
@@ -122,7 +122,7 @@
         <http://qudt.org/vocab/unit/GAL_US>,
         <http://qudt.org/vocab/unit/GM>,
         <http://qudt.org/vocab/unit/GM-PER-CentiM3>,
-	<http://qudt.org/vocab/unit/GM-PER-M3>
+	<http://qudt.org/vocab/unit/GM-PER-M3>,
         <http://qudt.org/vocab/unit/GRAD>,
         <http://qudt.org/vocab/unit/G_REL>,
         <http://qudt.org/vocab/unit/GigaBYTE>,

--- a/vocabularies-gsq/geounits.ttl
+++ b/vocabularies-gsq/geounits.ttl
@@ -2211,7 +2211,7 @@ geou:resource-grade-quality a skos:Collection ;
         geou:OZ-PER-TON_M,
         <http://qudt.org/vocab/unit/PPB>,
         <http://qudt.org/vocab/unit/PPM>,
-	<http://qudt.org/vocab/unit/CARAT-PER-M3>,
+	geou:CARAT-PER-M3,
 	<http://qudt.org/vocab/unit/GM-PER-M3>,
 	<http://qudt.org/vocab/unit/KiloGM-PER-M3>,
         geou:PERCENT-PER-VOL,

--- a/vocabularies-gsq/geounits.ttl
+++ b/vocabularies-gsq/geounits.ttl
@@ -105,6 +105,7 @@
         <http://qudt.org/vocab/unit/BTU_IT>,
         <http://qudt.org/vocab/unit/BYTE>,
         <http://qudt.org/vocab/unit/CARAT>,
+	<http://qudt.org/vocab/unit/CARAT-PER-M3>,
         <http://qudt.org/vocab/unit/CentiM3>,
         <http://qudt.org/vocab/unit/CentiP>,
         <http://qudt.org/vocab/unit/DAY>,
@@ -121,6 +122,7 @@
         <http://qudt.org/vocab/unit/GAL_US>,
         <http://qudt.org/vocab/unit/GM>,
         <http://qudt.org/vocab/unit/GM-PER-CentiM3>,
+	<http://qudt.org/vocab/unit/GM-PER-M3>
         <http://qudt.org/vocab/unit/GRAD>,
         <http://qudt.org/vocab/unit/G_REL>,
         <http://qudt.org/vocab/unit/GigaBYTE>,
@@ -1173,6 +1175,25 @@ geou:TROYOZ a skos:Concept ;
     skos:prefLabel "Carat"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/geou> .
 
+<http://qudt.org/vocab/unit/CARAT-PER-M3> a skos:Concept ;
+    skos:altLabel "Carat per metre cubed"@en,
+        "Carat per cubic metre"@en,
+        "CARAT PER CUBIC METRE"@en,
+        "CARAT PER METRE CUBED"@en,
+        "Carats per metre cubed"@en,
+        "Carats per cubic metre"@en,
+        "CARATS PER CUBIC METRE"@en,
+        "CARATS PER METRE CUBED"@en ;
+    skos:hiddenLabel "CARATS PER CUBIC METRE (ct/m3)"@en,
+        "CARATS PER METRE CUBED (ct/m3)"@en ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+    skos:definition "Carat per cubic metre is a derived unit of density, defined by mass in carats divided by volume in cubic metres. The symbolic abbreviation is \\(ct \\cdot m^{-3}\\), or equivalently either \\(ct/m^3\\)."@en ;
+    skos:notation "ct/m3" ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
+    skos:inScheme <http://linked.data.gov.au/def/geou> ;
+    skos:prefLabel "Carat per Cubic Meter"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geou> .
+
 <http://qudt.org/vocab/unit/CentiM3> a skos:Concept ;
     skos:altLabel "Cubic Centimetre"@en,
         "Centimetre Cubed"@en ;
@@ -1353,6 +1374,25 @@ geou:TROYOZ a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
     skos:inScheme <http://linked.data.gov.au/def/geou> ;
     skos:prefLabel "gram per centimetre cubed"@en ;
+    skos:topConceptOf <http://linked.data.gov.au/def/geou> .
+
+<http://qudt.org/vocab/unit/GM-PER-M3> a skos:Concept ;
+    skos:altLabel "Gram per metre cubed"@en,
+        "Gram per cubic metre"@en,
+        "GRAM PER CUBIC METRE"@en,
+        "GRAM PER METRE CUBED"@en,
+        "Grams per metre cubed"@en,
+        "Grams per cubic metre"@en,
+        "GRAMS PER CUBIC METRE"@en,
+        "GRAMS PER METRE CUBED"@en ;
+    skos:hiddenLabel "GRAMS PER CUBIC METRE (g/m3)"@en,
+        "GRAMS PER METRE CUBED (g/m3)"@en ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+    skos:definition "Gram per cubic metre is an SI derived unit of density, defined by mass in grams divided by volume in cubic metres. The official SI symbolic abbreviation is \\(g \\cdot m^{-3}\\), or equivalently either \\(g/m^3\\)."@en ;
+    skos:notation "g/m3" ;
+    rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
+    skos:inScheme <http://linked.data.gov.au/def/geou> ;
+    skos:prefLabel "Gram per Cubic Meter"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/geou> .
 
 <http://qudt.org/vocab/unit/GRAD> a skos:Concept ;
@@ -2171,6 +2211,9 @@ geou:resource-grade-quality a skos:Collection ;
         geou:OZ-PER-TON_M,
         <http://qudt.org/vocab/unit/PPB>,
         <http://qudt.org/vocab/unit/PPM>,
+	<http://qudt.org/vocab/unit/CARAT-PER-M3>,
+	<http://qudt.org/vocab/unit/GM-PER-M3>,
+	<http://qudt.org/vocab/unit/KiloGM-PER-M3>,
         geou:PERCENT-PER-VOL,
         geou:PERCENT-PER-WEIGHT,
         <http://qudt.org/vocab/unit/UNITLESS> ;

--- a/vocabularies-gsq/geounits.ttl
+++ b/vocabularies-gsq/geounits.ttl
@@ -96,6 +96,7 @@
         geou:SHOTS-PER-M,
         geou:TOC,
         geou:TROYOZ,
+	geou:CARAT-PER-M3,
         <http://qudt.org/vocab/unit/ARCMIN>,
         <http://qudt.org/vocab/unit/ARCSEC>,
         <http://qudt.org/vocab/unit/ATM>,
@@ -105,7 +106,6 @@
         <http://qudt.org/vocab/unit/BTU_IT>,
         <http://qudt.org/vocab/unit/BYTE>,
         <http://qudt.org/vocab/unit/CARAT>,
-	<http://qudt.org/vocab/unit/CARAT-PER-M3>,
         <http://qudt.org/vocab/unit/CentiM3>,
         <http://qudt.org/vocab/unit/CentiP>,
         <http://qudt.org/vocab/unit/DAY>,
@@ -1175,7 +1175,7 @@ geou:TROYOZ a skos:Concept ;
     skos:prefLabel "Carat"@en ;
     skos:topConceptOf <http://linked.data.gov.au/def/geou> .
 
-<http://qudt.org/vocab/unit/CARAT-PER-M3> a skos:Concept ;
+geou:CARAT-PER-M3 a skos:Concept ;
     skos:altLabel "Carat per metre cubed"@en,
         "Carat per cubic metre"@en,
         "CARAT PER CUBIC METRE"@en,
@@ -1186,7 +1186,7 @@ geou:TROYOZ a skos:Concept ;
         "CARATS PER METRE CUBED"@en ;
     skos:hiddenLabel "CARATS PER CUBIC METRE (ct/m3)"@en,
         "CARATS PER METRE CUBED (ct/m3)"@en ;
-    rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+    rdfs:isDefinedBy geou: ;
     skos:definition "Carat per cubic metre is a derived unit of density, defined by mass in carats divided by volume in cubic metres. The symbolic abbreviation is \\(ct \\cdot m^{-3}\\), or equivalently either \\(ct/m^3\\)."@en ;
     skos:notation "ct/m3" ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;


### PR DESCRIPTION
Adding concepts; grams per cubic metre (<http://qudt.org/vocab/unit/GM-PER-M3>), carats per cubic metre (geou:CARAT-PER-M3) Including concepts to resource-grade-quality collection for use in minerals production statistics reports in the lodgement portal;
	geou:CARAT-PER-M3,
	<http://qudt.org/vocab/unit/GM-PER-M3>,
	<http://qudt.org/vocab/unit/KiloGM-PER-M3>,