### PR TITLE
Add cassiterite geocommodities

### DIFF
--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -805,6 +805,7 @@ cdt:material-directshippingore
     skos:definition "The commodities relevant, applicable, and selectable as part of the material type direct shipping ore."@en ;
     skos:member
         cdt:bauxite ,
+        cdt:cassiterite-ore ,
         cdt:hematite-ore ,
         cdt:iron-ore ,
         cdt:magnetite-ore ,
@@ -5184,6 +5185,16 @@ cdt:bauxite
     skos:prefLabel "Bauxite"@en ;
 .
 
+cdt:cassiterite-ore
+    a skos:Concept ;
+    skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader cdt:direct-shipping-ore ;
+    skos:definition "Tin oxide. Primary ore of tin."@en ;
+    skos:inScheme cs: ;
+    skos:notation "CSTO" ;
+    skos:prefLabel "Cassiterite Ore"@en ;
+.
 cdt:coking-coal
     a skos:Concept ;
     skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -5195,6 +5195,7 @@ cdt:cassiterite-ore
     skos:notation "CSTO" ;
     skos:prefLabel "Cassiterite Ore"@en ;
 .
+
 cdt:coking-coal
     a skos:Concept ;
     skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;


### PR DESCRIPTION
Adding cassiterite-ore to the geocommodities vocabulary, in the "Direct Shipping Ore" collection to cater to customer need.

The customer has differentiated their cassiterite from the existing 'cassiterite gemstone' concept, in that they are shipping this ore for the purpose of being refined to tin. 