### PR TITLE
MMck UAT Review Mar-2025-2

### DIFF
--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -691,6 +691,7 @@ cdt:material-bulkmineral
         cdt:kyanite ,
         cdt:lime ,
         cdt:magnesite ,
+        cdt:magnetite ,
         cdt:mica ,
         cdt:mineral-sand ,
         cdt:mineral-wool ,

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -5502,7 +5502,7 @@ cdt:zircon
     skos:exactMatch <http://resource.geosciml.org/classifier/cgi/commodity-code/zircon> ;
     skos:inScheme cs: ;
     skos:notation "ZIR" ;
-    skos:prefLabel "Zircon"@en ;
+    skos:prefLabel "Zircon (Zr)"@en ;
 .
 
 cdt:aggregate

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -1147,6 +1147,7 @@ cdt:material-metaloxide
     skos:member
         cdt:alumina ,
         cdt:hematite ,
+        cdt:magnesium ,
         cdt:magnetite ,
         cdt:manganese ,
         cdt:tin ;

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -1971,7 +1971,7 @@ cdt:magnetite
     skos:exactMatch <http://resource.geosciml.org/classifier/cgi/commodity-code/magnetite> ;
     skos:inScheme cs: ;
     skos:notation "MT" ;
-    skos:prefLabel "Magnetite Fe3O4"@en ;
+    skos:prefLabel "Magnetite (Fe3O4)"@en ;
 .
 
 cdt:natural-secondary-aggregate
@@ -2861,7 +2861,7 @@ cdt:hematite
     skos:exactMatch <http://resource.geosciml.org/classifier/cgi/commodity-code/hematite> ;
     skos:inScheme cs: ;
     skos:notation "HEM" ;
-    skos:prefLabel "Hematite Fe2O3"@en ;
+    skos:prefLabel "Hematite (Fe2O3)"@en ;
 .
 
 cdt:horticultural-sand

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -3113,7 +3113,7 @@ cdt:phosphorous-pentoxide
     skos:exactMatch <http://resource.geosciml.org/classifier/cgi/commodity-code/phosphorous-pentoxide> ;
     skos:inScheme cs: ;
     skos:notation "PO" ;
-    skos:prefLabel "Phosphorous Pentoxide P2O5"@en ;
+    skos:prefLabel "Phosphorous Pentoxide (P2O5)"@en ;
 .
 
 cdt:plaster-sand

--- a/vocabularies-gsq/geo-commodities.ttl
+++ b/vocabularies-gsq/geo-commodities.ttl
@@ -5504,7 +5504,7 @@ cdt:zircon
     skos:exactMatch <http://resource.geosciml.org/classifier/cgi/commodity-code/zircon> ;
     skos:inScheme cs: ;
     skos:notation "ZIR" ;
-    skos:prefLabel "Zircon (Zr)"@en ;
+    skos:prefLabel "Zircon"@en ;
 .
 
 cdt:aggregate


### PR DESCRIPTION
Adding brackets to minerals with formula.
Added (Zr) to elemental Zircon to maintain consistency.

Administrative: Raised with RPI team questions as to whether adding mineral formulae is consistent, and how to best manage that dissonance in the future. Potentially rolling back the addition of formula to certain minerals, modifying the SPARQL to better suit the business need, by building compound terms from Minerals and Commodities vocabs, or creating logic that defines the reasoning for adding formula to only specific concepts.