### PR TITLE
Add release and prerelease workflows to upload data to database

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,6 +11,7 @@ jobs:
   publish:
     uses: geological-survey-of-queensland/vocabularies/.github/workflows/upload_to_database.yml@master
     with:
+      environment: uat
       request_timeout: ${{ env.REQUEST_TIMEOUT }}
     secrets:
       database_url: ${{ secrets.FUSEKI_DATASET_URL }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,8 +1,8 @@
-name: Upload data to UAT database on release
+name: Upload data to UAT database on prerelease
 
 on:
   release:
-    types: [released]
+    types: [prereleased]
 
 env:
   REQUEST_TIMEOUT: 300

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Upload data to UAT database on release
+name: Upload data to production database on release
 
 on:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Publish vocabularies to production database
+
+on:
+  release:
+    types: [released]
+
+env:
+  PYTHON_VERSION: "3.11"
+  REQUEST_TIMEOUT: "300"
+
+  # GitHub Actions secrets
+  FUSEKI_DATASET_URL: ${{ secrets.FUSEKI_DATASET_URL }}
+  FUSEKI_USERNAME: ${{ secrets.FUSEKI_USERNAME }}
+  FUSEKI_PASSWORD: ${{ secrets.FUSEKI_PASSWORD }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Use Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - run: pip install https://github.com/Kurrawong/kurrawong-python/archive/refs/tags/0.1.1.zip
+
+      - name: Upload vocabularies
+        run: |
+          kurra fuseki upload vocabularies-des ${{ env.FUSEKI_DATASET_URL }} -u ${{ env.FUSEKI_USERNAME }} -p ${{ env.FUSEKI_PASSWORD }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-external ${{ env.FUSEKI_DATASET_URL }} -u ${{ env.FUSEKI_USERNAME }} -p ${{ env.FUSEKI_PASSWORD }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-gsq ${{ env.FUSEKI_DATASET_URL }} -u ${{ env.FUSEKI_USERNAME }} -p ${{ env.FUSEKI_PASSWORD }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-qldgov ${{ env.FUSEKI_DATASET_URL }} -u ${{ env.FUSEKI_USERNAME }} -p ${{ env.FUSEKI_PASSWORD }} -t ${{ env.REQUEST_TIMEOUT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   publish:
     uses: geological-survey-of-queensland/vocabularies/.github/workflows/upload_to_database.yml@master
     with:
+      environment: production
       request_timeout: ${{ env.REQUEST_TIMEOUT }}
     secrets:
       database_url: ${{ secrets.FUSEKI_DATASET_URL }}

--- a/.github/workflows/upload_to_database.yml
+++ b/.github/workflows/upload_to_database.yml
@@ -1,4 +1,4 @@
-name: Upload data to RDF database
+name: Upload data to database
 
 on:
   workflow_call:
@@ -36,6 +36,6 @@ jobs:
       - name: Upload vocabularies
         run: |
           kurra fuseki upload vocabularies-des ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
-          kurra fuseki upload vocabularies-external${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-external$ {{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
           kurra fuseki upload vocabularies-gsq ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
           kurra fuseki upload vocabularies-qldgov ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}

--- a/.github/workflows/upload_to_database.yml
+++ b/.github/workflows/upload_to_database.yml
@@ -1,0 +1,41 @@
+name: Upload data to RDF database
+
+on:
+  workflow_call:
+    inputs:
+      request_timeout:
+        required: false
+        type: number
+    secrets:
+      database_url:
+        required: true
+      database_username:
+        required: true
+      database_password:
+        required: true
+
+env:
+  PYTHON_VERSION: "3.11"
+  REQUEST_TIMEOUT: ${{ inputs.request_timeout }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Use Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - run: pip install https://github.com/Kurrawong/kurrawong-python/archive/refs/tags/0.1.1.zip
+
+      - name: Upload vocabularies
+        run: |
+          kurra fuseki upload vocabularies-des ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-external${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-gsq ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-qldgov ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}

--- a/.github/workflows/upload_to_database.yml
+++ b/.github/workflows/upload_to_database.yml
@@ -3,6 +3,9 @@ name: Upload data to database
 on:
   workflow_call:
     inputs:
+      environment:
+        required: true
+        type: string
       request_timeout:
         required: false
         type: number
@@ -21,6 +24,7 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
 
     steps:
       - name: Checkout the repo

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  PYTHON_VERSION: "3.11"
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -15,10 +18,10 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v3
 
-      - name: Use Python 3.11
+      - name: Use Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt


### PR DESCRIPTION
This PR creates a reusable parametrised `workflow_call` in `upload_to_database.yml`.

The `upload_to_database.yml` is then called by `prerelease.yml` or `release.yml` when the `release` event is triggered. The `release` event is triggered when a repository administrator creates a new release, and ticks either `pre-release` or `release`. See [creating a release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) for more information.

To use these new workflows, an administrator of the repository must create [environment secrets](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets) with the following secret names:
- `FUSEKI_DATASET_URL` - Fuseki dataset URL for the GSQ vocabularies
- `FUSEKI_USERNAME` - Fuseki username
- `FUSEKI_PASSWORD` - Fuseki password