### PR TITLE
Update survey-relationship-type.ttl

### DIFF
--- a/vocabularies-gsq/survey-relationship-type.ttl
+++ b/vocabularies-gsq/survey-relationship-type.ttl
@@ -59,21 +59,21 @@ srt:repeat
     skos:prefLabel "Repeat"@en ;
 .
 
-srt:reprocessed
+srt:reprocessing
     a skos:Concept ;
     skos:historyNote "Developed by the Geological Survey of Queensland." ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "The original entity from which a new digital sample was created by reprocessing."@en ;
+    skos:definition "The relationship type applied to a related reprocessed survey to indicate that survey is the reprocessing job. Only used for related surveys within an original survey record to identify a related reprocessed survey."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Reprocessed"@en ;
     skos:topConceptOf cs: ;
 .
 
-srt:reprocessing
+srt:reprocessed-from
     a skos:Concept ;
     skos:historyNote "Developed by the Geological Survey of Queensland." ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "Generating a new digital sample by reprocessing pre-existing raw data with a new algorithm or processing parameters."@en ;
+    skos:definition "The relationship type applied to a related original survey to indicate that survey is an original acquisition. Only used for related surveys within a reprocessing survey record to identify the original survey(s) utilised in the reprocessing job."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Reprocessing"@en ;
     skos:topConceptOf cs: ;

--- a/vocabularies-gsq/survey-relationship-type.ttl
+++ b/vocabularies-gsq/survey-relationship-type.ttl
@@ -59,6 +59,16 @@ srt:repeat
     skos:prefLabel "Repeat"@en ;
 .
 
+srt:reprocessed
+    a skos:Concept ;
+    skos:historyNote "Developed by the Geological Survey of Queensland." ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "The original entity from which a new digital sample was created by reprocessing."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "Reprocessed"@en ;
+    skos:topConceptOf cs: ;
+.
+
 srt:reprocessing
     a skos:Concept ;
     skos:historyNote "Developed by the Geological Survey of Queensland." ;


### PR DESCRIPTION
In GeoProps, we can only link seismic surveys one-way with "Reprocessing" i.e. In the case where Survey 3 is a reprocessing of Survey 1 and Survey 2, the related survey records in GeoProps for Surveys 1 and 2 would both indicate that Survey 3 is a reprocessing.

However, there is no relevant option to update Survey 3 to indicate that 1 and 2 are the original surveys. 

I suggest adding in "Reprocessed" so we can clearly articulate the directional link i.e. Survey 3 would be updated to indicate that Surveys 1 and 2 are related reprocessed surveys. 