### PR TITLE
Update europa-file-type.ttl

### DIFF
--- a/vocabularies-gsq/europa-file-type.ttl
+++ b/vocabularies-gsq/europa-file-type.ttl
@@ -45,6 +45,7 @@ qgft:des-file-types
         <http://publications.europa.eu/resource/authority/file-type/KML> ,
         <http://publications.europa.eu/resource/authority/file-type/KMZ> ,
         <http://publications.europa.eu/resource/authority/file-type/MDB> ,
+        <http://publications.europa.eu/resource/authority/file-type/MPEG4_AVC>,
         <http://publications.europa.eu/resource/authority/file-type/NETCDF> ,
         <http://linked.data.gov.au/def/qg-file-types/PARQUET> ,
         <http://publications.europa.eu/resource/authority/file-type/PDF> ,


### PR DESCRIPTION
Users have requested that we include a video format in the resource file type. Proposing to include existing MPEG4_AVC for DES list. [SDOS-](https://it-partners.atlassian.net/browse/SDOS-261)