### PR TITLE
Add purge prez cache step and remove indirection for request_timeout

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,6 +11,7 @@ jobs:
       environment: uat
       request_timeout: 300
     secrets:
+      prez_url: ${{ secrets.PREZ_URL }}
       database_url: ${{ secrets.FUSEKI_DATASET_URL }}
       database_username: ${{ secrets.FUSEKI_USERNAME }}
       database_password: ${{ secrets.FUSEKI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
       environment: production
       request_timeout: 300
     secrets:
+      prez_url: ${{ secrets.PREZ_URL }}
       database_url: ${{ secrets.FUSEKI_DATASET_URL }}
       database_username: ${{ secrets.FUSEKI_USERNAME }}
       database_password: ${{ secrets.FUSEKI_PASSWORD }}

--- a/.github/workflows/upload_to_database.yml
+++ b/.github/workflows/upload_to_database.yml
@@ -7,9 +7,11 @@ on:
         required: true
         type: string
       request_timeout:
-        required: false
+        required: true
         type: number
     secrets:
+      prez_url:
+        required: true
       database_url:
         required: true
       database_username:
@@ -19,7 +21,6 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  REQUEST_TIMEOUT: ${{ inputs.request_timeout }}
 
 jobs:
   publish:
@@ -39,7 +40,10 @@ jobs:
 
       - name: Upload vocabularies
         run: |
-          kurra fuseki upload vocabularies-des ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
-          kurra fuseki upload vocabularies-external ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
-          kurra fuseki upload vocabularies-gsq ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
-          kurra fuseki upload vocabularies-qldgov ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ env.REQUEST_TIMEOUT }}
+          kurra fuseki upload vocabularies-des ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ inputs.request_timeout }}
+          kurra fuseki upload vocabularies-external ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ inputs.request_timeout }}
+          kurra fuseki upload vocabularies-gsq ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ inputs.request_timeout }}
+          kurra fuseki upload vocabularies-qldgov ${{ secrets.database_url }} -u ${{ secrets.database_username }} -p ${{ secrets.database_password }} -t ${{ inputs.request_timeout }}
+
+      - name: Purge Prez cache
+        run: curl -fsSL ${{ secrets.prez_url }}


### PR DESCRIPTION
### Prez purge cache

When updating the database for prerelease or release, the workflow will make a request to Prez to purge the in-memory cache. This ensures things such as labels in Prez stay fresh and up to date with the contents in the database.

**Action required by repo admin**: Add the `PREZ_URL` secret to each environment.

---

### Remove variable indirection

The indirection from `request_timeout` to an environment variable `REQUEST_TIMEOUT` has been removed. The `publish` job just uses `input.request_timeout` directly.