### PR TITLE
Standardising Terms Across Systems

### DIFF
--- a/vocabularies-gsq/borehole-status-event.ttl
+++ b/vocabularies-gsq/borehole-status-event.ttl
@@ -79,7 +79,7 @@ bhse:decommissioning
     a skos:Concept ;
     skos:historyNote "Compiled by the Geological Survey of Queensland" ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A Notice of decommissioning a well, water observation bore, water monitoring bore or water supply bore. Lodgement of Form MMOL-44. Decommissioning refers to the act of permanently shutting-in and abandoning a borehole. This event changes the borehole status to Capped and Abandoned."@en ;
+    skos:definition "A Notice of decommissioning a well, water observation bore, water monitoring bore or water supply bore. Lodgement of Form MMOL-44. Decommissioning refers to the act of permanently shutting-in and abandoning a borehole. This event changes the borehole status to Plugged and Abandoned."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Decommissioning"@en ;
     skos:topConceptOf cs: ;

--- a/vocabularies-gsq/borehole-status-event.ttl
+++ b/vocabularies-gsq/borehole-status-event.ttl
@@ -210,7 +210,7 @@ bhse:petroleum-production-commencement
     a skos:Concept ;
     skos:historyNote "Compiled by the Geological Survey of Queensland" ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "The production of petroleum from a well or bore has been confirmed by notice (PGGD-02) or through a Petroleum Production Report as defined under of the Petroleum and Gas (General Provisions) Regulation. This changes the borehole status to on-production."@en ;
+    skos:definition "The production of petroleum from a well or bore has been confirmed by notice (PGGD-02) or through a Petroleum Production Report as defined under of the Petroleum and Gas (General Provisions) Regulation. This changes the borehole status to producing."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Commencement of Production"@en ;
     skos:topConceptOf cs: ;


### PR DESCRIPTION
Two small changes;

"Capped and Abandoned" becomes "Plugged and Abandoned" in order to coincide better with GeoProperties. The AltLabel says both are the same, but ensuring that the names are the same in both definition and system limits confusion.

"On-Production" becomes "Producing" to align the definition with other vocabularies and the terms used in GeoProperties.