### PR TITLE
Resolving UAT Feedback MAR2025-1

### DIFF
--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -1215,7 +1215,7 @@ cdt:material-mineralsand
     skos:prefLabel "Material: Mineral Sand"@en ;
 .
 
-cdt:material-phosphate-rock
+cdt:material-phosphaterock
     a skos:Collection ;
     skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;
     skos:definition "The commodities relevant, applicable, and selectable as part of the material type phosphate rock."@en ;

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -1216,13 +1216,13 @@ cdt:material-mineralsand
 .
 
 cdt:material-phosphate-rock
-    a skos:Collection ;
-    skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;
-    skos:definition "The commodities relevant, applicable, and selectable as part of the material type mineral sand."@en ;
-    skos:member
-        cdt:phosphorous-pentoxide ;
-    skos:notation "MPHR" ;
-    skos:prefLabel "Material: Phosphate Rock"@en ;
+    a skos:Collection ;
+    skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;
+    skos:definition "The commodities relevant, applicable, and selectable as part of the material type phosphate rock."@en ;
+    skos:member
+        cdt:phosphorous-pentoxide ;
+    skos:notation "MPHR" ;
+    skos:prefLabel "Material: Phosphate Rock"@en ;
 .
 
 cdt:material-nonmetal

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -699,8 +699,8 @@ cdt:material-bulkmineral
         cdt:nitrate ,
         cdt:olivine ,
         cdt:orthoclase ,
+        cdt:palagonite ,
         cdt:perlite ,
-        cdt:phosphate-rock ,
         cdt:phosphorous-pentoxide ,
         cdt:potash ,
         cdt:pyrite ,
@@ -879,10 +879,9 @@ cdt:material-earthmaterial
         cdt:magnesite ,
         cdt:other-industrial-mineral ,
         cdt:other-industrial-rock ,
-        cdt:Palagonite ,
+        cdt:palagonite ,
         cdt:peat ,
         cdt:perlite ,
-        cdt:phosphate-rock ,
         cdt:salt ,
         cdt:silica-rock ,
         cdt:silica-sand ,
@@ -1150,8 +1149,7 @@ cdt:material-metaloxide
         cdt:hematite ,
         cdt:magnetite ,
         cdt:manganese ,
-        cdt:tin ,
-        cdt:nickel ;
+        cdt:tin ;
     skos:notation "MLMTO" ;
     skos:prefLabel "Material: Metal Oxide"@en ;
 .
@@ -1161,6 +1159,7 @@ cdt:material-metallicore
     skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;
     skos:definition "The commodities relevant, applicable, and selectable as part of the material type metallic ore."@en ;
     skos:member
+        cdt:alumina ,
         cdt:antimony ,
         cdt:calcite ,
         cdt:chromite ,
@@ -1168,15 +1167,13 @@ cdt:material-metallicore
         cdt:copper ,
         cdt:dolomite ,
         cdt:gold ,
-        cdt:hematite-ore ,
+        cdt:hematite ,
         cdt:iron ,
-        cdt:iron-ore ,
-        cdt:laterite ,
         cdt:lead ,
         cdt:magnesite ,
-        cdt:magnetite-ore ,
+        cdt:magnetite ,
         cdt:malachite ,
-        cdt:manganese-ore ,
+        cdt:manganese ,
         cdt:molybdenum ,
         cdt:nickel ,
         cdt:rhenium ,
@@ -1224,7 +1221,7 @@ cdt:material-phosphate-rock
     skos:definition "The commodities relevant, applicable, and selectable as part of the material type mineral sand."@en ;
     skos:member
         cdt:phosphorous-pentoxide ;
-    skos:notation "MLMPHR" ;
+    skos:notation "MPHR" ;
     skos:prefLabel "Material: Phosphate Rock"@en ;
 .
 

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -1216,13 +1216,13 @@ cdt:material-mineralsand
 .
 
 cdt:material-phosphaterock
-    a skos:Collection ;
-    skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;
-    skos:definition "The commodities relevant, applicable, and selectable as part of the material type phosphate rock."@en ;
-    skos:member
-        cdt:phosphorous-pentoxide ;
-    skos:notation "MPHR" ;
-    skos:prefLabel "Material: Phosphate Rock"@en ;
+    a skos:Collection ;
+    skos:historyNote "CGI Commodity code, adapted and augmented by the Geological Survey of Queensland with information from industry specfic requirements and from the Australian Uniform Code of Nomenclature for Reporting Production of Industrial Minerals by DNREV, 1996" ;
+    skos:definition "The commodities relevant, applicable, and selectable as part of the material type phosphate rock."@en ;
+    skos:member
+        cdt:phosphorous-pentoxide ;
+    skos:notation "MPHR" ;
+    skos:prefLabel "Material: Phosphate Rock"@en ;
 .
 
 cdt:material-nonmetal

--- a/vocabularies-gsq/sample-material.ttl
+++ b/vocabularies-gsq/sample-material.ttl
@@ -230,6 +230,7 @@ spmt:min-products
         spmt:metal-cathode ,
         spmt:metal-concentrate ,
         spmt:metal-hydroxide ,
+        spmt:metallic-ore ,
         spmt:metal-oxide ,
         spmt:metal-sulphate ,
         spmt:non-metal ,


### PR DESCRIPTION
Following Mike's review of the changes in uat, the following updates have been made. I can't see why the collection for material-phosphate-rock was not feeding to lodgement portal, so in hopes of appeasing the machine spirit, I've removed the second dash, pasted over the working material-bauxite collection and then modified that back to include the phosphate-rock concept details. The others should be self-explanatory in their reasoning. 

add cdt:palagonite to cdt:material-bulkmineral
remove cdt:phosphate-rock FROM cdt:material-bulkmineral

replace cdt:Palagonite WITH cdt:palagonite in cdt:material-earthmaterial

remove cdt:nickel from cdt:material-metaloxide

add cdt:alumina, cdt:hematite, cdt:magnetite, cdt:manganese to cdt:material-metallicore
remove cdt:hematite-ore, cdt:iron-ore, cdt:laterite, cdt:magnetite-ore, cdt:manganese-ore from cdt:material-metallicore

remove cdt:phosphate-rock from cdt:material-earthmaterial

replace cdt:material-phosphate-rock with cdt:material-phosphaterock