### PR TITLE
Implement Key Resource Area Report

### DIFF
--- a/vocabularies-gsq/georesources-report-types.ttl
+++ b/vocabularies-gsq/georesources-report-types.ttl
@@ -49,6 +49,7 @@ grt:departmental-reports
         grt:geological-survey-of-queensland-publication ,
         grt:geological-survey-of-queensland-record ,
         grt:industry-consultative-report ,
+        grt:key-resource-area-report ,
         grt:presentation ,
         grt:queensland-government-mining-journal ,
         grt:soil-and-land-resources ;
@@ -293,6 +294,7 @@ grt:non-permit-reports
         grt:geological-survey-of-queensland-publication ,
         grt:geological-survey-of-queensland-record ,
         grt:industry-consultative-report ,
+        grt:key-resource-area-report ,
         grt:presentation ,
         grt:queensland-government-mining-journal ,
         grt:soil-and-land-resources ,
@@ -548,6 +550,16 @@ grt:industry-network-initiative-final
     skos:inScheme cs: ;
     skos:notation "INIFIN" ;
     skos:prefLabel "Industry Network Initiative - Final"@en ;
+    skos:topConceptOf cs: ;
+.
+
+grt:key-resource-area-report
+    a skos:Concept ;
+    skos:historyNote "Developed by the Geological Survey of Queensland." ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A report produced to describe and define the details of a Key Resource Area."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "Key Resource Area Report"@en ;
     skos:topConceptOf cs: ;
 .
 

--- a/vocabularies-gsq/georesources-report-types.ttl
+++ b/vocabularies-gsq/georesources-report-types.ttl
@@ -150,6 +150,7 @@ grt:lodgement-portal-internal
         grt:greenhouse-gas-report-storage-capacity ,
         grt:greenhouse-gas-report-storage-injection ,
         grt:hydraulic-fracturing-activity-report ,
+        grt:key-resource-area-report ,
         grt:mine-plan-lodgement ,
         grt:minerals-annual-statistics ,
         grt:mmol-44 ,


### PR DESCRIPTION
Changing report types to include "key-resource-area-reports", change made in conjunction with changes to reportTemplates.json:
https://github.com/geological-survey-of-queensland/gsq-lodgement-portal/blob/addingKRAreports/scripts/reportTemplates.json

Key Resource Area Reports sit in the non-permit reports and department-reports vocabulary collections, for internal display only and to separate from the required spatial components. Could be updated in the future to make .shp files describing boundaries of each KRA mandatory.