### PR TITLE
Fix missing top Concepts

### DIFF
--- a/vocabularies-gsq/rock-unit-rank.ttl
+++ b/vocabularies-gsq/rock-unit-rank.ttl
@@ -1,70 +1,18 @@
+PREFIX : <https://linked.data.gov.au/def/rock-unit-rank/>
 PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/rock-unit-rank>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX geof: <https://linked.data.gov.au/def/geofeatures/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
-PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX rur: <https://linked.data.gov.au/def/rock-unit-rank/>
 PREFIX sdo: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-rur:Assemblage
+:CalderaComplex
     a skos:Concept ;
-    skos:historyNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A group of two or more related tectonometamorphic units of lower rank (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrass" ;
-    skos:prefLabel "assemblage"@en ;
-    skos:related geof:TectonometamorphicRockUnit ;
-.
-
-rur:Batholith
-    a skos:Concept ;
-    skos:historyNote "Wikipedia, accessed 07.09.2021"@en ;
-    dcterms:references "Wikipedia (accessed 07.09.2021): Batholith <https://en.wikipedia.org/wiki/Batholith>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A large mass of intrusive igneous (plutonic) rock that is generally larger than 100 square kilometres in area and has cooled from magma deep in the Earth's crust (Wikipedia, accessed 07.09.2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrbth" ;
-    skos:prefLabel "batholith"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:Bed
-    a skos:Concept ;
-    skos:historyNote "Customarily, only distinctive beds (key beds, marker beds), which are particularly useful for stratigraphic purposes, like correlation or reference, are given proper names and considered formal lithostratigraphic units (Salvador, 2013; Murphy & Salvador, Online)."@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
-        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "Bed/Beds: The smallest formal unit in the hierarchy of sedimentary lithostratigraphic units, e.g. a single stratum lithologically distinguishable from other layers above and below (Salvador, 2013; Murphy & Salvador, Online)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrbed" ;
-    skos:prefLabel "bed"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:Beds
-    a skos:Concept ;
-    skos:historyNote "Staines (1985) and endorsed by the Stratigraphic Nomenclature Committee, Geological Society of Australia"@en ;
-    dcterms:references "Staines, H.R.E., 1985: Field Geologist's Guide to Lithostratigraphic Nomenclature in Australia. Australian Journal of Earth Sciences, 32(2), 83-106. <https://doi.org/10.1080/08120098508729316>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "beds (uncapitalised): an informal, unranked unit applied to a sequence of poorly known strata until further work is carried out, as advised in the Field Geologist’s Guide to Lithostratigraphic Nomenclature in Australia (Staines, 1985), and endorsed by the Stratigraphic Nomenclature Committee, Geological Society of Australia."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrbds" ;
-    skos:prefLabel "beds"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:CalderaComplex
-    a skos:Concept ;
-    skos:historyNote "An example of a caldera complex in Queensland includes the Late Triassic Agnes Water Caldera Complex (Purdy, 2009), referenced in the Australian Stratigraphic Units Database/ASUD (accessed 28.10.2021) under Stratigraphic Number 79059, where the term was considered to be ‘Informal’, as it is ‘Probably a structural term’. Although this complex has attendant structure, it is the mix of rock units associated with it that also determines it to be a rock unit [that should be extended in scope to include associated intrusive rocks, the existence of which has been indicated by D. Purdy (pers. comm, 28.10. 2021)]. Another example, in eastern Victoria: The Early Devonian Mount Elizabeth Caldera Complex [Willman et al., 1999; referenced in ASUD (accessed 28.10.2021) under Stratigraphic Number 34812]. The rank term ‘caldera volcano-complex’ [as applied, for example, to the Glencoe Caldera Volcano-complex (Scottish Highlands) by Gillespie & Leslie (2021) in presentation of the British Geological Survey’s Rock Unit Classification System/BRUCS] is a likely skos:altLabel."@en ;
     dcterms:references
         "Australian Stratigraphic Units Database/ASUD, Geoscience Australia. <https://asud.ga.gov.au/search-stratigraphic-units>"@en ,
         "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ,
@@ -73,675 +21,323 @@ rur:CalderaComplex
         "Willman, C.E. et al., 1999: Omeo 1:100 000 Map Area Geological Report. Report 118, Geological Survey of Victoria. <http://earthresources.efirst.com.au/product.asp?pID=504&cID=39>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "caldera volcano-complex"@en ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "Rocks associated with a nested, multiple-collapse, caldera system that formed repeatedly during, and following, the eruptions of large-volume, ash-flow and air-fall tuffs. Intracaldera deposits include post-collapse subordinate volumes of lava flows that erupted from vents and small domes commonly located along ring faults. Lacustrine and laterally-resticted fluvial sediments, together with volcaniclastics including breccias formed by landslides, avalanches and rock fall from the caldera scarp, generally intertongue with the products of continued volcanic eruption (Here proposed after: McKee et al., 1999; Willman et al., 1999; Purdy, 2009)."@en ;
+    skos:historyNote "An example of a caldera complex in Queensland includes the Late Triassic Agnes Water Caldera Complex (Purdy, 2009), referenced in the Australian Stratigraphic Units Database/ASUD (accessed 28.10.2021) under Stratigraphic Number 79059, where the term was considered to be ‘Informal’, as it is ‘Probably a structural term’. Although this complex has attendant structure, it is the mix of rock units associated with it that also determines it to be a rock unit [that should be extended in scope to include associated intrusive rocks, the existence of which has been indicated by D. Purdy (pers. comm, 28.10. 2021)]. Another example, in eastern Victoria: The Early Devonian Mount Elizabeth Caldera Complex [Willman et al., 1999; referenced in ASUD (accessed 28.10.2021) under Stratigraphic Number 34812]. The rank term ‘caldera volcano-complex’ [as applied, for example, to the Glencoe Caldera Volcano-complex (Scottish Highlands) by Gillespie & Leslie (2021) in presentation of the British Geological Survey’s Rock Unit Classification System/BRUCS] is a likely skos:altLabel."@en ;
     skos:inScheme cs: ;
     skos:notation "rrcac" ;
     skos:prefLabel "caldera complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:CentralComplex
+:CentralComplex
     a skos:Concept ;
-    skos:historyNote "Examples in Queensland include the Mount Warning Central Complex and the Mount Barney Central Complex (Ewart et al, 1987: University of Queensland, Papers, 11(4), 1–82)."@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A unit comprising multiple related intrusions, usually with screens and irregular masses of associated extrusive rocks and/or country rocks, and commonly but not necessarily arranged spatially around one or more focal points. Central complexes are commonly composed of two or more spatially associated (and commonly intersecting) centres, and may generally be considered to represent the roots of a central volcano at a relatively shallow crustal level; however, that association is not essential to this definition (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Examples in Queensland include the Mount Warning Central Complex and the Mount Barney Central Complex (Ewart et al, 1987: University of Queensland, Papers, 11(4), 1–82)."@en ;
     skos:inScheme cs: ;
     skos:notation "rrcco" ;
     skos:prefLabel "central-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:ConeSheet
+:ConeSheetSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A sheet with a cone shape that dips inwards towards a central ‘focal’ point (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrics" ;
-    skos:prefLabel "cone-sheet"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:ConeSheetSwarm
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related cone sheets (Sensu: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrcss" ;
     skos:prefLabel "cone-sheet-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Diatreme
+:DykeSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A pipe filled with volcanic breccia that is inferred to form through gaseous disruption (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrdia" ;
-    skos:prefLabel "diatreme"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:Dyke
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel "Dike"@en ;
-    skos:definition "A sheet emplaced along a steep to vertical fracture, normally discordant to the host-rock structure (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrdyk" ;
-    skos:prefLabel "dyke"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:DykeSwarm
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "dike-swarm"@en ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related dykes (After: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrdsw" ;
     skos:prefLabel "dyke-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Flow
+:IntrusionSwarm
     a skos:Concept ;
-    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021.<https://stratigraphy.org/guide/>"@en ,
-        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A discrete extrusive volcanic body distinguishable by texture, composition, or other objective criteria (Salvador, 2013; Murphy & Salvador, Online)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrflw" ;
-    skos:prefLabel "flow"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:Formation
-    a skos:Concept ;
-    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
-        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "The primary formal unit of lithostratigraphic classification. Formations are the only formal lithostratigraphic units into which the stratigraphic column everywhere should be divided completely on the basis of lithology (Salvador, 2013; Murphy & Salvador, Online)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrfmn" ;
-    skos:prefLabel "formation"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:Group
-    a skos:Concept ;
-    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
-        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A succession of two or more contiguous or associated formations with significant and diagnostic lithologic properties in common (Salvador, 2013; Murphy & Salvador, Online)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrgrp" ;
-    skos:prefLabel "group"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:Intrusion
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:altLabel "Igneous Intrusion"@en ;
-    skos:definition "A body of rock formed by the emplacement of magma which solidifies before reaching the Earth's surface (After: Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rriin" ;
-    skos:prefLabel "intrusion"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:IntrusionCentre
-    a skos:Concept ;
-    skos:historyNote "Igneous intrusions may be grouped in centres (or clusters), expressing genetic and spatial relationships, these groupings (centres/clusters) being classified at Rank 4 by Gillespie & Leslie (2021). Per the example of the cited authors, a centre could comprise two intersecting plutons, and several ring-dykes, a dyke-swarm and a number of pipes that intersect the plutons or are spatially closely associated with them."@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A group of two or more related intrusive units of lower rank (below suite and subsuite, respectively at Rank 2 and Rank 3 in BRUCS) focused tightly around a central point and usually intersecting to some degree (After: Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrice" ;
-    skos:prefLabel "centre"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:IntrusionCluster
-    a skos:Concept ;
-    skos:historyNote "Igneous intrusions may be grouped in clusters (or centres), expressing genetic and spatial relationships, these groupings (centres/clusters) being classified at Rank 4 by Gillespie & Leslie (2021). Per the example of the cited authors, a cluster could comprise two dyke-swarms, a sill-swarm and numerous pipes, which are related but scattered over a wide area (unlike intrusions that are tightly grouped as a centre around a central point)."@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A group of two or more related intrusive units of lower rank (below suite and subsuite, respectively at Rank 2 and Rank 3 in BRUCS) that are associated spatially but not focussed tightly (After: Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rricl" ;
-    skos:prefLabel "intrusion cluster"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:IntrusionSwarm
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "Broadly: A swarm of related intrusions, as exemplified by Garbh-choire Peridotite Intrusion-swarm of the Cullin Centre and the Skye Central Complex in the UK (See: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrisw" ;
     skos:prefLabel "intrusion-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Laccolith
+:MetamorphicComplex
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An intrusion that is roughly circular in plan, generally with a planar floor and domed roof (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrlac" ;
-    skos:prefLabel "laccolith"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:Lens
-    a skos:Concept ;
-    skos:historyNote "Murphy & Salvador, Online, Accessed 21.02.2022; NASC, 2005"@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 21.02.2022. <https://stratigraphy.org/guide/>"@en ,
-        "North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel "Lentil"@en ;
-    skos:definition "A lens is a lens-shaped body of rock of different lithology than the unit that encloses it (Murphy & Salvador, Online, Accessed 21.02.2022); and similarly, a lens (lentil) has been defined as a geographically restricted member that terminates on all sides within a formation (NASC, 2005)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrlen" ;
-    skos:prefLabel "lens"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:Lopolith
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An intrusion that is kilometre-scale or larger and broadly saucer-shaped (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrlop" ;
-    skos:prefLabel "lopolith"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:Member
-    a skos:Concept ;
-    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
-        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "The formal lithostratigraphic unit next in rank below a formation (Salvador, 2013; Murphy & Salvador, Online)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrmbr" ;
-    skos:prefLabel "member"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:MetamorphicComplex
-    a skos:Concept ;
-    skos:historyNote "Examples in Queensland include the Kurbayia Metamorphic Complex (includes dioritic to granitic gneiss felsic gneiss, minor pelitic schist) and the Glen Eva Metamorphic Complex (foliated meta-igneous and metasedimentery rocks) [Jell, 2013: Geology of Queensland, Geological Survey of Queensland, 1063 pages.]."@en ;
     dcterms:references "This vocabulary"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A coherent but varied group of metamorphic rocks, the term preferably applied to metamorphosed rocks derived from more than one genetic class of precursors (sedimentary, igneous, metamorphic), and preferably where the precursors cannot be reliably identified because of the degree of metamorphism and deformation."@en ;
+    skos:historyNote "Examples in Queensland include the Kurbayia Metamorphic Complex (includes dioritic to granitic gneiss felsic gneiss, minor pelitic schist) and the Glen Eva Metamorphic Complex (foliated meta-igneous and metasedimentery rocks) [Jell, 2013: Geology of Queensland, Geological Survey of Queensland, 1063 pages.]."@en ;
     skos:inScheme cs: ;
     skos:notation "rrmco" ;
     skos:prefLabel "metamorphic complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:MetamorphicCoreComplex
+:MetamorphicCoreComplex
     a skos:Concept ;
-    skos:historyNote "Coney, 1980; Ring, 2014; Wikipedia, accessed 07.09.2021"@en ;
     dcterms:references
         "Coney (1980):Cordilleran metamorphic core complexes: An overview. In: Crittenden, M.D. et al. (Editors): Cordilleran Metamorphic Core Complexes. GSA Memoirs, 153, 7–34. <https://pubs.geoscienceworld.org/books/book/162/chapter/3791265/Cordilleran-metamorphic-core-complexes-An-overview>"@en ,
         "Ring, U., 2014: Metamorphic Core Complexes. Encyclopedia of Marine Geosciences. Springer, Dordrecht. <http://people.geo.su.se/uwe/publications/Metamorphic-core-complexes.pdf>"@en ,
         "Wikipedia (accessed 07.09.2021): Metamorphic core complex. <https://en.wikipedia.org/wiki/Metamorphic_core_complex>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "Exhumed segments of deep, lower to middle, continental crust, embracing metamorphic-plutonic basement rocks, that have undergone relatively fast transport to the Earth’s surface as a result of major, deep-seated crustal extension; unmetamorphosed cover rocks are generally sliced by numerous, younger-on-older faults and are separated from the basement rocks by a decollement and/or a steep metamorphic gradient with much brecciation and kinematic structural relationships that indicate sliding or detachment (Coney, 1980; Ring, 2014; Wikipedia, accessed 07.09.2021)."@en ;
+    skos:historyNote "Coney, 1980; Ring, 2014; Wikipedia, accessed 07.09.2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrmcc" ;
     skos:prefLabel "metamorphic-core-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:Nappe
+:Nappe
     a skos:Concept ;
-    skos:historyNote "Nappe is the basic tectonostratigraphic unit and the term includes detachment sheets and fold nappes (Kumpulainen, 2017)."@en ;
     dcterms:references
         "Kumpulainen, R.A. (Editor.), 2017: Guide for geological nomenclature in Sweden, GFF, 139:1, 3-20. <https://www.tandfonline.com/doi/full/10.1080/11035897.2016.1178666>" ,
         "Nystuen, J.P. (Editor), 1989: Rules and recommendations of naming geological units in Norway. Norsk Geologisk Tidskrift 69 (Supplement 2), 1–111. <https://foreninger.uio.no/ngf/ngt/pdfs/NGT_69_supplement1.pdf>" ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:NappeComplex ;
+    skos:broader :NappeComplex ;
     skos:definition "The tectonic term ‘nappe’ refers to any allochthonous, sheet-like body that has been moved on a shallow-dipping high-strain zone, and, following Nystuen (1989), the term is non-genetic with respect to the transport mechanism of the nappe rocks (Kumpulainen, 2017)."@en ;
+    skos:historyNote "Nappe is the basic tectonostratigraphic unit and the term includes detachment sheets and fold nappes (Kumpulainen, 2017)."@en ;
     skos:inScheme cs: ;
     skos:notation "rrnap" ;
     skos:prefLabel "nappe"@en ;
     skos:related geof:TectonostratigraphicRockUnit ;
 .
 
-rur:Neck
+:NeckSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A pipe inferred to have fed a volcano, now infilled with collapsed material from the vent (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrnek" ;
-    skos:prefLabel "neck"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:NeckSwarm
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related pipes (Sensu: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrnsw" ;
     skos:prefLabel "neck-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:NoRank
+:OphioliteComplex
     a skos:Concept ;
-    skos:historyNote "Defined in this vocabulary" ;
-    dcterms:references "This vocabulary"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel "Unranked"@en ;
-    skos:definition "An unranked and unnamed rock unit or body of rocks."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrnor" ;
-    skos:prefLabel "no rank"@en ;
-.
-
-rur:Ophiolite
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie (2021), in BRUCS, accorded an ophiolite a Rank-4 position (Tectonometamorphic Units) in BRUCS, to permit individual related occurrences of ophiolite to be grouped in higher-rank associations (giving an example, in the Highland Border Fault Zone in Scotland, of a possible reclassification of the Highland Border Ophoilite under the Highland Border Ophiolite Assemblage (Rank 2) and potentially (at Rank 1) under the Iapetus Ocean Ophiolite Superassemblage.The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A unit formed of obducted oceanic crust, generally recognized as having a mixed-class character comprising several layers of ultrabasic and basic igneous rock, dykes and other intrusions, pillow lavas and sea-floor sediments, with or without subjacent mantle (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rroph" ;
-    skos:prefLabel "ophiolite"@en ;
-    skos:related geof:TectonometamorphicRockUnit ;
-.
-
-rur:OphioliteComplex
-    a skos:Concept ;
-    skos:historyNote "Kusky et al., 2001; Harper et al., 2003; Gillespie et al., 2011; Fu et al., 2018"@en ;
     dcterms:references
         "Fu et al., 2018: Lajishankou Ophiolite Complex: Implications for Paleozoic Multiple Accretionary and Collisional Events in the South Qilian Belt. <https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2017TC004740>"@en ,
         "Gillespie et al, 2011: BGS classification of lithodemic units: a classification of onshore Phanerozoic intrusions in the UK, figure 1. <http://nora.nerc.ac.uk/id/eprint/18279/1/RR12001.pdf)>"@en ,
         "Harper et al., 2003, Geological Society of America, Field Guide 4, Evolution of a polygenetic ophiolite: The Jurassic Ingalls Ophiolite, Washington Cascades. <https://pubs.geoscienceworld.org/books/book/588/chapter/3804112/The-Ingalls-ophiolite-complex-central-Cascades>"@en ,
         "Kusky et al., 2001: The Archean Dongwanzi Ophiolite Complex, North China Craton: 2.505-Billion-Year-Old Oceanic Crust and Mantle. <https://www.science.org/doi/pdf/10.1126/science.1059426>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A complex unit comprising a mixture of ophiolite (an uplifted mafic-ultramafic section of Earth’s oceanic crust and upper mantle) that has been metamorphosed and generally subjected to polyphase tectonism over an extended period of time; such units are variously associated with other rock types, including intrusive rocks and basaltic-tholeiitic sheeted-dyke complexes, extrusive rocks (e.g., pillow lavas) and younger (overlying) sedimentary rocks (e.g., chert, greywacke, black shale, pebble conglomerate, and lenses of ophiolite breccias) and/or thrust sheets (Here proposed after: Kusky et al., 2001; Harper et al., 2003; Gillespie et al., 2011; Fu et al., 2018)."@en ;
+    skos:historyNote "Kusky et al., 2001; Harper et al., 2003; Gillespie et al., 2011; Fu et al., 2018"@en ;
     skos:inScheme cs: ;
     skos:notation "rroco" ;
     skos:prefLabel "ophiolite-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:Pipe
+:PipeSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "An intrusion sensu lato that is cylindrical and normally steeply orientated (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrpip" ;
-    skos:prefLabel "pipe"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:PipeSwarm
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related pipes (Sensu: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrpis" ;
     skos:prefLabel "pipe-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Plug
+:PlugSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A pipe inferred to have fed a volcano, but generally lacking collapsed material from the vent (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrplg" ;
-    skos:prefLabel "plug"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:PlugSwarm
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related plugs (Sensu: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrpls" ;
     skos:prefLabel "plug-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Pluton
+:RingComplex
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "An intrusion sensu lato that is kilometre-scale or larger, and cylindrical, lenticular or tabular (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrplu" ;
-    skos:prefLabel "pluton"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:PlutonCluster
-    a skos:Concept ;
-    skos:historyNote "Jell, 2013, pp. 61, 80–81"@en ;
-    dcterms:references "Jell, P.A. (Editor), 2013: Geology of Queensland. Geological Survey of Queensland, Brisbane, 1063 pages. <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/reports-news/geology-queensland-book-map>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A cluster of related plutons [e.g., the Forsayth Batholith (of the Forsayth Supersuite, Forsayth Subprovince, Etheridge Province, northern Queensland)], although the term ‘pluton cluster’ has not been applied per se to the unit, although it ‘comprises ~30 individual plutons or clusters of plutons 2–10 km in diameter’ (Jell, 2013, pp. 61, 80–81)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrpcl" ;
-    skos:prefLabel "pluton cluster"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:Ring-dyke
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel "Ring-dike"@en ;
-    skos:definition "A sheet that is arcuate or annular in plan, and usually vertical or inclined steeply outwards (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrrdy" ;
-    skos:prefLabel "ring-dyke"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:RingComplex
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A unit comprising multiple ring-intrusions and/or ring-dykes, cone-sheets, ring-dyke-swarms and cone-sheet-swarms, and their country-rock (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrrco" ;
     skos:prefLabel "ring-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:RingDykeSwarm
+:RingDykeSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related ring-dykes (Sensu: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrrds" ;
     skos:prefLabel "ring-dyke-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:RingIntrusion
+:SheetComplex
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "An intrusion that is emplaced within, or bounded by, a ring-fracture (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrrin" ;
-    skos:prefLabel "ring-intrusion"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:Sheet
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An intrusion sensu lato with broadly parallel margins and one dimension much shorter than the other two (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrsht" ;
-    skos:prefLabel "sheet"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:SheetComplex
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A unit comprising multiple sheets and their country-rock (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrshc" ;
     skos:prefLabel "sheet-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:SheetSwarm
+:SheetSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related sheets (Sensu: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrshs" ;
     skos:prefLabel "sheet-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Sill
+:SillComplex
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A sheet emplaced along a gently inclined to horizontal fracture; normally broadly concordant in strata (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrsil" ;
-    skos:prefLabel "sill"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:SillCluster
-    a skos:Concept ;
-    skos:historyNote "An example being the Borrowdale Sill Cluster in the UK (Gillespie et al., 2021, figure 4)."@en ;
-    dcterms:references "After: Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212, figure 4. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A cluster of related sills."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrscl" ;
-    skos:prefLabel "sill cluster"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:SillComplex
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A unit comprising multiple sills and their country-rock (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrslc" ;
     skos:prefLabel "sill-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:SillSwarm
+:SillSwarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Swarm ;
+    skos:broader :Swarm ;
     skos:definition "A group (two or more) of related sills (after: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrsls" ;
     skos:prefLabel "sill-swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:StructuralComplex
+:StructuralComplex
     a skos:Concept ;
-    skos:historyNote "North American Stratigraphic Code, 2005; also see: Easton, 2009; Kumpulainen, 2017"@en ;
     dcterms:references
         "Easton, R.M, 2009: A guide to the application of lithostratigraphic terminology in Precambrian terrains. Stratigrpahy, 6(2), 117–134. <https://nacsn.americangeosciences.org/sites/default/files/2018-01/48689_articles_article_file_1643.pdf>"@en ,
         "Kumpulainen (Editor), 2017: Guide for Geological Nomenclature in Sweden. GFF, 139:1, 3-20. <https://doi.org/10.1080/11035897.2016.1178666>"@en ,
         "North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A unit comprising a heterogeneous mixture of tectonically-disrupted bodies of rock in which some individual components are too small to be mapped and consisting of two or more rock classes or a single class only (North American Stratigraphic Code, 2005; also see: Easton, 2009; Kumpulainen, 2017)."@en ;
+    skos:historyNote "North American Stratigraphic Code, 2005; also see: Easton, 2009; Kumpulainen, 2017"@en ;
     skos:inScheme cs: ;
     skos:notation "rrstc" ;
     skos:prefLabel "stuctural-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:Subassemblage
+:Subsuite
     a skos:Concept ;
-    skos:historyNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A group of two or more tectonometamorphic units of lower rank that display shared characteristics and belong to the same assemblage (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrsba" ;
-    skos:prefLabel "subassemblage"@en ;
-    skos:related geof:TectonometamorphicRockUnit ;
-.
-
-rur:Subcomplex
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "One of two or more subdivisions of the same complex, with shared characteristics (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrsbc" ;
-    skos:prefLabel "subcomplex"@en ;
-    skos:related geof:ComplexRockUnit ;
-.
-
-rur:Subgroup
-    a skos:Concept ;
-    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
-        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A Group may be subdivided into subgroups (Salvador, 2013; Murphy & Salvador, Online)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrsbg" ;
-    skos:prefLabel "subgroup"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:Subsuite
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017"@en ;
     dcterms:references
         "Compare: Kumpulainen (Editor), 2017: Guide for Geological Nomenclature in Sweden. GFF, 139:1, 3-20. <https://doi.org/10.1080/11035897.2016.1178666>"@en ,
         "Compare: North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ,
         "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:broader rur:Suite ;
+    skos:broader :Suite ;
     skos:definition "A group of two or more related igneous-intrusive rock units of lower rank that display shared characteristics and belong to the same suite (After: Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017"@en ;
     skos:inScheme cs: ;
     skos:notation "rrsbs" ;
     skos:prefLabel "subsuite"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Superassemblage
+:Superassemblage
     a skos:Concept ;
-    skos:historyNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:broader <http://sweetontology.net/realmGeol/GeologicFeature> ;
     skos:definition "A group of two or more related 'assemblages' of tectonometamorphic units with or without other units of lower rank that are not part of those 'assemblages' (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
     skos:inScheme cs: ;
     skos:notation "rrspa" ;
     skos:prefLabel "superassemblage"@en ;
     skos:related geof:TectonometamorphicRockUnit ;
 .
 
-rur:Supercomplex
+:Supercomplex
     a skos:Concept ;
-    skos:historyNote "The Subcommission on Quaternary Stratigraphy, Online"@en ;
     dcterms:references
         "After and compare: Subcommission on Quaternary Stratigraphy — Lithodemic Stratigraphy. Accessed online 04.11.2021. <http://quaternary.stratigraphy.org/stratigraphic-guide/lithodemic-stratigraphy/>"@en ,
         "After: Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:broader <http://sweetontology.net/realmGeol/GeologicFeature> ;
     skos:definition "A supercomplex consists of two or more complexes, having a degree of natural relationship with each other (After: The Subcommission on Quaternary Stratigraphy, Online)."@en ;
+    skos:historyNote "The Subcommission on Quaternary Stratigraphy, Online"@en ;
     skos:inScheme cs: ;
     skos:notation "rrspc" ;
     skos:prefLabel "supercomplex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:Supergroup
+:Supergroup
     a skos:Concept ;
-    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
     dcterms:references
         "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
         "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:broader <http://sweetontology.net/realmGeol/GeologicFeature> ;
     skos:definition "A lithostratigraphic Supergroup may contain several associated groups or associated groups and formations, all with significant lithologic properties in common (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
     skos:inScheme cs: ;
     skos:notation "rrspg" ;
     skos:prefLabel "supergroup"@en ;
     skos:related geof:LithostratigraphicUnit ;
 .
 
-rur:Supersuite
+:Supersuite
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017"@en ;
     dcterms:references
         "Compare: Kumpulainen (Editor), 2017: Guide for Geological Nomenclature in Sweden. GFF, 139:1, 3-20. <https://doi.org/10.1080/11035897.2016.1178666>"@en ,
         "Compare: North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ,
@@ -749,41 +345,15 @@ rur:Supersuite
     rdfs:isDefinedBy cs: ;
     skos:broader <http://sweetontology.net/realmGeol/GeologicFeature> ;
     skos:definition "A group of two or more related suites with or without other units of lower rank that are not part of those suites. For example, a supersuite may contain a central complex, comprising multiple related intrusions, and associated extrusive rocks and/or country rocks (after: Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017"@en ;
     skos:inScheme cs: ;
     skos:notation "rrsps" ;
     skos:prefLabel "supersuite"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Tongue
+:VolcanicComplex
     a skos:Concept ;
-    skos:historyNote "Murphy & Salvador, Online, Accessed 21.02.2022; NASC, 2005"@en ;
-    dcterms:references
-        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 21.02.2022. <https://stratigraphy.org/guide/>"@en ,
-        "North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "A tongue is a projecting part of a lithostratigraphic unit extending out beyond its main body (Murphy & Salvador, Online, Accessed 21.02.2022); and similarly: a wedging ‘member’ that extends outward beyond a formation or wedges (‘pinches’) out within another formation (NASC, 2005)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrton" ;
-    skos:prefLabel "tongue"@en ;
-    skos:related geof:LithostratigraphicUnit ;
-.
-
-rur:Vein
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An intrusion that is sheet-like, but generally narrower and less regular than a sheet (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrvei" ;
-    skos:prefLabel "vein"@en ;
-    skos:related geof:IgneousIntrusiveRockUnit ;
-.
-
-rur:VolcanicComplex
-    a skos:Concept ;
-    skos:historyNote "North American Stratigraphic Code, 2005; Kumpulainen, 2017; Gillespie & Leslie, 2021"@en ;
     dcterms:references
         "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ,
         "Kumpulainen (Editor), 2017: Guide for Geological Nomenclature in Sweden. GFF, 139:1, 3-20. <https://doi.org/10.1080/11035897.2016.1178666>"@en ,
@@ -792,102 +362,530 @@ rur:VolcanicComplex
     skos:altLabel
         "volcanic complex"@en ,
         "volcano-complex"@en ;
-    skos:broader rur:Complex ;
+    skos:broader :Complex ;
     skos:definition "A unit comprising all the related units, extrusive, intrusive and sedimentary, formed at a site of persistent volcanic activity (North American Stratigraphic Code, 2005; Kumpulainen, 2017; Gillespie & Leslie, 2021, for ‘volcano-complex’)."@en ;
+    skos:historyNote "North American Stratigraphic Code, 2005; Kumpulainen, 2017; Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrvco" ;
     skos:prefLabel "volcanic-complex"@en ;
     skos:related geof:ComplexRockUnit ;
 .
 
-rur:NappeComplex
+:Assemblage
     a skos:Concept ;
-    skos:historyNote "In Sweden, Kumpulainen (2017) recognised two ranks of tectonostratigraphic units (nappe and nappe complex), although four ranks were recognized in Norway by Nystuen (1989)."@en ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A group of two or more related tectonometamorphic units of lower rank (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrass" ;
+    skos:prefLabel "assemblage"@en ;
+    skos:related geof:TectonometamorphicRockUnit ;
+.
+
+:Batholith
+    a skos:Concept ;
+    dcterms:references "Wikipedia (accessed 07.09.2021): Batholith <https://en.wikipedia.org/wiki/Batholith>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A large mass of intrusive igneous (plutonic) rock that is generally larger than 100 square kilometres in area and has cooled from magma deep in the Earth's crust (Wikipedia, accessed 07.09.2021)."@en ;
+    skos:historyNote "Wikipedia, accessed 07.09.2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrbth" ;
+    skos:prefLabel "batholith"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Bed
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
+        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "Bed/Beds: The smallest formal unit in the hierarchy of sedimentary lithostratigraphic units, e.g. a single stratum lithologically distinguishable from other layers above and below (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:historyNote "Customarily, only distinctive beds (key beds, marker beds), which are particularly useful for stratigraphic purposes, like correlation or reference, are given proper names and considered formal lithostratigraphic units (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrbed" ;
+    skos:prefLabel "bed"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:Beds
+    a skos:Concept ;
+    dcterms:references "Staines, H.R.E., 1985: Field Geologist's Guide to Lithostratigraphic Nomenclature in Australia. Australian Journal of Earth Sciences, 32(2), 83-106. <https://doi.org/10.1080/08120098508729316>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "beds (uncapitalised): an informal, unranked unit applied to a sequence of poorly known strata until further work is carried out, as advised in the Field Geologist’s Guide to Lithostratigraphic Nomenclature in Australia (Staines, 1985), and endorsed by the Stratigraphic Nomenclature Committee, Geological Society of Australia."@en ;
+    skos:historyNote "Staines (1985) and endorsed by the Stratigraphic Nomenclature Committee, Geological Society of Australia"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrbds" ;
+    skos:prefLabel "beds"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:ConeSheet
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A sheet with a cone shape that dips inwards towards a central ‘focal’ point (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrics" ;
+    skos:prefLabel "cone-sheet"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Diatreme
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A pipe filled with volcanic breccia that is inferred to form through gaseous disruption (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrdia" ;
+    skos:prefLabel "diatreme"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Dyke
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel "Dike"@en ;
+    skos:definition "A sheet emplaced along a steep to vertical fracture, normally discordant to the host-rock structure (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrdyk" ;
+    skos:prefLabel "dyke"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Flow
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021.<https://stratigraphy.org/guide/>"@en ,
+        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A discrete extrusive volcanic body distinguishable by texture, composition, or other objective criteria (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrflw" ;
+    skos:prefLabel "flow"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:Formation
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
+        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "The primary formal unit of lithostratigraphic classification. Formations are the only formal lithostratigraphic units into which the stratigraphic column everywhere should be divided completely on the basis of lithology (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrfmn" ;
+    skos:prefLabel "formation"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:Group
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
+        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A succession of two or more contiguous or associated formations with significant and diagnostic lithologic properties in common (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrgrp" ;
+    skos:prefLabel "group"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:Intrusion
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel "Igneous Intrusion"@en ;
+    skos:definition "A body of rock formed by the emplacement of magma which solidifies before reaching the Earth's surface (After: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rriin" ;
+    skos:prefLabel "intrusion"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:IntrusionCentre
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A group of two or more related intrusive units of lower rank (below suite and subsuite, respectively at Rank 2 and Rank 3 in BRUCS) focused tightly around a central point and usually intersecting to some degree (After: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Igneous intrusions may be grouped in centres (or clusters), expressing genetic and spatial relationships, these groupings (centres/clusters) being classified at Rank 4 by Gillespie & Leslie (2021). Per the example of the cited authors, a centre could comprise two intersecting plutons, and several ring-dykes, a dyke-swarm and a number of pipes that intersect the plutons or are spatially closely associated with them."@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrice" ;
+    skos:prefLabel "centre"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:IntrusionCluster
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A group of two or more related intrusive units of lower rank (below suite and subsuite, respectively at Rank 2 and Rank 3 in BRUCS) that are associated spatially but not focussed tightly (After: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Igneous intrusions may be grouped in clusters (or centres), expressing genetic and spatial relationships, these groupings (centres/clusters) being classified at Rank 4 by Gillespie & Leslie (2021). Per the example of the cited authors, a cluster could comprise two dyke-swarms, a sill-swarm and numerous pipes, which are related but scattered over a wide area (unlike intrusions that are tightly grouped as a centre around a central point)."@en ;
+    skos:inScheme cs: ;
+    skos:notation "rricl" ;
+    skos:prefLabel "intrusion cluster"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Laccolith
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "An intrusion that is roughly circular in plan, generally with a planar floor and domed roof (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrlac" ;
+    skos:prefLabel "laccolith"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Lens
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 21.02.2022. <https://stratigraphy.org/guide/>"@en ,
+        "North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel "Lentil"@en ;
+    skos:definition "A lens is a lens-shaped body of rock of different lithology than the unit that encloses it (Murphy & Salvador, Online, Accessed 21.02.2022); and similarly, a lens (lentil) has been defined as a geographically restricted member that terminates on all sides within a formation (NASC, 2005)."@en ;
+    skos:historyNote "Murphy & Salvador, Online, Accessed 21.02.2022; NASC, 2005"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrlen" ;
+    skos:prefLabel "lens"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:Lopolith
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "An intrusion that is kilometre-scale or larger and broadly saucer-shaped (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrlop" ;
+    skos:prefLabel "lopolith"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Member
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
+        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "The formal lithostratigraphic unit next in rank below a formation (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrmbr" ;
+    skos:prefLabel "member"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:NappeComplex
+    a skos:Concept ;
     dcterms:references
         "Kumpulainen, R.A. (Editor.), 2017: Guide for geological nomenclature in Sweden, GFF, 139:1, 3-20. <https://www.tandfonline.com/doi/full/10.1080/11035897.2016.1178666>" ,
         "Nystuen, J.P. (Editor), 1989: Rules and recommendations of naming geological units in Norway. Norsk Geologisk Tidskrift 69 (Supplement 2), 1–111. <https://foreninger.uio.no/ngf/ngt/pdfs/NGT_69_supplement1.pdf>" ;
     rdfs:isDefinedBy cs: ;
     skos:broader <http://sweetontology.net/realmGeol/GeologicFeature> ;
     skos:definition "A nappe complex consists of two or more distinct nappes that are stacked upon, and related to, one another in some significant respect, e.g., shared general environment of origin, similar metamorphism and/or deformation. (Kumpulainen, 2017)"@en ;
+    skos:historyNote "In Sweden, Kumpulainen (2017) recognised two ranks of tectonostratigraphic units (nappe and nappe complex), although four ranks were recognized in Norway by Nystuen (1989)."@en ;
     skos:inScheme cs: ;
     skos:notation "rrnpc" ;
     skos:prefLabel "nappe complex"@en ;
     skos:related geof:TectonostratigraphicRockUnit ;
 .
 
-rur:Suite
+:Neck
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017"@en ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A pipe inferred to have fed a volcano, now infilled with collapsed material from the vent (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrnek" ;
+    skos:prefLabel "neck"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:NoRank
+    a skos:Concept ;
+    dcterms:references "This vocabulary"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel "Unranked"@en ;
+    skos:definition "An unranked and unnamed rock unit or body of rocks."@en ;
+    skos:historyNote "Defined in this vocabulary" ;
+    skos:inScheme cs: ;
+    skos:notation "rrnor" ;
+    skos:prefLabel "no rank"@en ;
+.
+
+:Ophiolite
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A unit formed of obducted oceanic crust, generally recognized as having a mixed-class character comprising several layers of ultrabasic and basic igneous rock, dykes and other intrusions, pillow lavas and sea-floor sediments, with or without subjacent mantle (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie (2021), in BRUCS, accorded an ophiolite a Rank-4 position (Tectonometamorphic Units) in BRUCS, to permit individual related occurrences of ophiolite to be grouped in higher-rank associations (giving an example, in the Highland Border Fault Zone in Scotland, of a possible reclassification of the Highland Border Ophoilite under the Highland Border Ophiolite Assemblage (Rank 2) and potentially (at Rank 1) under the Iapetus Ocean Ophiolite Superassemblage.The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
+    skos:inScheme cs: ;
+    skos:notation "rroph" ;
+    skos:prefLabel "ophiolite"@en ;
+    skos:related geof:TectonometamorphicRockUnit ;
+.
+
+:Pipe
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "An intrusion sensu lato that is cylindrical and normally steeply orientated (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrpip" ;
+    skos:prefLabel "pipe"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Plug
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A pipe inferred to have fed a volcano, but generally lacking collapsed material from the vent (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrplg" ;
+    skos:prefLabel "plug"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Pluton
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "An intrusion sensu lato that is kilometre-scale or larger, and cylindrical, lenticular or tabular (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrplu" ;
+    skos:prefLabel "pluton"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:PlutonCluster
+    a skos:Concept ;
+    dcterms:references "Jell, P.A. (Editor), 2013: Geology of Queensland. Geological Survey of Queensland, Brisbane, 1063 pages. <https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/reports-news/geology-queensland-book-map>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A cluster of related plutons [e.g., the Forsayth Batholith (of the Forsayth Supersuite, Forsayth Subprovince, Etheridge Province, northern Queensland)], although the term ‘pluton cluster’ has not been applied per se to the unit, although it ‘comprises ~30 individual plutons or clusters of plutons 2–10 km in diameter’ (Jell, 2013, pp. 61, 80–81)."@en ;
+    skos:historyNote "Jell, 2013, pp. 61, 80–81"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrpcl" ;
+    skos:prefLabel "pluton cluster"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Ring-dyke
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel "Ring-dike"@en ;
+    skos:definition "A sheet that is arcuate or annular in plan, and usually vertical or inclined steeply outwards (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrrdy" ;
+    skos:prefLabel "ring-dyke"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:RingIntrusion
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "An intrusion that is emplaced within, or bounded by, a ring-fracture (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrrin" ;
+    skos:prefLabel "ring-intrusion"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Sheet
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "An intrusion sensu lato with broadly parallel margins and one dimension much shorter than the other two (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrsht" ;
+    skos:prefLabel "sheet"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Sill
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A sheet emplaced along a gently inclined to horizontal fracture; normally broadly concordant in strata (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrsil" ;
+    skos:prefLabel "sill"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:SillCluster
+    a skos:Concept ;
+    dcterms:references "After: Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212, figure 4. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A cluster of related sills."@en ;
+    skos:historyNote "An example being the Borrowdale Sill Cluster in the UK (Gillespie et al., 2021, figure 4)."@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrscl" ;
+    skos:prefLabel "sill cluster"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Subassemblage
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A group of two or more tectonometamorphic units of lower rank that display shared characteristics and belong to the same assemblage (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "A rank term newly defined by Gillespie & Leslie (2021) for tectonometamorphic units, with potential for application to such rock types in Queensland and Australia. The BRUCS tectonometamorphic rank terminology is only partially introduced into this ontology."@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrsba" ;
+    skos:prefLabel "subassemblage"@en ;
+    skos:related geof:TectonometamorphicRockUnit ;
+.
+
+:Subcomplex
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "One of two or more subdivisions of the same complex, with shared characteristics (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrsbc" ;
+    skos:prefLabel "subcomplex"@en ;
+    skos:related geof:ComplexRockUnit ;
+.
+
+:Subgroup
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ,
+        "Salvador, A., 2013: International Stratigraphic Guide. Reprinted Second Edition, The International Union of Geological Sciences and The Geological Society of America, 214 pages. <https://doi.org/10.1130/9780813774022>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A Group may be subdivided into subgroups (Salvador, 2013; Murphy & Salvador, Online)."@en ;
+    skos:historyNote "Salvador, 2013; Murphy & Salvador, Online"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrsbg" ;
+    skos:prefLabel "subgroup"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:Tongue
+    a skos:Concept ;
+    dcterms:references
+        "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 21.02.2022. <https://stratigraphy.org/guide/>"@en ,
+        "North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "A tongue is a projecting part of a lithostratigraphic unit extending out beyond its main body (Murphy & Salvador, Online, Accessed 21.02.2022); and similarly: a wedging ‘member’ that extends outward beyond a formation or wedges (‘pinches’) out within another formation (NASC, 2005)."@en ;
+    skos:historyNote "Murphy & Salvador, Online, Accessed 21.02.2022; NASC, 2005"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrton" ;
+    skos:prefLabel "tongue"@en ;
+    skos:related geof:LithostratigraphicUnit ;
+.
+
+:Vein
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:definition "An intrusion that is sheet-like, but generally narrower and less regular than a sheet (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrvei" ;
+    skos:prefLabel "vein"@en ;
+    skos:related geof:IgneousIntrusiveRockUnit ;
+.
+
+:Vein-complex
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader :Complex ;
+    skos:definition "A unit comprising multiple veins and their country-rock, the whole being typically intermediate in character between a xenolith-rich intrusion and veined country-rock (Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrvnc" ;
+    skos:prefLabel "vein-complex"@en ;
+    skos:related
+        geof:ComplexRockUnit ,
+        :VeinSwarm ;
+.
+
+:VeinSwarm
+    a skos:Concept ;
+    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
+    rdfs:isDefinedBy cs: ;
+    skos:altLabel
+        "stockwork veins"@en ,
+        "stockworks"@en ;
+    skos:broader :Swarm ;
+    skos:definition "A Network (system) of related veins (here delimited). Differs from the associated vein-complex, which comprises both the vein system and its country rock (see and compare: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
+    skos:inScheme cs: ;
+    skos:notation "rrvsw" ;
+    skos:prefLabel "vein-swarm"@en ;
+    skos:related
+        geof:IgneousIntrusiveRockUnit ,
+        :Vein-complex ;
+.
+
+:Suite
+    a skos:Concept ;
     dcterms:references
         "Compare: Kumpulainen (Editor), 2017: Guide for Geological Nomenclature in Sweden. GFF, 139:1, 3-20. <https://doi.org/10.1080/11035897.2016.1178666>"@en ,
         "Compare: North American Stratigraphic Code, 2005: AAPG Bulletin, 89(11), 1547–1591. <https://doi.org/10.1306/05230505015>"@en ,
         "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:definition "A group of two or more related intrusive igneous rock units. Two or more related suites may form a supersuite, and a suite may be subdived into two or more subsuites (After: Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021; cf. North American Stratigraphic Code, 2005; cf. Kumpulainen, 2017"@en ;
     skos:inScheme cs: ;
     skos:notation "rrsui" ;
     skos:prefLabel "suite"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Vein-complex
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader rur:Complex ;
-    skos:definition "A unit comprising multiple veins and their country-rock, the whole being typically intermediate in character between a xenolith-rich intrusion and veined country-rock (Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrvnc" ;
-    skos:prefLabel "vein-complex"@en ;
-    skos:related
-        geof:ComplexRockUnit ,
-        rur:VeinSwarm ;
-.
-
-rur:VeinSwarm
-    a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
-    dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel
-        "stockwork veins"@en ,
-        "stockworks"@en ;
-    skos:broader rur:Swarm ;
-    skos:definition "A Network (system) of related veins (here delimited). Differs from the associated vein-complex, which comprises both the vein system and its country rock (see and compare: Gillespie & Leslie, 2021)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "rrvsw" ;
-    skos:prefLabel "vein-swarm"@en ;
-    skos:related
-        geof:IgneousIntrusiveRockUnit ,
-        rur:Vein-complex ;
-.
-
 <http://sweetontology.net/realmGeol/GeologicFeature>
     a skos:Concept ;
-    skos:historyNote "Taken from the SWEET Ontology"@en ;
     rdfs:isDefinedBy <http://sweetontology.net> ;
     skos:definition "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;
     skos:example "Individuals: Lake Eyre Basin, Sarmatian Craton, Victoria Point Sandbar, Mount Erebus Volcano. Subclasses: Basin, Craton, Shield, Province, Sub-Province."@en ;
+    skos:historyNote "Taken from the SWEET Ontology"@en ;
     skos:inScheme cs: ;
     skos:prefLabel "geologic feature"@en ;
 .
 
-rur:Swarm
+:Swarm
     a skos:Concept ;
-    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     dcterms:references "Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:definition "A group of two or more related intrusive units, such as cone-sheets, diatremes, dykes, laccoliths, necks, pipes, plugs, ring-dykes, sheets, sills and veins, that are spatially associated (After: Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "Gillespie & Leslie, 2021"@en ;
     skos:inScheme cs: ;
     skos:notation "rrswm" ;
     skos:prefLabel "swarm"@en ;
     skos:related geof:IgneousIntrusiveRockUnit ;
 .
 
-rur:Complex
+:Complex
     a skos:Concept ;
-    skos:historyNote "The ISG definition is followed, with minor rewording (and without any change of meaning), although a complex unit is not here classified as a lithostratigraphic unit (as per the ISG). The North American Stratigraphic Code (2005) and Kumpulainen (2017), together with other Scandinavian guides, preferably adhere to a more specific definition, restricting a complex to a mixture of two or more genetic classes, albeit regarding a complex as a non-ranked lithodemic unit (generally, a defined, nonstratiform/non-stratified body of predominantly intrusive or highly deformed and/or highly metamorphosed rock). However, as the ISG usage (in embracing a mixture of diverse types of any genetic class) better suits the nomenclature applied to some complex rock units in Queensland, it is therefore provisionally followed. A complex, although unranked in the North American Stratigraphic Code, was considered to be ‘commonly comparable to suite or supersuite’, such that two or more associated complexes could be grouped in a supersuite. This problematical application of lithodemic nomenclature was addressed by the Subcommission on Quaternary Stratigraphy with their suggested introduction of the term ‘supercomplex’ and attendant recommendation for a two-fold hierarchy of rank for lithodemic rock units: lithodeme, suite and supersuite; and complex and supercomplex. Here, complex rock units are separated from lithostratigraphic and other single-class units (e.g., intrusive rock units) and broadly treated as stand-alone, largely nonstratiform, mixed-class units, thus reflecting the approach of Gillespie & Leslie (2021) in their construction of the British Geological Survey’s rock classification system (BRUCS). [Also, following Gillespie & Leslie, the North American Stratigraphic Code lithodemic terminology is not followed, and ‘suite’ rankings are applied solely to intrusive rock units (not also to metamorphic units)]. However, as indicated, nomenclatural usage in Queensland is not true to the more restricted and preferred definition of rock complexes comprising more than one genetic class of rocks (e.g., Jell, 2013)."@en ;
     dcterms:references
         "After and compare: Gillespie, M.R. & Leslie, A.G., 2021: BRUCS: a new system for classifying and naming mappable rock units. Journal of the Geological Society, 178(4), jgs2020-212. <https://jgs.lyellcollection.org/content/jgs/178/4/jgs2020-212.full.pdf>"@en ,
         "After and compare: Kumpulainen (Editor), 2017: Guide for Geological Nomenclature in Sweden. GFF, 139:1, 3-20. <https://doi.org/10.1080/11035897.2016.1178666>"@en ,
@@ -898,6 +896,7 @@ rur:Complex
         "Murphy, M.A. & Salvador, A. (Editors; revised by W.E. Piller & M-P Aubry), Online: International Stratigraphic Guide — An abridged version. Accessed online 04.11.2021. <https://stratigraphy.org/guide/>"@en ;
     rdfs:isDefinedBy cs: ;
     skos:definition "The rank of a rock unit that embraces a mixture of diverse types of any genetic (sedimentary, igneous, metamorphic) class of rocks or a mixture of two or more genetic classes, and characterised by irregularly-mixed lithology or by highly-complicated structural relations [rephrased from International Stratigraphic Guide/ISG (Salvador, 2013; Murphy & Salvador, Online)]. Two or more associated complex rock units may be grouped and ranked as a supercomplex, and a complex rock unit may be divided and ranked into two or more subcomplex rock units (Variously after: Subcommission on Quaternary Stratigraphy; Gillespie & Leslie, 2021)."@en ;
+    skos:historyNote "The ISG definition is followed, with minor rewording (and without any change of meaning), although a complex unit is not here classified as a lithostratigraphic unit (as per the ISG). The North American Stratigraphic Code (2005) and Kumpulainen (2017), together with other Scandinavian guides, preferably adhere to a more specific definition, restricting a complex to a mixture of two or more genetic classes, albeit regarding a complex as a non-ranked lithodemic unit (generally, a defined, nonstratiform/non-stratified body of predominantly intrusive or highly deformed and/or highly metamorphosed rock). However, as the ISG usage (in embracing a mixture of diverse types of any genetic class) better suits the nomenclature applied to some complex rock units in Queensland, it is therefore provisionally followed. A complex, although unranked in the North American Stratigraphic Code, was considered to be ‘commonly comparable to suite or supersuite’, such that two or more associated complexes could be grouped in a supersuite. This problematical application of lithodemic nomenclature was addressed by the Subcommission on Quaternary Stratigraphy with their suggested introduction of the term ‘supercomplex’ and attendant recommendation for a two-fold hierarchy of rank for lithodemic rock units: lithodeme, suite and supersuite; and complex and supercomplex. Here, complex rock units are separated from lithostratigraphic and other single-class units (e.g., intrusive rock units) and broadly treated as stand-alone, largely nonstratiform, mixed-class units, thus reflecting the approach of Gillespie & Leslie (2021) in their construction of the British Geological Survey’s rock classification system (BRUCS). [Also, following Gillespie & Leslie, the North American Stratigraphic Code lithodemic terminology is not followed, and ‘suite’ rankings are applied solely to intrusive rock units (not also to metamorphic units)]. However, as indicated, nomenclatural usage in Queensland is not true to the more restricted and preferred definition of rock complexes comprising more than one genetic class of rocks (e.g., Jell, 2013)."@en ;
     skos:inScheme cs: ;
     skos:notation "rrcom" ;
     skos:prefLabel "complex"@en ;
@@ -924,7 +923,6 @@ cs:
         <https://orcid.org/0000-0002-8742-7730> ;
     dcterms:description "The rock-unit-rank classification provisionally offered here draws variously and with difficulty from several international stratigraphic codes/guides, to best, albeit not fully, adhere to the present nomenclatural, rock-rank usage in Queensland and Australia. However, this work has variously highlighted the inappropriateness and/or deficiencies of some usage, with the aim of the approach presented here to provide a basis for initial discussion and, ultimately, a path to a more-refined, locally-employed rock-unit-rank classification, based on evolving international standards and proposals, to better satisfy the needs and demands of the digital/information age. The principal issue relates to highly metamorphosed rocks of unknown origin [‘where rocks have been modified to the extent that the original unit category … and/or the nature of the relationship with adjacent units … cannot be deduced or inferred reliably (Gillespie & Leslie, 2021, p. 8)]. Such problems have been highlighted and variously dealt with across the codes, guides and classifications referred to. But, in addressing these difficulties, Gillespie & Leslie (2021, p. 8, figure 2), in their new system for classifying mappable rock units in the UK (BRUCS: the British Geological Survey’s Rock Unit Classification System), presented the new class ‘Tectonometamorphic Units’ for ‘rock bodies that cannot reliably be classified as an accumulated unit (either a stratiform/layered-sedimentary or extrusive-igneous-rock unit) or an intrusion as a result of superimposed deformation and/or metamorphism’. They recognised six ranks in this class (in part: Superassemblage, Assemblage, Subassemblage, Ophiolite/Package/Set, etc.), but their attendant terminology almost has no present application to Australian rock ranks/types of such nature (apart from Ophiolite), soliciting a need for review and potential change. Accordingly, for these rock types, specifically highly-metamorphosed rocks, the status quo in Queensland (and Australia) is unavoidably adhered to, presently retaining such rocks as lithostratigraphic units [e.g., Sulieman Gneiss, ASUD* 24510; Plum Mountain Gneiss, ASUD* 24459; Yambo Metamorphic Group (high-grade metasedimentary and meta-igneous rocks), ASUD* 23282; and, of lower metamorphic grade, the structurally-simpler Holroyd Group (metasiltstone/sandstone, slate, phyllite, quartzite, schist, gneiss, metadolerite, amphibolite), ASUD* 25063 (all referred to, e.g., in Jell, 2013: Geology of Queensland, Geological Survey of Queensland, 1063 pages). But, both the latter two units, because of the mixed-genetic rock classes within them, would be more appropriately ranked as complex rock units (than as lithostratigraphic units). Otherwise proposed here is a closely-considered selection, mixture, and, in part, an extension/variation of rank terms variously from: [1] The International Stratigraphic Guide/ISG (Salvador, 1987; Murphy & Salvador, 1999; Salvador, 2013; ISG online, accessed 04.11.2021): for lithostratigraphic units embracing: (a) layered/stratiform, accumulated sedimentary rocks, (b) stratified volcanic rocks, and (c) bodies of metamorphic rocks that can be recognised as of sedimentary and/or extrusive volcanic origin. [2] Gillespie & Leslie (2021) for the BRUCS’s classification of intrusive igneous rocks (Supersuite, Suite, Subsuite, Centre/Cluster, etc.). [3] Scandinavian geological-nomenclatural guides for tectonostratigraphic units (tectonically-displaced, allochthonous sheets: nappes or nappe complexes), largely the guide for Sweden by Kumpulainen (2017), but also see: Nystuen (1989) for the Norwegian guide and Strand et al. (2010) for the Finnish guide). These rock units are essentially tectonometamorphic units sensu Gillespie & Leslie (2021, pp. 8, 16), but, seizing their suggestion, that, ‘in parts of the world … it may be appropriate … to use a hierarchy of tectonostratigraphic units (following the guidance used in Norway, Finland or Sweden)’, they are treated as stand-alone tectonic units. [4] The proposal of the Subcommission on Quaternary Stratigraphy to apply rank to complex rock units (complex, supercomplex), but here recognising complex rock units as a distinct class of rock units (neither as lithodemic units, as per the Subcommission and the North American Stratigraphic Code, nor as lithostratigraphic units, as per the ISG), but largely following Gillespie & Leslie for ‘mixed-class units’, albeit differing from them in the local nomenclatural constraint of necessitating the present need to follow the ISG definition of a ‘Complex’ [a unit composed of diverse types of any class or classes or rocks (sedimentary, igneous, metamorphic), as opposed to a complex embracing a mixture of two or more genetic classes of rocks, i.e., igneous, sedimentary, metamorphic, as per the North American Stratigrphic Code (2005) and Kulpmainen (2017), etc.]. ASUD* = Australian Stratigraphic Units Database Stratigraphic Number."@en ;
     dcterms:modified "2023-03-16"^^xsd:date ;
-    skos:historyNote "Created by the Gological survey of Queensland" ;
     dcterms:publisher <https://linked.data.gov.au/org/gsq> ;
     dcterms:references
         "Australian Stratigraphic Units Database/ASUD, Geoscience Australia. <https://asud.ga.gov.au/search-stratigraphic-units>"@en ,
@@ -946,9 +944,47 @@ cs:
     owl:versionInfo "Most ontology content but not complete diagrammatic coverage." ;
     skos:definition "This vocabulary lists types of rock unit ranks relevant to the Geological Survey of Queensland. It is automatically derived from GSQ's Geologic Features Ontology (https://linked.data.gov.au/def/geofeatures)"@en ;
     skos:editorialNote "Following Gillespie & Leslie (2017), the North-American-Stratigraphic-Code (2005) lithodemic nomenclature (supersuite, suite, lithodeme) for nonstratiform, ranked units of ‘intrusive, highly deformed and/or highly metamorphosed rock’; and for nonstratiform unranked complex units (a mixture of rocks of two or more genetic classes) is not followed, but only from the perspectives: (1) the terms ‘lithodeme’ and ‘lithodemic’ are not utilized; (2) the ‘subsuite’, ‘suite’ and ‘supersuite’ rankings are applied only to intrusive igneous rock units, not also to highly metamorphosed rock units (as also per Gillespie & Leslie, 2021); and complex rock units are treated separately and given rankings (after Gillespie & Leslie, 2021). Lithodemic nomenclature, which included rock complexes, was further advocated in the various Scandinavian nomenclatural guides (e.g., Kumpulainen, 2017); compare the ISG (Online, accessed 28.09.2021) for the little-followed recommendation: ‘use of the term \"suite\" seems inadvisable’. The ‘suite’ terminology is entrenched not only in Queensland/Australian rock nomenclature, but also that of elsewhere."@en ;
-    skos:hasTopConcept <http://sweetontology.net/realmGeol/GeologicFeature> ;
+    skos:hasTopConcept
+        <http://sweetontology.net/realmGeol/GeologicFeature> ,
+        :Assemblage ,
+        :Batholith ,
+        :Bed ,
+        :Beds ,
+        :Complex ,
+        :ConeSheet ,
+        :Diatreme ,
+        :Dyke ,
+        :Flow ,
+        :Formation ,
+        :Group ,
+        :Intrusion ,
+        :IntrusionCentre ,
+        :IntrusionCluster ,
+        :Laccolith ,
+        :Lens ,
+        :Lopolith ,
+        :Member ,
+        :Neck ,
+        :NoRank ,
+        :Ophiolite ,
+        :Pipe ,
+        :Plug ,
+        :Pluton ,
+        :PlutonCluster ,
+        :Ring-dyke ,
+        :RingIntrusion ,
+        :Sheet ,
+        :Sill ,
+        :SillCluster ,
+        :Subassemblage ,
+        :Subcomplex ,
+        :Subgroup ,
+        :Suite ,
+        :Swarm ,
+        :Tongue ,
+        :Vein ;
+    skos:historyNote "Created by the Gological survey of Queensland" ;
     skos:prefLabel "Rock Unit Rank"@en ;
     prof:isProfileOf <http://sweetontology.net/realmGeol> ;
     sdo:codeRepository <https://github.com/geological-survey-of-queensland/rock-unit-rank> ;
 .
-


### PR DESCRIPTION
Rock Unit Rank is missing top concept declarations for most Concepts so they are not displaying, see;

https://vocabs.gsq.digital/v/vocab/defn:rock-unit-rank

This PR just adds them all to the top of the vocab, so all will be listed.

further hierarchy can be added once they are visible, if needed.