### PR TITLE
Update borehole-status.ttl with correct vocab derivation mode namespace

### DIFF
--- a/vocabularies-gsq/borehole-status.ttl
+++ b/vocabularies-gsq/borehole-status.ttl
@@ -2,6 +2,7 @@ PREFIX : <http://linked.data.gov.au/def/borehole-status/>
 PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <http://linked.data.gov.au/def/borehole-status>
 PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX mode: <https://linked.data.gov.au/def/vocdermods/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -325,7 +326,7 @@ cs:
     dcterms:publisher <https://linked.data.gov.au/org/gsq> ;
     prov:qualifiedDerivation [
         prov:entity <http://linked.data.gov.au/def/site-status> ;
-        prov:hadRole <http://linked.data.gov.au/def/vocab-derivation-modes/subsetting-and-extension> ;
+        prov:hadRole mode:subsetting-and-extension ;
     ] ;
     reg:status agldwgstatus:experimental ;
     skos:definition "The operational situation of a Borehole, also known as a Drillhole or a Wellbore. These statuses also apply to Bores or Wells that may be made of multiple Boreholes or Wellbores."@en ;


### PR DESCRIPTION
Fixes usage of vocab derivation mode using wrong namespace.

See the repo of vocab derivation mode vocab: https://github.com/AGLDWG/vocab-derivation-modes
Online at PID: https://linked.data.gov.au/def/vocdermods