### PR TITLE
Update georesources-report-types.ttl

### DIFF
--- a/vocabularies-gsq/georesources-report-types.ttl
+++ b/vocabularies-gsq/georesources-report-types.ttl
@@ -619,7 +619,7 @@ grt:permit-report-partial-relinquishment-higher-tenure
     skos:definition "A report detailing all the activities a holder has undertaken on a specific region of an exploration permit that has been relinquished upon grant of a higher tenure. As required by the Mineral Resources Act and as defined by the Practice Direction. Required under the Queensland Mineral Resources Regulation 2013, s16 and s29B."@en ;
     skos:inScheme <https://linked.data.gov.au/def/georesource-report> ;
     skos:notation "RELINQHT" ;
-    skos:prefLabel "Coal or Mineral Permit Report - Partial Relinquishment (Grant of higher tenure)"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Partial Relinquishment (Grant of higher tenure)(EPC/EPM)"@en ;
     skos:topConceptOf <https://linked.data.gov.au/def/georesource-report> ;
 .
 
@@ -883,7 +883,7 @@ grt:permit-report-surrender-higher-tenure
     skos:definition "A report that is required to be lodged as a part of the obligations of surrendering tenure over a Coal or Oil Shale Mining Lease or Mineral Development Licence upon grant of a higher tenure. Required under the Queensland Mineral Resources Regulation 2013, s16 and s29C"@en ;
     skos:inScheme <https://linked.data.gov.au/def/georesource-report> ;
     skos:notation "SURRHT" ;
-    skos:prefLabel "Coal or Mineral Permit Report - Surrender (Grant of higher tenure)"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Partial Surrender (Grant of higher tenure)(MDL/ML)"@en ;
     skos:topConceptOf <https://linked.data.gov.au/def/georesource-report> ;
 .
 
@@ -1200,7 +1200,7 @@ grt:permit-report-partial-relinquishment
     skos:definition "A report detailing all the activities a holder has undertaken on a specific region of an exploration permit that has been relinquished where a higher tenure over the same area has not been granted. As required by the Mineral Resources Act and as defined by the Practice Direction. Required under the Queensland Mineral Resources Regulation 2013, s16 and s29B."@en ;
     skos:inScheme <https://linked.data.gov.au/def/georesource-report> ;
     skos:notation "RELINQ" ;
-    skos:prefLabel "Coal or Mineral Permit Report - Partial Relinquishment (End of Tenure)"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Partial Relinquishment (End of Tenure)(EPC/EPM)"@en ;
     skos:topConceptOf <https://linked.data.gov.au/def/georesource-report> ;
 .
 
@@ -1392,7 +1392,7 @@ grt:permit-report-surrender
     skos:definition "A report that is required to be lodged as a part of the obligations of surrendering tenure over a Coal or Oil Shale Mining Lease or Mineral Development Licence where a higher tenure over the same area has not been granted. Required under the Queensland Mineral Resources Regulation 2013, s16 and s29C."@en ;
     skos:inScheme <https://linked.data.gov.au/def/georesource-report> ;
     skos:notation "SURR" ;
-    skos:prefLabel "Coal or Mineral Permit Report - Surrender (End of Tenure)"@en ;
+    skos:prefLabel "Coal or Mineral Permit Report - Partial Surrender (End of Tenure)(MDL/ML)"@en ;
     skos:topConceptOf <https://linked.data.gov.au/def/georesource-report> ;
 .
 


### PR DESCRIPTION
To reduce risk of lodging reports under incorrect report types, L1 requests the below changes to be made - added as **BOLD**:

- Coal or Mineral Permit Report – Partial Relinquishment (End of tenure) **(EPC, EPM)**
- Coal or Mineral Permit Report – Partial Relinquishment (Grant of higher tenure) **(EPC, EPM)**
- Coal or Mineral Permit Report – **Partial** Surrender (End of tenure) **(MDL, ML)**
- Coal or Mineral Permit Report – **Partial** Surrender (Grant of higher tenure) **(MDL, ML)**

See details here: https://itp-qld.atlassian.net/browse/SUP-121