### PR TITLE
Remove Extractives Statistical reporting from visibility in LP - Update georesources-report-types.ttl

### DIFF
--- a/vocabularies-gsq/georesources-report-types.ttl
+++ b/vocabularies-gsq/georesources-report-types.ttl
@@ -133,7 +133,6 @@ grt:lodgement-portal-internal
         grt:collaborative-exploration-initiative-proposals ,
         grt:commissioned-industry-study-or-report ,
         grt:departmental-drilling ,
-        grt:extractives-annual-statistics ,
         grt:geological-survey-of-queensland-publication ,
         grt:geological-survey-of-queensland-record ,
         grt:geophysical-survey-report-final ,
@@ -212,7 +211,6 @@ grt:lodgement-portal-reports
     skos:definition "Reports accepted by the DNRME Geoscience Open Data Portal Lodgement site."@en ;
     skos:member
         grt:coal-quarterly-statistics ,
-        grt:extractives-annual-statistics ,
         grt:geophysical-survey-report-final ,
         grt:geothermal-end-tenure ,
         grt:geothermal-report-annual-reserves ,


### PR DESCRIPTION
Extractives Statistics should not be visible on public and internal LP