### PR TITLE
Update ANZIC2006-industry-classifications.ttl

### DIFF
--- a/vocabularies-gsq/ANZIC2006-industry-classifications.ttl
+++ b/vocabularies-gsq/ANZIC2006-industry-classifications.ttl
@@ -1,5 +1,5 @@
 PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
-PREFIX cs: <http://linked.data.gov.au/def/anzsic-2006>
+PREFIX icatcs: <http://linked.data.gov.au/def/anzsic-2006>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX icat: <http://linked.data.gov.au/def/anzsic-2006/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -10,2385 +10,8924 @@ PREFIX sdo: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-icat:A0110
-    a skos:Concept ;
+#CONCEPT SCHEME
+
+icatcs:
+    a
+        owl:Ontology ,
+        skos:ConceptScheme ;
+    dcterms:created "2020-02-17"^^xsd:date ;
+    dcterms:creator <https://linked.data.gov.au/org/gsq> ;
+    dcterms:modified "2024-04-09"^^xsd:date ;
+    dcterms:publisher <https://linked.data.gov.au/org/gsq> ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Nursery and Floriculture Production."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0110" ;
+    reg:status agldwgstatus:stable ;
+    skos:definition """An industrial classification organises data about business units. It provides a standard framework under which business units carrying out similar production activities can be grouped together, with each resultant group referred to as an industry.\r
+    An individual business entity is assigned to an industry based on its predominant economic activity. The term business entity is used in its widest sense to include any organisation undertaking productive activities, including companies, non-profit organisations, government departments and enterprises. ANZSIC has four hierarchic levels: Divisions (the broadest level), Subdivisions, Groups and Classes (the finest level).
+    At the Divisional level, the main purpose is to provide a limited number of categories which provide a broad overall picture of the economy and are suitable for the publication of summary tables in official statistics. The Subdivision, Group and Class levels provide increasingly detailed dissections of these categories for the compilation of more specific and detailed statistics."""@en ;
+    skos:hasTopConcept
+        icat:A ,
+        icat:B ,
+        icat:C ,
+        icat:D ,
+        icat:E ,
+        icat:F ,
+        icat:G ,
+        icat:H ,
+        icat:I ,
+        icat:J ,
+        icat:K ,
+        icat:L ,
+        icat:M ,
+        icat:N ,
+        icat:O ,
+        icat:P ,
+        icat:Q ,
+        icat:R ,
+        icat:S ,
+        icat:X ;
+    skos:prefLabel "Australian and New Zealand Standard Industrial Classification 2006 - Codes and Titles"@en ;
+.
+
+#CONCEPTS
+
+icat:A a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Agriculture, Forestry and Fishing Division includes units mainly engaged in growing crops, raising animals, growing and harvesting timber, and harvesting fish and other animals from farms or their natural habitats. The division makes a distinction between two basic activities: production and support services to production. Included as production activities are horticulture, livestock production, aquaculture, forestry and logging, and fishing, hunting and trapping.
+
+The term 'agriculture' is used broadly to refer to both the growing and cultivation of horticultural and other crops (excluding forestry), and the controlled breeding, raising or farming of animals (excluding aquaculture).
+
+Aquacultural activities include the controlled breeding, raising or farming of fish, molluscs and crustaceans.
+
+Forestry and logging activities include growing, maintaining and harvesting forests, as well as gathering forest products.
+
+Fishing, hunting and trapping includes gathering or catching marine life such as fish or shellfish, or other animals, from their uncontrolled natural environments in water or on land.
+
+Also included in the division are units engaged in providing support services to the units engaged in production activities.."""@en ;
+    skos:notation "A" ;
+    skos:prefLabel "Agriculture, Forestry and Fishing"@en ;
+.
+
+icat:01 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:A ; 
+    skos:definition """This subdivision includes units mainly engaged in Agriculture."""@en ;
+    skos:notation "01" ;
+    skos:prefLabel "Agriculture"@en ;
+.
+
+icat:011 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Nursery and Floriculture Production."""@en ;
+    skos:notation "011" ;
     skos:prefLabel "Nursery and Floriculture Production"@en ;
 .
 
-icat:A0120
-    a skos:Concept ;
+icat:0111 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Mushroom and Vegetable Growing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0120" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:011 ; 
+    skos:example 
+        "Bedding plant growing (under cover)"@en,
+        "Bulb propagating (under cover)"@en,
+        "Fruit tree nursery operation (under cover)"@en,
+        "Nursery production n.e.c. (under cover)"@en,
+        "Ornamental plant growing (under cover)"@en,
+        "Perennial growing (under cover)"@en,
+        "Seedling growing (under cover)"@en,
+        "Vine stock nursery operation (under cover)"@en ;
+    skos:definition """This class consists of units mainly engaged in propagating and/or growing plants (or parts of plants) under cover. 'Under cover' is generally defined as greenhouses, cold frames, cloth houses and lath houses. Also included are units mainly engaged in propagating and/or growing plant nursery products (except nursery stock for forests), bulbs, corms, or tubers under cover.."""@en ;
+    skos:notation "0111" ;
+    skos:prefLabel "Nursery Production (Under Cover)"@en ;
+.
+
+icat:0112 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:011 ; 
+    skos:example 
+        "Bulb propagating (outdoors)"@en,
+        "Fruit tree nursery operation (outdoors)"@en,
+        "Nursery production n.e.c. (outdoors)"@en,
+        "Ornamental plant growing (outdoors)"@en,
+        "Seedling growing (outdoors)"@en,
+        "Vine stock nursery operation (outdoors)"@en ;
+    skos:definition """This class consists of units mainly engaged in propagating and/or growing plants (or parts of plants) outdoors. Also included are units mainly engaged in propagating and/or growing plant nursery products (such as ornamental plants, fruit trees or seedlings), bulbs, corms, or tubers outdoors.."""@en ;
+    skos:notation "0112" ;
+    skos:prefLabel "Nursery Production (Outdoors)"@en ;
+.
+
+icat:0113 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:011 ; 
+    skos:example 
+        "Turf growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing turf for transplanting.."""@en ;
+    skos:notation "0113" ;
+    skos:prefLabel "Turf Growing"@en ;
+.
+
+icat:0114 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:011 ; 
+    skos:example 
+        "Display foliage growing (under cover)"@en,
+        "Flower growing (under cover)"@en,
+        "Orchid growing (under cover)"@en,
+        "Seed, flower, growing (under cover)"@en ;
+    skos:definition """This class consists of units mainly engaged in growing and/or producing floriculture products such as cut flowers or foliage, or flower seeds under cover. 'Under cover' is generally defined as greenhouses, cold frames, cloth houses and lath houses.."""@en ;
+    skos:notation "0114" ;
+    skos:prefLabel "Floriculture Production (Under Cover)"@en ;
+.
+
+icat:0115 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:011 ; 
+    skos:example 
+        "Calla lily growing (outdoor)"@en,
+        "Display foliage growing (outdoors)"@en,
+        "Flower growing (outdoors)"@en,
+        "Hydrangea growing (outdoors)"@en,
+        "Peony growing (outdoor)"@en,
+        "Seed, flower, growing (outdoors)"@en ;
+    skos:definition """This class consists of units mainly engaged in growing and/or producing floriculture products outdoors, such as cut flowers or foliage, or flower seeds.."""@en ;
+    skos:notation "0115" ;
+    skos:prefLabel "Floriculture Production (Outdoors)"@en ;
+.
+
+icat:012 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Mushroom and Vegetable Growing."""@en ;
+    skos:notation "012" ;
     skos:prefLabel "Mushroom and Vegetable Growing"@en ;
 .
 
-icat:A0130
-    a skos:Concept ;
+icat:0121 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Fruit and Tree Nut Growing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0130" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:012 ; 
+    skos:example 
+        "Cultivated mushroom growing"@en,
+        "Mushroom spawn growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing cultivated mushrooms in climate-controlled environments.."""@en ;
+    skos:notation "0121" ;
+    skos:prefLabel "Mushroom Growing"@en ;
+.
+
+icat:0122 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:012 ; 
+    skos:example 
+        "Capsicum growing (under cover)"@en,
+        "Cucumber growing (under cover)"@en,
+        "Herb growing (under cover)"@en,
+        "Lettuce growing (under cover)"@en,
+        "Sprout growing (under cover)"@en,
+        "Tomato growing (under cover)"@en,
+        "Vegetable growing n.e.c. (under cover)"@en ;
+    skos:definition """This class consists of units mainly engaged in growing vegetable crops under cover (including hydroponic systems). 'Under cover' is generally defined as greenhouses, cold frames, cloth houses and lath houses.."""@en ;
+    skos:notation "0122" ;
+    skos:prefLabel "Vegetable Growing (Under Cover)"@en ;
+.
+
+icat:0123 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:012 ; 
+    skos:example 
+        "Asparagus growing (outdoors)"@en,
+        "Bean growing (outdoors; except dry field beans or soybeans)"@en,
+        "Carrot growing (outdoors)"@en,
+        "Garlic growing (outdoors)"@en,
+        "Herb growing (outdoors)"@en,
+        "Kumara growing (outdoors)"@en,
+        "Melon growing (outdoors)"@en,
+        "Onion growing (outdoors)"@en,
+        "Pea growing (outdoors; except dry field peas)"@en,
+        "Potato growing (outdoors)"@en,
+        "Sugar beet growing (outdoors)"@en,
+        "Sweetcorn growing (outdoors)"@en,
+        "Tomato growing (outdoors)"@en,
+        "Truffle growing (outdoors)"@en,
+        "Vegetable growing n.e.c. (outdoors)"@en,
+        "Vegetable seed growing (outdoors)"@en ;
+    skos:definition """This class consists of units mainly engaged in growing vegetable crops outdoors in open fields. Units mainly engaged in growing fresh herbs, melons, and tomatoes (outdoors) are also included in this class.."""@en ;
+    skos:notation "0123" ;
+    skos:prefLabel "Vegetable Growing (Outdoors)"@en ;
+.
+
+icat:013 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Fruit and Tree Nut Growing."""@en ;
+    skos:notation "013" ;
     skos:prefLabel "Fruit and Tree Nut Growing"@en ;
 .
 
-icat:A0140
-    a skos:Concept ;
+icat:0131 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Sheep, Beef Cattle and Grain Farming."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0140" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Grape growing"@en,
+        "Grape sundrying"@en,
+        "Table grape growing"@en,
+        "Vineyard operation"@en,
+        "Wine grape growing"@en ;
+    skos:definition """This class includes units mainly engaged in growing table or wine grapes; or sun drying grapes.."""@en ;
+    skos:notation "0131" ;
+    skos:prefLabel "Grape Growing"@en ;
+.
+
+icat:0132 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Kiwifruit growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing kiwifruit.."""@en ;
+    skos:notation "0132" ;
+    skos:prefLabel "Kiwifruit Growing"@en ;
+.
+
+icat:0133 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Berryfruit growing"@en,
+        "Blackberry growing"@en,
+        "Blackcurrant growing"@en,
+        "Blueberry growing"@en,
+        "Boysenberry growing"@en,
+        "Cranberry growing"@en,
+        "Gooseberry growing"@en,
+        "Loganberry growing"@en,
+        "Raspberry growing"@en,
+        "Redcurrant growing"@en,
+        "Strawberry growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing berry fruit.."""@en ;
+    skos:notation "0133" ;
+    skos:prefLabel "Berry Fruit Growing"@en ;
+.
+
+icat:0134 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Apple growing"@en,
+        "Nashi pear growing"@en,
+        "Pear growing"@en,
+        "Quince growing"@en ;
+    skos:definition """This class includes units mainly engaged in growing apples, pears or other pome fruit such as nashi pears or quinces.."""@en ;
+    skos:notation "0134" ;
+    skos:prefLabel "Apple and Pear Growing"@en ;
+.
+
+icat:0135 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Apricot growing"@en,
+        "Cherry growing"@en,
+        "Nectarine growing"@en,
+        "Peach growing"@en,
+        "Plum or prune growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing stone fruit such as apricots, cherries, nectarines, peaches and plums.."""@en ;
+    skos:notation "0135" ;
+    skos:prefLabel "Stone Fruit Growing"@en ;
+.
+
+icat:0136 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Citrus fruit growing"@en,
+        "Citrus orchard operation"@en,
+        "Grapefruit growing"@en,
+        "Lemon growing"@en,
+        "Mandarin growing"@en,
+        "Orange growing"@en,
+        "Tangelo growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing citrus fruit.."""@en ;
+    skos:notation "0136" ;
+    skos:prefLabel "Citrus Fruit Growing"@en ;
+.
+
+icat:0137 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Olive growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing olives.."""@en ;
+    skos:notation "0137" ;
+    skos:prefLabel "Olive Growing"@en ;
+.
+
+icat:0139 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:013 ; 
+    skos:example 
+        "Almond growing"@en,
+        "Avocado growing"@en,
+        "Banana growing"@en,
+        "Brazil nut growing"@en,
+        "Cashew nut growing"@en,
+        "Chestnut growing"@en,
+        "Coconut growing"@en,
+        "Custard apple growing"@en,
+        "Feijoa growing"@en,
+        "Fig growing"@en,
+        "Loquat growing"@en,
+        "Macadamia nut growing"@en,
+        "Mango growing"@en,
+        "Passionfruit growing"@en,
+        "Pawpaw growing"@en,
+        "Pecan nut growing"@en,
+        "Persimmon growing"@en,
+        "Pineapple growing"@en,
+        "Tamarillo growing"@en,
+        "Walnut growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing tree nuts, tropical fruit, subtropical fruit, and other fruit not elsewhere classified.."""@en ;
+    skos:notation "0139" ;
+    skos:prefLabel "Other Fruit and Tree Nut Growing"@en ;
+.
+
+icat:014 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Sheep, Beef Cattle and Grain Farming."""@en ;
+    skos:notation "014" ;
     skos:prefLabel "Sheep, Beef Cattle and Grain Farming"@en ;
 .
 
-icat:A0150
-    a skos:Concept ;
+icat:0141 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Crop Growing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0150" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:014 ; 
+    skos:example 
+        "Prime lamb raising"@en,
+        "Raw sheep milk production"@en,
+        "Sheep agistment service"@en,
+        "Sheep farming"@en,
+        "Wool growing"@en ;
+    skos:definition """This class consists of units mainly engaged in farming sheep.."""@en ;
+    skos:notation "0141" ;
+    skos:prefLabel "Sheep Farming (Specialised)"@en ;
+.
+
+icat:0142 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:014 ; 
+    skos:example 
+        "Beef cattle farming"@en,
+        "Buffalo, domesticated, grazing"@en,
+        "Dairy cattle agistment service"@en,
+        "Dairy cattle replacement farming"@en ;
+    skos:definition """This class consists of units mainly engaged in farming beef cattle.."""@en ;
+    skos:notation "0142" ;
+    skos:prefLabel "Beef Cattle Farming (Specialised)"@en ;
+.
+
+icat:0143 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:014 ; 
+    skos:example 
+        "Beef cattle feedlot operation"@en ;
+    skos:definition """This class consists of units mainly engaged in operating feedlots for beef cattle. A feedlot is a confined area with watering and feeding facilities where cattle are hand or mechanically fed for the purposes of production.."""@en ;
+    skos:notation "0143" ;
+    skos:prefLabel "Beef Cattle Feedlots (Specialised)"@en ;
+.
+
+icat:0144 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:014 ; 
+    skos:example 
+        "Beef cattle and sheep farming"@en,
+        "Sheep and beef cattle farming"@en ;
+    skos:definition """This class consists of units mainly engaged in farming both sheep and beef cattle.."""@en ;
+    skos:notation "0144" ;
+    skos:prefLabel "Sheep-Beef Cattle Farming"@en ;
+.
+
+icat:0145 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:014 ; 
+    skos:example 
+        "Beef cattle farming and grain growing"@en,
+        "Grain growing and sheep or beef cattle farming"@en,
+        "Prime lamb raising and grain growing"@en,
+        "Sheep farming and grain growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing grain in conjunction with sheep farming or beef cattle farming.."""@en ;
+    skos:notation "0145" ;
+    skos:prefLabel "Grain-Sheep or Grain-Beef Cattle Farming"@en ;
+.
+
+icat:0146 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:014 ; 
+    skos:example 
+        "Rice growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing rice.."""@en ;
+    skos:notation "0146" ;
+    skos:prefLabel "Rice Growing"@en ;
+.
+
+icat:0149 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:014 ; 
+    skos:example 
+        "Barley growing"@en,
+        "Cereal grain growing"@en,
+        "Coarse grain growing"@en,
+        "Field pea or field bean growing"@en,
+        "Grain seed growing"@en,
+        "Lupin growing"@en,
+        "Maize growing"@en,
+        "Millet growing"@en,
+        "Oat growing"@en,
+        "Oilseed growing n.e.c."@en,
+        "Pasture seed growing"@en,
+        "Safflower growing"@en,
+        "Sorghum growing (except forage sorghum)"@en,
+        "Soybean growing"@en,
+        "Sunflower growing"@en,
+        "Wheat growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing cereal or coarse grains or other cereal crops (except rice). Also included are units mainly engaged in growing oilseeds, pasture seeds, lupins, field peas or beans.."""@en ;
+    skos:notation "0149" ;
+    skos:prefLabel "Other Grain Growing"@en ;
+.
+
+icat:015 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Other Crop Growing."""@en ;
+    skos:notation "015" ;
     skos:prefLabel "Other Crop Growing"@en ;
 .
 
-icat:A0160
-    a skos:Concept ;
+icat:0151 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Dairy Cattle Farming."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0160" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:015 ; 
+    skos:example 
+        "Sugar cane growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing sugar cane.."""@en ;
+    skos:notation "0151" ;
+    skos:prefLabel "Sugar Cane Growing"@en ;
+.
+
+icat:0152 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:015 ; 
+    skos:example 
+        "Cotton growing"@en ;
+    skos:definition """This class consists of units mainly engaged in growing cotton.."""@en ;
+    skos:notation "0152" ;
+    skos:prefLabel "Cotton Growing"@en ;
+.
+
+icat:0159 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:015 ; 
+    skos:example 
+        "Arrowroot growing"@en,
+        "Bamboo growing"@en,
+        "Flax seed growing"@en,
+        "Fodder growing"@en,
+        "Forage sorghum growing"@en,
+        "Ginger growing"@en,
+        "Hop growing"@en,
+        "Jute growing"@en,
+        "Lavender growing"@en,
+        "Lucerne growing"@en,
+        "Mustard growing"@en,
+        "Pasture growing for hay or silage"@en,
+        "Peanut growing"@en,
+        "Pharmaceutical/cosmetic plant growing"@en,
+        "Seed growing n.e.c."@en,
+        "Spice crop growing"@en,
+        "Sudan grass growing"@en,
+        "Tobacco growing"@en,
+        "Vegetable growing for fodder"@en ;
+    skos:definition """This class consists of units mainly engaged in growing horticultural crops and plants not elsewhere classified, including animal fodder crops such as hay, sudan grass and silage.."""@en ;
+    skos:notation "0159" ;
+    skos:prefLabel "Other Crop Growing n.e.c."@en ;
+.
+
+icat:016 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Dairy Cattle Farming."""@en ;
+    skos:notation "016" ;
     skos:prefLabel "Dairy Cattle Farming"@en ;
 .
 
-icat:A0170
-    a skos:Concept ;
+icat:0160 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Poultry Farming."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0170" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:016 ; 
+    skos:example 
+        "Dairy cattle farming"@en,
+        "Raw cattle milk production"@en,
+        "Sharemilking dairy cattle"@en ;
+    skos:definition """This class consists of units mainly engaged in farming dairy cattle. Also included are units mainly engaged in sharemilking i.e. where the unit is contracted to milk the herd and/or perform other farm duties for a share of the milk income.."""@en ;
+    skos:notation "0160" ;
+    skos:prefLabel "Dairy Cattle Farming"@en ;
+.
+
+icat:017 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Poultry Farming."""@en ;
+    skos:notation "017" ;
     skos:prefLabel "Poultry Farming"@en ;
 .
 
-icat:A0180
-    a skos:Concept ;
+icat:0171 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Deer Farming."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0180" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:017 ; 
+    skos:example 
+        "Chicken farming (for meat)"@en,
+        "Duck farming"@en,
+        "Game bird farming"@en,
+        "Goose farming"@en,
+        "Poultry farming (for meat)"@en,
+        "Poultry hatchery operation (meat breeds)"@en,
+        "Turkey farming"@en ;
+    skos:definition """This class consists of units mainly engaged in raising poultry for production of meat or in hatching meat breed chicks. This class also includes the raising of game birds for meat or in hatching game birds for raising for meat.."""@en ;
+    skos:notation "0171" ;
+    skos:prefLabel "Poultry Farming (Meat)"@en ;
+.
+
+icat:0172 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:017 ; 
+    skos:example 
+        "Egg farm operation"@en,
+        "Poultry farming (for eggs)"@en,
+        "Poultry hatchery operation (egg breeds)"@en ;
+    skos:definition """This class consists of units mainly engaged in farming poultry for production of eggs or in hatching egg breed chicks.."""@en ;
+    skos:notation "0172" ;
+    skos:prefLabel "Poultry Farming (Eggs)"@en ;
+.
+
+icat:018 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Deer Farming."""@en ;
+    skos:notation "018" ;
     skos:prefLabel "Deer Farming"@en ;
 .
 
-icat:A0190
-    a skos:Concept ;
+icat:0180 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Livestock Farming."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0190" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:018 ; 
+    skos:example 
+        "Deer breeding"@en,
+        "Deer farming for venison"@en,
+        "Deer velvet production"@en ;
+    skos:definition """This class consists of units mainly engaged in farming deer.."""@en ;
+    skos:notation "0180" ;
+    skos:prefLabel "Deer Farming"@en ;
+.
+
+icat:019 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:01 ; 
+    skos:definition """This group includes units mainly engaged in Other Livestock Farming."""@en ;
+    skos:notation "019" ;
     skos:prefLabel "Other Livestock Farming"@en ;
 .
 
-icat:A0200
-    a skos:Concept ;
+icat:0191 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Aquaculture."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0200" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:019 ; 
+    skos:example 
+        "Horse agistment service"@en,
+        "Horse breeding"@en,
+        "Stud farm operation (horses)"@en ;
+    skos:definition """This class consists of units mainly engaged in farming horses.."""@en ;
+    skos:notation "0191" ;
+    skos:prefLabel "Horse Farming"@en ;
+.
+
+icat:0192 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:019 ; 
+    skos:example 
+        "Pig farming"@en,
+        "Pig raising"@en ;
+    skos:definition """This class consists of units mainly engaged in farming pigs.."""@en ;
+    skos:notation "0192" ;
+    skos:prefLabel "Pig Farming"@en ;
+.
+
+icat:0193 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:019 ; 
+    skos:example 
+        "Apiculture"@en,
+        "Beekeeping"@en ;
+    skos:definition """This class consists of units mainly engaged in raising bees, including collecting honey, royal jelly, bees’ wax, or other bee products.."""@en ;
+    skos:notation "0193" ;
+    skos:prefLabel "Beekeeping"@en ;
+.
+
+icat:0199 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:019 ; 
+    skos:example 
+        "Alpaca farming"@en,
+        "Bird breeding (except poultry or game birds)"@en,
+        "Cat breeding"@en,
+        "Crocodile farming"@en,
+        "Dairy goat farming"@en,
+        "Dog breeding"@en,
+        "Emu farming"@en,
+        "Fur skin animal (including possum and ferret) farming"@en,
+        "Goat farming"@en,
+        "Livestock raising n.e.c."@en,
+        "Ostrich farming"@en,
+        "Pet breeding"@en,
+        "Rabbit farming"@en,
+        "Snake farming"@en,
+        "Worm farming"@en ;
+    skos:definition """This class consists of units mainly engaged in breeding or raising farm or domestic animals not elsewhere classified.."""@en ;
+    skos:notation "0199" ;
+    skos:prefLabel "Other Livestock Farming n.e.c."@en ;
+.
+
+icat:02 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:A ; 
+    skos:definition """This subdivision includes units mainly engaged in Aquaculture."""@en ;
+    skos:notation "02" ;
     skos:prefLabel "Aquaculture"@en ;
 .
 
-icat:A0300
-    a skos:Concept ;
+icat:020 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Forestry and Logging."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0300" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:02 ; 
+    skos:definition """This group includes units mainly engaged in Aquaculture."""@en ;
+    skos:notation "020" ;
+    skos:prefLabel "Aquaculture"@en ;
+.
+
+icat:0201 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:020 ; 
+    skos:example 
+        "Mussel farming (longline)"@en,
+        "Offshore longline or rack aquaculture"@en,
+        "Oyster farming (rack)"@en,
+        "Paua farming (longline or rack)"@en,
+        "Pearl oyster farming (rack)"@en,
+        "Seaweed farming (longline or rack)"@en ;
+    skos:definition """This class consists of units mainly engaged in offshore farming of molluscs and seaweed using longlines (rope) or racks.."""@en ;
+    skos:notation "0201" ;
+    skos:prefLabel "Offshore Longline and Rack Aquaculture"@en ;
+.
+
+icat:0202 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:020 ; 
+    skos:example 
+        "Finfish farming (caged)"@en,
+        "Salmon farming (caged)"@en,
+        "Trout farming (caged)"@en,
+        "Tuna farming (caged)"@en ;
+    skos:definition """This class consists of units mainly engaged in offshore farming of finfish using cages.."""@en ;
+    skos:notation "0202" ;
+    skos:prefLabel "Offshore Caged Aquaculture"@en ;
+.
+
+icat:0203 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:020 ; 
+    skos:example 
+        "Crustacean or mollusc breeding or farming (pond or tank)"@en,
+        "Fish breeding or farming (pond or tank)"@en,
+        "Fish hatchery operation"@en,
+        "Ornamental fish farming"@en,
+        "Paua farming (pond)"@en,
+        "Prawn farming (pond)"@en,
+        "Salmon farming (pond or tank)"@en,
+        "Trout farming (pond or tank)"@en,
+        "Tuna farming (pond or tank)"@en,
+        "Yabby farming (pond or tank)"@en ;
+    skos:definition """This class consists of units mainly engaged in farming finfish, crustaceans or molluscs in tanks or ponds onshore.."""@en ;
+    skos:notation "0203" ;
+    skos:prefLabel "Onshore Aquaculture"@en ;
+.
+
+icat:03 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:A ; 
+    skos:definition """This subdivision includes units mainly engaged in Forestry and Logging."""@en ;
+    skos:notation "03" ;
     skos:prefLabel "Forestry and Logging"@en ;
 .
 
-icat:A0410
-    a skos:Concept ;
+icat:030 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Fishing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0410" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:03 ; 
+    skos:definition """This group includes units mainly engaged in Forestry and Logging."""@en ;
+    skos:notation "030" ;
+    skos:prefLabel "Forestry and Logging"@en ;
+.
+
+icat:0301 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:030 ; 
+    skos:example 
+        "Forest product gathering"@en,
+        "Forestry growing operation"@en,
+        "Kauri gum digging"@en,
+        "Native orchid gathering"@en,
+        "Pine cone collecting"@en,
+        "Resin gathering"@en,
+        "Sphagnum moss gathering"@en ;
+    skos:definition """This class consists of units mainly engaged in growing standing timber in native or plantation forests, or timber tracts, for commercial benefit. This class also includes the gathering of forest products such as mushrooms, kauri gum or resin from forest environments.."""@en ;
+    skos:notation "0301" ;
+    skos:prefLabel "Forestry"@en ;
+.
+
+icat:0302 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:030 ; 
+    skos:example 
+        "Firewood cutting (forest)"@en,
+        "Logging"@en,
+        "Mine timber hewing (forest)"@en,
+        "Pole hewing (forest)"@en,
+        "Post shaping (forest)"@en,
+        "Railway sleeper hewing"@en,
+        "Rough shaping of forest timber"@en,
+        "Timber hewing (forest)"@en,
+        "Tree cutting or felling"@en ;
+    skos:definition """This class consists of units mainly engaged in logging native or plantation forests, including felling, cutting and/or roughly hewing logs into products such as railway sleepers or posts. This class also includes units mainly engaged in cutting trees and scrubs for firewood.."""@en ;
+    skos:notation "0302" ;
+    skos:prefLabel "Logging"@en ;
+.
+
+icat:04 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:A ; 
+    skos:definition """This subdivision includes units mainly engaged in Fishing, Hunting and Trapping."""@en ;
+    skos:notation "04" ;
+    skos:prefLabel "Fishing, Hunting and Trapping"@en ;
+.
+
+icat:041 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:04 ; 
+    skos:definition """This group includes units mainly engaged in Fishing."""@en ;
+    skos:notation "041" ;
     skos:prefLabel "Fishing"@en ;
 .
 
-icat:A0420
-    a skos:Concept ;
+icat:0411 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Hunting and Trapping."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0420" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:041 ; 
+    skos:example 
+        "Crab fishing or potting"@en,
+        "Rock lobster fishing or potting"@en,
+        "Saltwater crayfish fishing"@en ;
+    skos:definition """This class consists of units mainly engaged in catching rock lobsters or crabs from their natural habitats of ocean or coastal waters, using baited pots.."""@en ;
+    skos:notation "0411" ;
+    skos:prefLabel "Rock Lobster and Crab Potting"@en ;
+.
+
+icat:0412 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:041 ; 
+    skos:example 
+        "Prawn fishing"@en,
+        "Scampi fishing"@en ;
+    skos:definition """This class consists of units mainly engaged in catching prawns from ocean or coastal waters.."""@en ;
+    skos:notation "0412" ;
+    skos:prefLabel "Prawn Fishing"@en ;
+.
+
+icat:0413 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:041 ; 
+    skos:example 
+        "Bottom long line fishing"@en,
+        "Line fishing"@en,
+        "Ocean trolling"@en,
+        "Squid jigging"@en,
+        "Surface long line fishing"@en ;
+    skos:definition """This class consists of units mainly engaged in line fishing in inshore, mid-depth or surface waters. This class includes units engaged in several fishing methods, including surface or bottom long lining, trolling, or hand or powered-reel fishing.."""@en ;
+    skos:notation "0413" ;
+    skos:prefLabel "Line Fishing"@en ;
+.
+
+icat:0414 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:041 ; 
+    skos:example 
+        "Beach seining, fishing"@en,
+        "Bottom gill netting, fishing"@en,
+        "Danish seining, fishing"@en,
+        "Finfish trawling"@en,
+        "Pair trawling"@en,
+        "Purse seining"@en,
+        "Set netting, fishing"@en,
+        "Surface netting, fishing"@en ;
+    skos:definition """This class consists of units mainly engaged in trawling, seining or netting in mid-depth to deep ocean or coastal waters using a variety of net fishing methods. Trawling methods involve one or two boats towing a very large bag net, either on the seabed or in mid-depth waters. Seining methods include purse, Danish or beach seining. Netting methods include surface or bottom gill netting.."""@en ;
+    skos:notation "0414" ;
+    skos:prefLabel "Fish Trawling, Seining and Netting"@en ;
+.
+
+icat:0419 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:041 ; 
+    skos:example 
+        "Abalone/paua fishing"@en,
+        "Freshwater eel fishing"@en,
+        "Freshwater fishing n.e.c."@en,
+        "Marine water fishery product gathering"@en,
+        "Oyster catching (except from cultivated oyster beds)"@en,
+        "Pearling (except pearl oyster farming)"@en,
+        "Seaweed harvesting"@en,
+        "Spat catching"@en,
+        "Turtle hunting"@en ;
+    skos:definition """This class consists of units mainly engaged in fishing not elsewhere classified or in other types of marine life gathering.."""@en ;
+    skos:notation "0419" ;
+    skos:prefLabel "Other Fishing"@en ;
+.
+
+icat:042 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:04 ; 
+    skos:definition """This group includes units mainly engaged in Hunting and Trapping."""@en ;
+    skos:notation "042" ;
     skos:prefLabel "Hunting and Trapping"@en ;
 .
 
-icat:A0510
-    a skos:Concept ;
+icat:0420 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Forestry Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0510" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:042 ; 
+    skos:example 
+        "Bird trapping"@en,
+        "Buffalo hunting"@en,
+        "Crocodile hunting"@en,
+        "Culling of wild animals"@en,
+        "Deer hunting"@en,
+        "Dingo hunting or trapping"@en,
+        "Fur skin animal hunting or trapping"@en,
+        "Game preserve, commercial, operation"@en,
+        "Kangaroo hunting"@en,
+        "Mutton bird catching"@en,
+        "Possum hunting and trapping"@en,
+        "Rabbit hunting or trapping"@en,
+        "Snake catching"@en ;
+    skos:definition """This class consists of units mainly engaged in hunting, trapping or taking animals, birds or reptiles in the wild for commercial, population control or pest control purposes.."""@en ;
+    skos:notation "0420" ;
+    skos:prefLabel "Hunting and Trapping"@en ;
+.
+
+icat:05 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:A ; 
+    skos:definition """This subdivision includes units mainly engaged in Agriculture, Forestry and Fishing Support Services."""@en ;
+    skos:notation "05" ;
+    skos:prefLabel "Agriculture, Forestry and Fishing Support Services"@en ;
+.
+
+icat:051 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:05 ; 
+    skos:definition """This group includes units mainly engaged in Forestry Support Services."""@en ;
+    skos:notation "051" ;
     skos:prefLabel "Forestry Support Services"@en ;
 .
 
-icat:A0520
-    a skos:Concept ;
+icat:0510 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Agriculture and Fishing Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0520" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:051 ; 
+    skos:example 
+        "Forest conservation service"@en,
+        "Forest nursery operation or service"@en,
+        "Forest pest control service (except aerial or wild animal control)"@en,
+        "Forest planting"@en,
+        "Reforestation service"@en,
+        "Silvicultural service"@en,
+        "Timber plantation maintenance"@en,
+        "Timber tract maintenance"@en,
+        "Tree pruning (forest)"@en,
+        "Tree thinning (forest)"@en ;
+    skos:definition """This class consists of units mainly engaged in providing support services to forestry. Services include silvicultural services, such as planting, pruning and thinning trees, forest reafforestation, forest plantation conservation or maintenance. This class also includes units mainly engaged in operating forestry planting stock nurseries.."""@en ;
+    skos:notation "0510" ;
+    skos:prefLabel "Forestry Support Services"@en ;
+.
+
+icat:052 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:05 ; 
+    skos:definition """This group includes units mainly engaged in Agriculture and Fishing Support Services."""@en ;
+    skos:notation "052" ;
     skos:prefLabel "Agriculture and Fishing Support Services"@en ;
 .
 
-icat:B0700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Oil and Gas Extraction."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B0700" ;
-    skos:prefLabel "Oil and Gas Extraction"@en ;
-.
-
-icat:B0800
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Metal Ore Mining."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B0800" ;
-    skos:prefLabel "Metal Ore Mining"@en ;
-.
-
-icat:B0910
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B0900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Construction Material Mining."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B0910" ;
-    skos:prefLabel "Construction Material Mining"@en ;
-.
-
-icat:B0990
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B0900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Non-Metallic Mineral Mining and Quarrying."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B0990" ;
-    skos:prefLabel "Other Non-Metallic Mineral Mining and Quarrying"@en ;
-.
-
-icat:B1010
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B1000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Exploration."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B1010" ;
-    skos:prefLabel "Exploration"@en ;
-.
-
-icat:B1090
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B1000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Mining Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B1090" ;
-    skos:prefLabel "Other Mining Support Services"@en ;
-.
-
-icat:C1110
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Meat and Meat Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1110" ;
-    skos:prefLabel "Meat and Meat Product Manufacturing"@en ;
-.
-
-icat:C1120
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Seafood Processing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1120" ;
-    skos:prefLabel "Seafood Processing"@en ;
-.
-
-icat:C1130
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Dairy Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1130" ;
-    skos:prefLabel "Dairy Product Manufacturing"@en ;
-.
-
-icat:C1140
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Fruit and Vegetable Processing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1140" ;
-    skos:prefLabel "Fruit and Vegetable Processing"@en ;
-.
-
-icat:C1150
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Oil and Fat Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1150" ;
-    skos:prefLabel "Oil and Fat Manufacturing"@en ;
-.
-
-icat:C1160
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Grain Mill and Cereal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1160" ;
-    skos:prefLabel "Grain Mill and Cereal Product Manufacturing"@en ;
-.
-
-icat:C1170
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Bakery Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1170" ;
-    skos:prefLabel "Bakery Product Manufacturing"@en ;
-.
-
-icat:C1180
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Sugar and Confectionery Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1180" ;
-    skos:prefLabel "Sugar and Confectionery Manufacturing"@en ;
-.
-
-icat:C1190
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Food Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1190" ;
-    skos:prefLabel "Other Food Product Manufacturing"@en ;
-.
-
-icat:C1210
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Beverage Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1210" ;
-    skos:prefLabel "Beverage Manufacturing"@en ;
-.
-
-icat:C1220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Cigarette and Tobacco Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1220" ;
-    skos:prefLabel "Cigarette and Tobacco Product Manufacturing"@en ;
-.
-
-icat:C1310
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Textile Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1310" ;
-    skos:prefLabel "Textile Manufacturing"@en ;
-.
-
-icat:C1320
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Leather Tanning, Fur Dressing and Leather Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1320" ;
-    skos:prefLabel "Leather Tanning, Fur Dressing and Leather Product Manufacturing"@en ;
-.
-
-icat:C1330
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Textile Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1330" ;
-    skos:prefLabel "Textile Product Manufacturing"@en ;
-.
-
-icat:C1340
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Knitted Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1340" ;
-    skos:prefLabel "Knitted Product Manufacturing"@en ;
-.
-
-icat:C1350
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Clothing and Footwear Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1350" ;
-    skos:prefLabel "Clothing and Footwear Manufacturing"@en ;
-.
-
-icat:C1410
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Log Sawmilling and Timber Dressing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1410" ;
-    skos:prefLabel "Log Sawmilling and Timber Dressing"@en ;
-.
-
-icat:C1490
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Wood Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1490" ;
-    skos:prefLabel "Other Wood Product Manufacturing"@en ;
-.
-
-icat:C1510
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pulp, Paper and Paperboard Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1510" ;
-    skos:prefLabel "Pulp, Paper and Paperboard Manufacturing"@en ;
-.
-
-icat:C1520
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Converted Paper Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1520" ;
-    skos:prefLabel "Converted Paper Product Manufacturing"@en ;
-.
-
-icat:C1610
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Printing and Printing Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1610" ;
-    skos:prefLabel "Printing and Printing Support Services"@en ;
-.
-
-icat:C1620
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Reproduction of Recorded Media."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1620" ;
-    skos:prefLabel "Reproduction of Recorded Media"@en ;
-.
-
-icat:C1700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Petroleum and Coal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1700" ;
-    skos:prefLabel "Petroleum and Coal Product Manufacturing"@en ;
-.
-
-icat:C1810
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Chemical Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1810" ;
-    skos:prefLabel "Basic Chemical Manufacturing"@en ;
-.
-
-icat:C1820
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Polymer Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1820" ;
-    skos:prefLabel "Basic Polymer Manufacturing"@en ;
-.
-
-icat:C1830
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Fertiliser and Pesticide Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1830" ;
-    skos:prefLabel "Fertiliser and Pesticide Manufacturing"@en ;
-.
-
-icat:C1840
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pharmaceutical and Medicinal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1840" ;
-    skos:prefLabel "Pharmaceutical and Medicinal Product Manufacturing"@en ;
-.
-
-icat:C1850
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Cleaning Compound and Toiletry Preparation Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1850" ;
-    skos:prefLabel "Cleaning Compound and Toiletry Preparation Manufacturing"@en ;
-.
-
-icat:C1890
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Basic Chemical Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1890" ;
-    skos:prefLabel "Other Basic Chemical Product Manufacturing"@en ;
-.
-
-icat:C1910
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Polymer Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1910" ;
-    skos:prefLabel "Polymer Product Manufacturing"@en ;
-.
-
-icat:C1920
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C1900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Natural Rubber Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1920" ;
-    skos:prefLabel "Natural Rubber Product Manufacturing"@en ;
-.
-
-icat:C2010
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Glass and Glass Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2010" ;
-    skos:prefLabel "Glass and Glass Product Manufacturing"@en ;
-.
-
-icat:C2020
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Ceramic Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2020" ;
-    skos:prefLabel "Ceramic Product Manufacturing"@en ;
-.
-
-icat:C2030
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Cement, Lime, Plaster and Concrete Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2030" ;
-    skos:prefLabel "Cement, Lime, Plaster and Concrete Product Manufacturing"@en ;
-.
-
-icat:C2090
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Non-Metallic Mineral Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2090" ;
-    skos:prefLabel "Other Non-Metallic Mineral Product Manufacturing"@en ;
-.
-
-icat:C2110
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Ferrous Metal Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2110" ;
-    skos:prefLabel "Basic Ferrous Metal Manufacturing"@en ;
-.
-
-icat:C2120
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Ferrous Metal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2120" ;
-    skos:prefLabel "Basic Ferrous Metal Product Manufacturing"@en ;
-.
-
-icat:C2130
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Non-Ferrous Metal Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2130" ;
-    skos:prefLabel "Basic Non-Ferrous Metal Manufacturing"@en ;
-.
-
-icat:C2140
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Non-Ferrous Metal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2140" ;
-    skos:prefLabel "Basic Non-Ferrous Metal Product Manufacturing"@en ;
-.
-
-icat:C2210
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Iron and Steel Forging."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2210" ;
-    skos:prefLabel "Iron and Steel Forging"@en ;
-.
-
-icat:C2220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Structural Metal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2220" ;
-    skos:prefLabel "Structural Metal Product Manufacturing"@en ;
-.
-
-icat:C2230
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Metal Container Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2230" ;
-    skos:prefLabel "Metal Container Manufacturing"@en ;
-.
-
-icat:C2240
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Sheet Metal Product Manufacturing (except Metal Structural and Container Products)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2240" ;
-    skos:prefLabel "Sheet Metal Product Manufacturing (except Metal Structural and Container Products)"@en ;
-.
-
-icat:C2290
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Fabricated Metal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2290" ;
-    skos:prefLabel "Other Fabricated Metal Product Manufacturing"@en ;
-.
-
-icat:C2310
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motor Vehicle and Motor Vehicle Part Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2310" ;
-    skos:prefLabel "Motor Vehicle and Motor Vehicle Part Manufacturing"@en ;
-.
-
-icat:C2390
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Transport Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2390" ;
-    skos:prefLabel "Other Transport Equipment Manufacturing"@en ;
-.
-
-icat:C2410
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Professional and Scientific Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2410" ;
-    skos:prefLabel "Professional and Scientific Equipment Manufacturing"@en ;
-.
-
-icat:C2420
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Computer and Electronic Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2420" ;
-    skos:prefLabel "Computer and Electronic Equipment Manufacturing"@en ;
-.
-
-icat:C2430
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Electrical Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2430" ;
-    skos:prefLabel "Electrical Equipment Manufacturing"@en ;
-.
-
-icat:C2440
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Domestic Appliance Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2440" ;
-    skos:prefLabel "Domestic Appliance Manufacturing"@en ;
-.
-
-icat:C2450
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pump, Compressor, Heating and Ventilation Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2450" ;
-    skos:prefLabel "Pump, Compressor, Heating and Ventilation Equipment Manufacturing"@en ;
-.
-
-icat:C2460
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Specialised Machinery and Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2460" ;
-    skos:prefLabel "Specialised Machinery and Equipment Manufacturing"@en ;
-.
-
-icat:C2490
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Machinery and Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2490" ;
-    skos:prefLabel "Other Machinery and Equipment Manufacturing"@en ;
-.
-
-icat:C2510
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Furniture Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2510" ;
-    skos:prefLabel "Furniture Manufacturing"@en ;
-.
-
-icat:C2590
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C2500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2590" ;
-    skos:prefLabel "Other Manufacturing"@en ;
-.
-
-icat:D2620
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D2600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Electricity Transmission."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2620" ;
-    skos:prefLabel "Electricity Transmission"@en ;
-.
-
-icat:D2630
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D2600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Electricity Distribution."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2630" ;
-    skos:prefLabel "Electricity Distribution"@en ;
-.
-
-icat:D2640
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D2600 ;
-    skos:definition "An individual business entity whose predominant economic activity is On Selling Electricity and Electricity Market Operation."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2640" ;
-    skos:prefLabel "On Selling Electricity and Electricity Market Operation"@en ;
-.
-
-icat:D2700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Gas Supply."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2700" ;
-    skos:prefLabel "Gas Supply"@en ;
-.
-
-icat:D2800
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Water Supply, Sewerage and Drainage Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2800" ;
-    skos:prefLabel "Water Supply, Sewerage and Drainage Services"@en ;
-.
-
-icat:D2910
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D2900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Waste Collection Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2910" ;
-    skos:prefLabel "Waste Collection Services"@en ;
-.
-
-icat:D2920
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D2900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Waste Treatment, Disposal and Remediation Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2920" ;
-    skos:prefLabel "Waste Treatment, Disposal and Remediation Services"@en ;
-.
-
-icat:E3010
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E3000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Residential Building Construction."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3010" ;
-    skos:prefLabel "Residential Building Construction"@en ;
-.
-
-icat:E3020
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E3000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Non-Residential Building Construction."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3020" ;
-    skos:prefLabel "Non-Residential Building Construction"@en ;
-.
-
-icat:E3100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Heavy and Civil Engineering Construction."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3100" ;
-    skos:prefLabel "Heavy and Civil Engineering Construction"@en ;
-.
-
-icat:E3210
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E3200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Land Development and Site Preparation Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3210" ;
-    skos:prefLabel "Land Development and Site Preparation Services"@en ;
-.
-
-icat:E3220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E3200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Building Structure Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3220" ;
-    skos:prefLabel "Building Structure Services"@en ;
-.
-
-icat:E3230
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E3200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Building Installation Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3230" ;
-    skos:prefLabel "Building Installation Services"@en ;
-.
-
-icat:E3240
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E3200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Building Completion Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3240" ;
-    skos:prefLabel "Building Completion Services"@en ;
-.
-
-icat:E3290
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E3200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Construction Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3290" ;
-    skos:prefLabel "Other Construction Services"@en ;
-.
-
-icat:F3310
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Agricultural Product Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3310" ;
-    skos:prefLabel "Agricultural Product Wholesaling"@en ;
-.
-
-icat:F3320
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Mineral, Metal and Chemical Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3320" ;
-    skos:prefLabel "Mineral, Metal and Chemical Wholesaling"@en ;
-.
-
-icat:F3330
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Timber and Hardware Goods Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3330" ;
-    skos:prefLabel "Timber and Hardware Goods Wholesaling"@en ;
-.
-
-icat:F3410
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Specialised Industrial Machinery and Equipment Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3410" ;
-    skos:prefLabel "Specialised Industrial Machinery and Equipment Wholesaling"@en ;
-.
-
-icat:F3490
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Machinery and Equipment Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3490" ;
-    skos:prefLabel "Other Machinery and Equipment Wholesaling"@en ;
-.
-
-icat:F3500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motor Vehicle and Motor Vehicle Parts Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3500" ;
-    skos:prefLabel "Motor Vehicle and Motor Vehicle Parts Wholesaling"@en ;
-.
-
-icat:F3600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Grocery, Liquor and Tobacco Product Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3600" ;
-    skos:prefLabel "Grocery, Liquor and Tobacco Product Wholesaling"@en ;
-.
-
-icat:F3710
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Textile, Clothing and Footwear Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3710" ;
-    skos:prefLabel "Textile, Clothing and Footwear Wholesaling"@en ;
-.
-
-icat:F3720
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pharmaceutical and Toiletry Goods Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3720" ;
-    skos:prefLabel "Pharmaceutical and Toiletry Goods Wholesaling"@en ;
-.
-
-icat:F3730
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F3700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Furniture, Floor Covering and Other Goods Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3730" ;
-    skos:prefLabel "Furniture, Floor Covering and Other Goods Wholesaling"@en ;
-.
-
-icat:F3800
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Commission-Based Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3800" ;
-    skos:prefLabel "Commission-Based Wholesaling"@en ;
-.
-
-icat:G3910
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G3900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motor Vehicle Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G3910" ;
-    skos:prefLabel "Motor Vehicle Retailing"@en ;
-.
-
-icat:G3920
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G3900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motor Vehicle Parts and Tyre Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G3920" ;
-    skos:prefLabel "Motor Vehicle Parts and Tyre Retailing"@en ;
-.
-
-icat:G4000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Fuel Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4000" ;
-    skos:prefLabel "Fuel Retailing"@en ;
-.
-
-icat:G4110
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Supermarket and Grocery Stores."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4110" ;
-    skos:prefLabel "Supermarket and Grocery Stores"@en ;
-.
-
-icat:G4120
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Specialised Food Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4120" ;
-    skos:prefLabel "Specialised Food Retailing"@en ;
-.
-
-icat:G4210
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Furniture, Floor Coverings, Houseware and Textile Goods Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4210" ;
-    skos:prefLabel "Furniture, Floor Coverings, Houseware and Textile Goods Retailing"@en ;
-.
-
-icat:G4220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Electrical and Electronic Goods Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4220" ;
-    skos:prefLabel "Electrical and Electronic Goods Retailing"@en ;
-.
-
-icat:G4230
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Hardware, Building and Garden Supplies Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4230" ;
-    skos:prefLabel "Hardware, Building and Garden Supplies Retailing"@en ;
-.
-
-icat:G4240
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Recreational Goods Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4240" ;
-    skos:prefLabel "Recreational Goods Retailing"@en ;
-.
-
-icat:G4250
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Clothing, Footwear and Personal Accessory Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4250" ;
-    skos:prefLabel "Clothing, Footwear and Personal Accessory Retailing"@en ;
-.
-
-icat:G4260
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Department Stores."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4260" ;
-    skos:prefLabel "Department Stores"@en ;
-.
-
-icat:G4270
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pharmaceutical and Other Store-Based Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4270" ;
-    skos:prefLabel "Pharmaceutical and Other Store-Based Retailing"@en ;
-.
-
-icat:G4310
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Non-Store Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4310" ;
-    skos:prefLabel "Non-Store Retailing"@en ;
-.
-
-icat:G4320
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G4300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Retail Commission-Based Buying and/or Selling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4320" ;
-    skos:prefLabel "Retail Commission-Based Buying and/or Selling"@en ;
-.
-
-icat:H4400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:H0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Accommodation."@en ;
-    skos:inScheme cs: ;
-    skos:notation "H4400" ;
-    skos:prefLabel "Accommodation"@en ;
-.
-
-icat:H4510
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:H4500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Cafes, Restaurants and Takeaway Food Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "H4510" ;
-    skos:prefLabel "Cafes, Restaurants and Takeaway Food Services"@en ;
-.
-
-icat:H4520
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:H4500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pubs, Taverns and Bars."@en ;
-    skos:inScheme cs: ;
-    skos:notation "H4520" ;
-    skos:prefLabel "Pubs, Taverns and Bars"@en ;
-.
-
-icat:H4530
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:H4500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Clubs (Hospitality)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "H4530" ;
-    skos:prefLabel "Clubs (Hospitality)"@en ;
-.
-
-icat:I4610
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I4600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Road Freight Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4610" ;
-    skos:prefLabel "Road Freight Transport"@en ;
-.
-
-icat:I4620
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I4600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Road Passenger Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4620" ;
-    skos:prefLabel "Road Passenger Transport"@en ;
-.
-
-icat:I4710
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I4700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Rail Freight Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4710" ;
-    skos:prefLabel "Rail Freight Transport"@en ;
-.
-
-icat:I4720
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I4700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Rail Passenger Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4720" ;
-    skos:prefLabel "Rail Passenger Transport"@en ;
-.
-
-icat:I4810
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I4800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Water Freight Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4810" ;
-    skos:prefLabel "Water Freight Transport"@en ;
-.
-
-icat:I4820
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I4800 ;
-    skos:definition "An individual business entity whose predominant economic activity is Water Passenger Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4820" ;
-    skos:prefLabel "Water Passenger Transport"@en ;
-.
-
-icat:I4900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Air and Space Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4900" ;
-    skos:prefLabel "Air and Space Transport"@en ;
-.
-
-icat:I5010
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I5000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Scenic and Sightseeing Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5010" ;
-    skos:prefLabel "Scenic and Sightseeing Transport"@en ;
-.
-
-icat:I5020
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I5000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pipeline and Other Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5020" ;
-    skos:prefLabel "Pipeline and Other Transport"@en ;
-.
-
-icat:I5100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Postal and Courier Pick-up and Delivery Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5100" ;
-    skos:prefLabel "Postal and Courier Pick-up and Delivery Services"@en ;
-.
-
-icat:I5210
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I5200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Water Transport Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5210" ;
-    skos:prefLabel "Water Transport Support Services"@en ;
-.
-
-icat:I5220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I5200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Airport Operations and Other Air Transport Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5220" ;
-    skos:prefLabel "Airport Operations and Other Air Transport Support Services"@en ;
-.
-
-icat:I5290
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I5200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Transport Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5290" ;
-    skos:prefLabel "Other Transport Support Services"@en ;
-.
-
-icat:I5300
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Warehousing and Storage Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5300" ;
-    skos:prefLabel "Warehousing and Storage Services"@en ;
-.
-
-icat:J5410
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Newspaper, Periodical, Book and Directory Publishing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5410" ;
-    skos:prefLabel "Newspaper, Periodical, Book and Directory Publishing"@en ;
-.
-
-icat:J5420
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Software Publishing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5420" ;
-    skos:prefLabel "Software Publishing"@en ;
-.
-
-icat:J5510
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motion Picture and Video Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5510" ;
-    skos:prefLabel "Motion Picture and Video Activities"@en ;
-.
-
-icat:J5520
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Sound Recording and Music Publishing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5520" ;
-    skos:prefLabel "Sound Recording and Music Publishing"@en ;
-.
-
-icat:J5610
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Radio Broadcasting."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5610" ;
-    skos:prefLabel "Radio Broadcasting"@en ;
-.
-
-icat:J5620
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Television Broadcasting."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5620" ;
-    skos:prefLabel "Television Broadcasting"@en ;
-.
-
-icat:J5700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Internet Publishing and Broadcasting."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5700" ;
-    skos:prefLabel "Internet Publishing and Broadcasting"@en ;
-.
-
-icat:J5800
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Telecommunications Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5800" ;
-    skos:prefLabel "Telecommunications Services"@en ;
-.
-
-icat:J5910
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Internet Service Providers and Web Search Portals."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5910" ;
-    skos:prefLabel "Internet Service Providers and Web Search Portals"@en ;
-.
-
-icat:J5920
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J5900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Data Processing, Web Hosting and Electronic Information Storage Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5920" ;
-    skos:prefLabel "Data Processing, Web Hosting and Electronic Information Storage Services"@en ;
-.
-
-icat:J6010
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J6000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Libraries and Archives."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J6010" ;
-    skos:prefLabel "Libraries and Archives"@en ;
-.
-
-icat:J6020
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J6000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Information Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J6020" ;
-    skos:prefLabel "Other Information Services"@en ;
-.
-
-icat:K6210
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Central Banking."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6210" ;
-    skos:prefLabel "Central Banking"@en ;
-.
-
-icat:K6220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Depository Financial Intermediation."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6220" ;
-    skos:prefLabel "Depository Financial Intermediation"@en ;
-.
-
-icat:K6230
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Non-Depository Financing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6230" ;
-    skos:prefLabel "Non-Depository Financing"@en ;
-.
-
-icat:K6240
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Financial Asset Investing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6240" ;
-    skos:prefLabel "Financial Asset Investing"@en ;
-.
-
-icat:K6310
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Life Insurance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6310" ;
-    skos:prefLabel "Life Insurance"@en ;
-.
-
-icat:K6320
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Health and General Insurance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6320" ;
-    skos:prefLabel "Health and General Insurance"@en ;
-.
-
-icat:K6330
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Superannuation Funds."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6330" ;
-    skos:prefLabel "Superannuation Funds"@en ;
-.
-
-icat:K6410
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Auxiliary Finance and Investment Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6410" ;
-    skos:prefLabel "Auxiliary Finance and Investment Services"@en ;
-.
-
-icat:K6420
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K6400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Auxiliary Insurance Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6420" ;
-    skos:prefLabel "Auxiliary Insurance Services"@en ;
-.
-
-icat:L6610
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L6600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motor Vehicle and Transport Equipment Rental and Hiring."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6610" ;
-    skos:prefLabel "Motor Vehicle and Transport Equipment Rental and Hiring"@en ;
-.
-
-icat:L6620
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L6600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Farm Animal and Bloodstock Leasing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6620" ;
-    skos:prefLabel "Farm Animal and Bloodstock Leasing"@en ;
-.
-
-icat:L6630
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L6600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Goods and Equipment Rental and Hiring."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6630" ;
-    skos:prefLabel "Other Goods and Equipment Rental and Hiring"@en ;
-.
-
-icat:L6640
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L6600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Non-Financial Intangible Assets (Except Copyrights) Leasing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6640" ;
-    skos:prefLabel "Non-Financial Intangible Assets (Except Copyrights) Leasing"@en ;
-.
-
-icat:L6710
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L6700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Property Operators."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6710" ;
-    skos:prefLabel "Property Operators"@en ;
-.
-
-icat:L6720
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L6700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Real Estate Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6720" ;
-    skos:prefLabel "Real Estate Services"@en ;
-.
-
-icat:M6910
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Scientific Research Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6910" ;
-    skos:prefLabel "Scientific Research Services"@en ;
-.
-
-icat:M6920
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Architectural, Engineering and Technical Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6920" ;
-    skos:prefLabel "Architectural, Engineering and Technical Services"@en ;
-.
-
-icat:M6930
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Legal and Accounting Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6930" ;
-    skos:prefLabel "Legal and Accounting Services"@en ;
-.
-
-icat:M6940
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Advertising Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6940" ;
-    skos:prefLabel "Advertising Services"@en ;
-.
-
-icat:M6950
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Market Research and Statistical Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6950" ;
-    skos:prefLabel "Market Research and Statistical Services"@en ;
-.
-
-icat:M6960
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Management and Related Consulting Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6960" ;
-    skos:prefLabel "Management and Related Consulting Services"@en ;
-.
-
-icat:M6970
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Veterinary Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6970" ;
-    skos:prefLabel "Veterinary Services"@en ;
-.
-
-icat:M6990
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M6900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Professional, Scientific and Technical Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6990" ;
-    skos:prefLabel "Other Professional, Scientific and Technical Services"@en ;
-.
-
-icat:M7000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Computer System Design and Related Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M7000" ;
-    skos:prefLabel "Computer System Design and Related Services"@en ;
-.
-
-icat:N7210
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:N7200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Employment Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N7210" ;
-    skos:prefLabel "Employment Services"@en ;
-.
-
-icat:N7220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:N7200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Travel Agency and Tour Arrangement Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N7220" ;
-    skos:prefLabel "Travel Agency and Tour Arrangement Services"@en ;
-.
-
-icat:N7290
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:N7200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Administrative Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N7290" ;
-    skos:prefLabel "Other Administrative Services"@en ;
-.
-
-icat:N7310
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:N7300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Building Cleaning, Pest Control and Gardening Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N7310" ;
-    skos:prefLabel "Building Cleaning, Pest Control and Gardening Services"@en ;
-.
-
-icat:N7320
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:N7300 ;
-    skos:definition "An individual business entity whose predominant economic activity is Packaging Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N7320" ;
-    skos:prefLabel "Packaging Services"@en ;
-.
-
-icat:O7510
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O7500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Central Government Administration."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7510" ;
-    skos:prefLabel "Central Government Administration"@en ;
-.
-
-icat:O7520
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O7500 ;
-    skos:definition "An individual business entity whose predominant economic activity is State Government Administration."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7520" ;
-    skos:prefLabel "State Government Administration"@en ;
-.
-
-icat:O7530
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O7500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Local Government Administration."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7530" ;
-    skos:prefLabel "Local Government Administration"@en ;
-.
-
-icat:O7540
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O7500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Justice."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7540" ;
-    skos:prefLabel "Justice"@en ;
-.
-
-icat:O7550
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O7500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Government Representation."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7550" ;
-    skos:prefLabel "Government Representation"@en ;
-.
-
-icat:O7600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Defence."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7600" ;
-    skos:prefLabel "Defence"@en ;
-.
-
-icat:O7710
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O7700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Public Order and Safety Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7710" ;
-    skos:prefLabel "Public Order and Safety Services"@en ;
-.
-
-icat:O7720
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O7700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Regulatory Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7720" ;
-    skos:prefLabel "Regulatory Services"@en ;
-.
-
-icat:P8010
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:P8000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Preschool Education."@en ;
-    skos:inScheme cs: ;
-    skos:notation "P8010" ;
-    skos:prefLabel "Preschool Education"@en ;
-.
-
-icat:P8020
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:P8000 ;
-    skos:definition "An individual business entity whose predominant economic activity is School Education."@en ;
-    skos:inScheme cs: ;
-    skos:notation "P8020" ;
-    skos:prefLabel "School Education"@en ;
-.
-
-icat:P8100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:P0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Tertiary Education."@en ;
-    skos:inScheme cs: ;
-    skos:notation "P8100" ;
-    skos:prefLabel "Tertiary Education"@en ;
-.
-
-icat:P8220
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:P8200 ;
-    skos:definition "An individual business entity whose predominant economic activity is Educational Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "P8220" ;
-    skos:prefLabel "Educational Support Services"@en ;
-.
-
-icat:Q8400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Hospitals."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8400" ;
-    skos:prefLabel "Hospitals"@en ;
-.
-
-icat:Q8510
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q8500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Medical Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8510" ;
-    skos:prefLabel "Medical Services"@en ;
-.
-
-icat:Q8520
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q8500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pathology and Diagnostic Imaging Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8520" ;
-    skos:prefLabel "Pathology and Diagnostic Imaging Services"@en ;
-.
-
-icat:Q8530
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q8500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Allied Health Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8530" ;
-    skos:prefLabel "Allied Health Services"@en ;
-.
-
-icat:Q8590
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q8500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Health Care Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8590" ;
-    skos:prefLabel "Other Health Care Services"@en ;
-.
-
-icat:Q8600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Residential Care Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8600" ;
-    skos:prefLabel "Residential Care Services"@en ;
-.
-
-icat:Q8710
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q8700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Child Care Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8710" ;
-    skos:prefLabel "Child Care Services"@en ;
-.
-
-icat:Q8790
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q8700 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Social Assistance Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8790" ;
-    skos:prefLabel "Other Social Assistance Services"@en ;
-.
-
-icat:R8910
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R8900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Museum Operation."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R8910" ;
-    skos:prefLabel "Museum Operation"@en ;
-.
-
-icat:R8920
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R8900 ;
-    skos:definition "An individual business entity whose predominant economic activity is Parks and Gardens Operations."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R8920" ;
-    skos:prefLabel "Parks and Gardens Operations"@en ;
-.
-
-icat:R9000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Creative and Performing Arts Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R9000" ;
-    skos:prefLabel "Creative and Performing Arts Activities"@en ;
-.
-
-icat:R9110
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R9100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Sports and Physical Recreation Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R9110" ;
-    skos:prefLabel "Sports and Physical Recreation Activities"@en ;
-.
-
-icat:R9120
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R9100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Horse and Dog Racing Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R9120" ;
-    skos:prefLabel "Horse and Dog Racing Activities"@en ;
-.
-
-icat:R9130
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R9100 ;
-    skos:definition "An individual business entity whose predominant economic activity is Amusement and Other Recreation Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R9130" ;
-    skos:prefLabel "Amusement and Other Recreation Activities"@en ;
-.
-
-icat:R9200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Gambling Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R9200" ;
-    skos:prefLabel "Gambling Activities"@en ;
-.
-
-icat:S9410
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Automotive Repair and Maintenance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9410" ;
-    skos:prefLabel "Automotive Repair and Maintenance"@en ;
-.
-
-icat:S9420
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Machinery and Equipment Repair and Maintenance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9420" ;
-    skos:prefLabel "Machinery and Equipment Repair and Maintenance"@en ;
-.
-
-icat:S9490
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9400 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Repair and Maintenance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9490" ;
-    skos:prefLabel "Other Repair and Maintenance"@en ;
-.
-
-icat:S9510
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Personal Care Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9510" ;
-    skos:prefLabel "Personal Care Services"@en ;
-.
-
-icat:S9520
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Funeral, Crematorium and Cemetery Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9520" ;
-    skos:prefLabel "Funeral, Crematorium and Cemetery Services"@en ;
-.
-
-icat:S9530
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Personal Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9530" ;
-    skos:prefLabel "Other Personal Services"@en ;
-.
-
-icat:S9540
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Religious Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9540" ;
-    skos:prefLabel "Religious Services"@en ;
-.
-
-icat:S9550
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S9500 ;
-    skos:definition "An individual business entity whose predominant economic activity is Civic, Professional and Other Interest Group Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9550" ;
-    skos:prefLabel "Civic, Professional and Other Interest Group Services"@en ;
-.
-
-icat:S9600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Private Households Employing Staff and Undifferentiated Goods and Service Producing Activities of Households for Own Use."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9600" ;
-    skos:prefLabel "Private Households Employing Staff and Undifferentiated Goods and Service Producing Activities of Households for Own Use"@en ;
-.
-
-icat:coal-buyer
-    a skos:Collection ;
-    skos:definition "Industry categorisations as applicable to coal sales."@en ;
-    skos:member
-        icat:B0600 ,
-        icat:C0000 ,
-        icat:C2100 ,
-        icat:D2610 ,
-        icat:X9800 ,
-        icat:X9900 ;
-    skos:prefLabel "Coal Buyer Industry"@en ;
-    prov:wasDerivedFrom cs: ;
-.
-
-icat:B0600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel "Coal Mine"@en ;
-    skos:broader icat:B0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Coal Mining."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B0600" ;
+icat:0521 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:052 ; 
+    skos:example 
+        "Cotton ginning"@en ;
+    skos:definition """This class consists of units mainly engaged in ginning cotton.."""@en ;
+    skos:notation "0521" ;
+    skos:prefLabel "Cotton Ginning"@en ;
+.
+
+icat:0522 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:052 ; 
+    skos:example 
+        "Alpaca shearing"@en,
+        "Goat shearing"@en,
+        "Sheep shearing"@en ;
+    skos:definition """This class consists of units mainly engaged in providing shearing services for sheep, goats and other livestock raised mainly for their hair.."""@en ;
+    skos:notation "0522" ;
+    skos:prefLabel "Shearing Services"@en ;
+.
+
+icat:0529 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:052 ; 
+    skos:example 
+        "Aerial crop spraying or dusting"@en,
+        "Aerial mustering"@en,
+        "Aerial pest control or baiting"@en,
+        "Aerial seeding service"@en,
+        "Aerial topdressing"@en,
+        "Agricultural support service n.e.c."@en,
+        "Aquaculture support service"@en,
+        "Artificial insemination service"@en,
+        "Crop harvesting"@en,
+        "Dairy herd testing"@en,
+        "Farm irrigation service"@en,
+        "Fertiliser spreading (including aerial)"@en,
+        "Fishing support service"@en,
+        "Fruit or vegetable picking"@en,
+        "Hay or silage baling or pressing"@en,
+        "Livestock dipping"@en,
+        "Livestock drafting or droving"@en,
+        "Seed grading or cleaning"@en,
+        "Wool classing (including reclassing and bulk classing)"@en ;
+    skos:definition """This class consists of units mainly engaged in providing agricultural and fishing support services not elsewhere classified.."""@en ;
+    skos:notation "0529" ;
+    skos:prefLabel "Other Agriculture and Fishing Support Services"@en ;
+.
+
+icat:B a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Mining Division includes units that mainly extract naturally occurring mineral solids, such as coal and ores; liquid minerals, such as crude petroleum; and gases, such as natural gas. The term mining is used in the broad sense to include underground or open cut mining; dredging; quarrying; well operations or evaporation pans; recovery from ore dumps or tailings as well as beneficiation activities (i.e. preparing, including crushing, screening, washing and flotation) and other preparation work customarily performed at the mine site, or as a part of mining activity.
+
+The Mining Division distinguishes two basic activities: mine operation and mining support activities.
+
+Mine operation includes units operating mines, quarries, or oil and gas wells on their own account, or for others on a contract or fee basis, as well as mining sites under development.
+
+Mining support activities include units that perform mining services on a contract or fee basis, and exploration (except geophysical surveying).
+
+Units in the Mining Division are grouped and classified according to the natural resource mined or to be mined. Industries include units that extract natural resources, and/or those that beneficiate the mineral mined. Beneficiation is the process whereby the extracted material is reduced to particles that can be separated into mineral and waste, the former suitable for further processing or direct use. The operations that take place in beneficiation are primarily mechanical, such as grinding, washing, magnetic separation, and centrifugal separation. In contrast, manufacturing operations primarily use chemical and electro-chemical processes, such as electrolysis and distillation.."""@en ;
+    skos:notation "B" ;
+    skos:prefLabel "Mining"@en ;
+.
+
+icat:06 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:B ; 
+    skos:definition """This subdivision includes units mainly engaged in Coal Mining."""@en ;
+    skos:notation "06" ;
     skos:prefLabel "Coal Mining"@en ;
 .
 
-icat:D2610
-    a skos:Concept ;
+icat:060 a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D2600 ;
-    skos:definition "An individual business entity whose predominant economic activity is Electricity Generation."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2610" ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:06 ; 
+    skos:definition """This group includes units mainly engaged in Coal Mining."""@en ;
+    skos:notation "060" ;
+    skos:prefLabel "Coal Mining"@en ;
+.
+
+icat:0600 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:060 ; 
+    skos:example 
+        "Black coal mining"@en,
+        "Brown coal mining"@en,
+        "Lignite mining"@en,
+        "Peat cutting (except horticultural)"@en ;
+    skos:definition """This class consists of units mainly engaged in open-cut or underground mining of black or brown coal.."""@en ;
+    skos:notation "0600" ;
+    skos:prefLabel "Coal Mining"@en ;
+.
+
+icat:07 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:B ; 
+    skos:definition """This subdivision includes units mainly engaged in Oil and Gas Extraction."""@en ;
+    skos:notation "07" ;
+    skos:prefLabel "Oil and Gas Extraction"@en ;
+.
+
+icat:070 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:07 ; 
+    skos:definition """This group includes units mainly engaged in Oil and Gas Extraction."""@en ;
+    skos:notation "070" ;
+    skos:prefLabel "Oil and Gas Extraction"@en ;
+.
+
+icat:0700 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:070 ; 
+    skos:example 
+        "Natural gas extraction"@en,
+        "Oil shale mining"@en,
+        "Petroleum gas extraction"@en ;
+    skos:definition """This class consists of units mainly engaged in producing crude oil, natural gas or condensate through the extraction of oil and gas deposits.."""@en ;
+    skos:notation "0700" ;
+    skos:prefLabel "Oil and Gas Extraction"@en ;
+.
+
+icat:08 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:B ; 
+    skos:definition """This subdivision includes units mainly engaged in Metal Ore Mining."""@en ;
+    skos:notation "08" ;
+    skos:prefLabel "Metal Ore Mining"@en ;
+.
+
+icat:080 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:08 ; 
+    skos:definition """This group includes units mainly engaged in Metal Ore Mining."""@en ;
+    skos:notation "080" ;
+    skos:prefLabel "Metal Ore Mining"@en ;
+.
+
+icat:0801 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Iron ore dressing or beneficiating"@en,
+        "Iron ore mining"@en,
+        "Iron sand mining"@en ;
+    skos:definition """This class consists of units mainly engaged in mining iron ore or iron sands. Units primarily engaged in the production of sinter and other agglomerates, except those associated with blast furnace operations, are classified in this class.."""@en ;
+    skos:notation "0801" ;
+    skos:prefLabel "Iron Ore Mining"@en ;
+.
+
+icat:0802 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Aluminium ore mining"@en,
+        "Bauxite mining"@en ;
+    skos:definition """This class consists of units mainly engaged in bauxite mining.."""@en ;
+    skos:notation "0802" ;
+    skos:prefLabel "Bauxite Mining"@en ;
+.
+
+icat:0803 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Copper ore leaching"@en,
+        "Copper ore mining"@en,
+        "Electro won copper production"@en ;
+    skos:definition """This class consists of units mainly engaged in mining copper ore.."""@en ;
+    skos:notation "0803" ;
+    skos:prefLabel "Copper Ore Mining"@en ;
+.
+
+icat:0804 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Alluvial gold mining"@en,
+        "Eluvial gold mining"@en,
+        "Gold bullion production"@en,
+        "Gold dredging"@en,
+        "Gold mining"@en,
+        "Gold ore roasting and flotation extraction, including metallurgical hydro-extraction"@en,
+        "Gold washing or sluicing"@en,
+        "Reworking of mullock heaps or tailings for gold"@en ;
+    skos:definition """This class consists of units mainly engaged in mining gold ore and in beneficiating gold ore, or in the preliminary extraction of gold from ore mined by the same unit by smelting or by extraction of gold from a liquor.."""@en ;
+    skos:notation "0804" ;
+    skos:prefLabel "Gold Ore Mining"@en ;
+.
+
+icat:0805 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Ilmenite sand mining"@en,
+        "Leucoxene sand mining"@en,
+        "Mineral sand mining"@en,
+        "Monazite sand mining"@en,
+        "Rutile sand mining"@en,
+        "Synthetic rutile production"@en,
+        "Zircon sand mining"@en ;
+    skos:definition """This class consists of units mainly engaged in mining mineral sand (except iron sand).."""@en ;
+    skos:notation "0805" ;
+    skos:prefLabel "Mineral Sand Mining"@en ;
+.
+
+icat:0806 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Nickel ore mining"@en ;
+    skos:definition """This class consists of units mainly engaged in mining nickel ore.."""@en ;
+    skos:notation "0806" ;
+    skos:prefLabel "Nickel Ore Mining"@en ;
+.
+
+icat:0807 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Lead ore mining"@en,
+        "Silver-lead-zinc ore mining"@en,
+        "Silver ore mining"@en,
+        "Zinc ore mining"@en ;
+    skos:definition """This class consists of units mainly engaged in mining ores of silver, lead or zinc.."""@en ;
+    skos:notation "0807" ;
+    skos:prefLabel "Silver-Lead-Zinc Ore Mining"@en ;
+.
+
+icat:0809 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:080 ; 
+    skos:example 
+        "Antimony ore mining"@en,
+        "Beryllium ore mining"@en,
+        "Bismuth ore mining"@en,
+        "Iron pyrite mining"@en,
+        "Manganese ore mining"@en,
+        "Metallic ore mining n.e.c."@en,
+        "Molybdenite mining"@en,
+        "Platinum group metal mining"@en,
+        "Tantalite mining"@en,
+        "Tin ore mining"@en,
+        "Tungsten ore mining"@en,
+        "Uranium ore mining"@en ;
+    skos:definition """This class consists of units mainly engaged in mining metallic mineral ore not elsewhere classified.."""@en ;
+    skos:notation "0809" ;
+    skos:prefLabel "Other Metal Ore Mining"@en ;
+.
+
+icat:09 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:B ; 
+    skos:definition """This subdivision includes units mainly engaged in Non-Metallic Mineral Mining and Quarrying."""@en ;
+    skos:notation "09" ;
+    skos:prefLabel "Non-Metallic Mineral Mining and Quarrying"@en ;
+.
+
+icat:091 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:09 ; 
+    skos:definition """This group includes units mainly engaged in Construction Material Mining."""@en ;
+    skos:notation "091" ;
+    skos:prefLabel "Construction Material Mining"@en ;
+.
+
+icat:0911 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:091 ; 
+    skos:example 
+        "Pebble quarrying"@en,
+        "River gravel quarrying, washing or screening"@en,
+        "Rock, ornamental, gathering"@en,
+        "Sand quarrying, washing or screening"@en ;
+    skos:definition """This class consists of units mainly engaged in quarrying, washing or screening sand or natural gravel.."""@en ;
+    skos:notation "0911" ;
+    skos:prefLabel "Gravel and Sand Quarrying"@en ;
+.
+
+icat:0919 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:091 ; 
+    skos:example 
+        "Aggregate quarrying"@en,
+        "Bentonite quarrying"@en,
+        "Blue metal stone quarrying"@en,
+        "Brick shale quarrying"@en,
+        "Building stone quarrying"@en,
+        "Cement clay quarrying"@en,
+        "Chalk quarrying"@en,
+        "Clay quarrying"@en,
+        "Construction material crushing or screening"@en,
+        "Dimension stone quarrying"@en,
+        "Earth, soil or filling quarrying"@en,
+        "Fullers earth quarrying"@en,
+        "Granite quarrying"@en,
+        "Limestone quarrying"@en,
+        "Marble quarrying"@en,
+        "Road fill quarrying"@en,
+        "Sandstone quarrying"@en,
+        "Slate quarrying"@en,
+        "Stone quarrying"@en,
+        "Tile clay quarrying"@en ;
+    skos:definition """This class consists of units mainly engaged in quarrying, crushing or screening crushed or broken stone or in quarrying dimension stone or construction materials not elsewhere classified. This class also includes the quarrying of clay, marble, granite, limestone, slate or dolomite for use as a manufacturing input.."""@en ;
+    skos:notation "0919" ;
+    skos:prefLabel "Other Construction Material Mining"@en ;
+.
+
+icat:099 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:09 ; 
+    skos:definition """This group includes units mainly engaged in Other Non-Metallic Mineral Mining and Quarrying."""@en ;
+    skos:notation "099" ;
+    skos:prefLabel "Other Non-Metallic Mineral Mining and Quarrying"@en ;
+.
+
+icat:0990 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:099 ; 
+    skos:example 
+        "Abrasives mining"@en,
+        "Alabaster mining"@en,
+        "Alum mining"@en,
+        "Alunite mining"@en,
+        "Barite mining"@en,
+        "Chrysoprase mining"@en,
+        "Diamond mining"@en,
+        "Diatomite mining"@en,
+        "Felspar quarrying"@en,
+        "Flint quarrying"@en,
+        "Fluorspar mining"@en,
+        "Gemstone mining"@en,
+        "Glauconite mining"@en,
+        "Graphite mining"@en,
+        "Green sand mining"@en,
+        "Gypsum mining"@en,
+        "Horticultural peat extraction"@en,
+        "Jade mining"@en,
+        "Kyanite mining"@en,
+        "Lithium mineral mining"@en,
+        "Magnesite mining"@en,
+        "Mica mining"@en,
+        "Mineral pigment mining n.e.c."@en,
+        "Opal mining"@en,
+        "Phosphate rock mining"@en,
+        "Quartz quarrying n.e.c."@en,
+        "Salt harvesting"@en,
+        "Silica mining (for industrial purposes)"@en,
+        "Talc quarrying"@en,
+        "Vermiculite mining"@en,
+        "Zeolite mining"@en ;
+    skos:definition """This class consists of units mainly engaged in mining or quarrying non-metallic minerals, except construction materials.."""@en ;
+    skos:notation "0990" ;
+    skos:prefLabel "Other Non-Metallic Mineral Mining and Quarrying"@en ;
+.
+
+icat:10 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:B ; 
+    skos:definition """This subdivision includes units mainly engaged in Exploration and Other Mining Support Services."""@en ;
+    skos:notation "10" ;
+    skos:prefLabel "Exploration and Other Mining Support Services"@en ;
+.
+
+icat:101 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:10 ; 
+    skos:definition """This group includes units mainly engaged in Exploration."""@en ;
+    skos:notation "101" ;
+    skos:prefLabel "Exploration"@en ;
+.
+
+icat:1011 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:101 ; 
+    skos:definition """This class consists of units mainly engaged in exploring for crude petroleum and natural gas.."""@en ;
+    skos:notation "1011" ;
+    skos:prefLabel "Petroleum Exploration"@en ;
+.
+
+icat:1012 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:101 ; 
+    skos:definition """This class consists of units mainly engaged in exploring for minerals (except for crude petroleum or natural gas).."""@en ;
+    skos:notation "1012" ;
+    skos:prefLabel "Mineral Exploration"@en ;
+.
+
+icat:109 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:10 ; 
+    skos:definition """This group includes units mainly engaged in Other Mining Support Services."""@en ;
+    skos:notation "109" ;
+    skos:prefLabel "Other Mining Support Services"@en ;
+.
+
+icat:1090 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:109 ; 
+    skos:definition """This class consists of units mainly engaged in providing mining support services integral to the mining process.."""@en ;
+    skos:notation "1090" ;
+    skos:prefLabel "Other Mining Support Services"@en ;
+.
+
+icat:C a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Manufacturing Division includes units mainly engaged in the physical or chemical transformation of materials, substances or components into new products (except agriculture and construction). The materials, substances or components transformed by units in this division are raw materials that are products of agriculture, forestry, fishing and mining, or products of other manufacturing units.
+
+Units in the Manufacturing Division are often described as plants, factories or mills and characteristically use power-driven machines and other materials-handling equipment. However, units that transform materials, substances or components into new products by hand, or in the unit's home, are also included. Activities undertaken by units incidental to their manufacturing activity, such as selling directly to the consumer products manufactured on the same premises from which they are sold, such as bakeries and custom tailors, are also included in the division. If, in addition to self-produced products, other products that are not manufactured by the same unit are also sold, the rules for the treatment of mixed activities have to be applied and units classified according to their predominant activity.
+
+Assembly of the component parts of manufactured products, either self-produced or purchased from other units, is considered manufacturing. For example, assembly of self-manufactured prefabricated components at a construction site is considered manufacturing, as the assembly is incidental to the manufacturing activity. Conversely, when undertaken as a primary activity, the on-site assembly of components manufactured by others is considered to be construction.
+
+The boundaries between the Manufacturing Division and other divisions in ANZSIC can sometimes be unclear. The units in the Manufacturing Division are engaged in the transformation of materials into new products. Their output is a new product. However, the definition of what constitutes a 'new product' can be somewhat subjective. As clarification, the following activities are examples of manufacturing activities included in the Manufacturing Division in ANZSIC 2006:
+
+    - Milk bottling and pasteurising;
+    - Both processing and canning or bottling;
+    - Fresh fish packaging (including oyster shucking, fish filleting);
+    - Printing and related support activities;
+    - Ready-mixed concrete production;
+    - Leather tanning and dressing;
+    - Grinding of lenses to prescription;
+    - Wood preserving and treatment;
+    - Electroplating, plating, metal heat treating, and polishing;
+    - Fabricating signs and advertising displays;
+    - Tyre retreading;
+    - Ship, boat, railway rolling stock and aircraft repair and maintenance; and
+    - Substantial alteration, renovation or reconstruction of goods such as transport equipment.
+
+There are some other activities that are often considered 'manufacturing', but for ANZSIC, these are classified in another division. These activities include:
+
+    - Logging and production of crops or livestock (included in the Agriculture, Forestry and Fishing Division);
+    - Construction of structures and fabricating operations performed at the site of construction by contractors (included in the Construction Division);
+    - Publishing and the combined activity of publishing and printing (included in the Information Media and Communications Division); and
+    - Beneficiation (included in the Mining Division).
+
+The subdivisions in the Manufacturing Division generally reflect distinct production processes related to material inputs, production equipment and employee skills.."""@en ;
+    skos:notation "C" ;
+    skos:prefLabel "Manufacturing"@en ;
+.
+
+icat:11 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Food Product Manufacturing."""@en ;
+    skos:notation "11" ;
+    skos:prefLabel "Food Product Manufacturing"@en ;
+.
+
+icat:111 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Meat and Meat Product Manufacturing."""@en ;
+    skos:notation "111" ;
+    skos:prefLabel "Meat and Meat Product Manufacturing"@en ;
+.
+
+icat:1111 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:111 ; 
+    skos:definition """This class consists of units mainly engaged in slaughtering animals (except poultry), boning, freezing, preserving or packing meat (except poultry) or canning meat (except poultry, seafood, bacon, ham and corned meat). Units mainly engaged in manufacturing meat from abattoir by-products (except from products of poultry slaughtering) and rendering lard or tallow are also included.."""@en ;
+    skos:notation "1111" ;
+    skos:prefLabel "Meat Processing"@en ;
+.
+
+icat:1112 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:111 ; 
+    skos:definition """This class consists of units mainly engaged in slaughtering and dressing birds (including poultry and game birds) and/or preparing and processing, boning, chilling, freezing or packaging (including canning) the whole or selected parts of bird carcasses.."""@en ;
+    skos:notation "1112" ;
+    skos:prefLabel "Poultry Processing"@en ;
+.
+
+icat:1113 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:111 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing cured and preserved meats, such as bacon or ham, and in manufacturing smallgoods or prepared meat products not elsewhere classified. Units cure the meat by salting, drying, pickling or smoking.."""@en ;
+    skos:notation "1113" ;
+    skos:prefLabel "Cured Meat and Smallgoods Manufacturing"@en ;
+.
+
+icat:112 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Seafood Processing."""@en ;
+    skos:notation "112" ;
+    skos:prefLabel "Seafood Processing"@en ;
+.
+
+icat:1120 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:112 ; 
+    skos:definition """This class consists of units mainly engaged in processing fish or other seafoods. Processes include skinning or shelling, grading, filleting, boning, crumbing, battering and freezing of the seafood. This class also includes units mainly engaged in operating vessels which gather and process fish or other seafoods.."""@en ;
+    skos:notation "1120" ;
+    skos:prefLabel "Seafood Processing"@en ;
+.
+
+icat:113 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Dairy Product Manufacturing."""@en ;
+    skos:notation "113" ;
+    skos:prefLabel "Dairy Product Manufacturing"@en ;
+.
+
+icat:1131 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:113 ; 
+    skos:definition """This class consists of units mainly engaged in processing raw milk. Processes include pasteurisation of milk and separation to produce milk and cream with varying fat content.."""@en ;
+    skos:notation "1131" ;
+    skos:prefLabel "Milk and Cream Processing"@en ;
+.
+
+icat:1132 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:113 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing ice cream or frozen confectionery.."""@en ;
+    skos:notation "1132" ;
+    skos:prefLabel "Ice Cream Manufacturing"@en ;
+.
+
+icat:1133 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:113 ; 
+    skos:definition """This class consists of units mainly engaged either in manufacturing rennetted or cultured dairy products such as cheese or yoghurt, or in manufacturing other dairy products such as butter, milk powder and condensed or evaporated milk.."""@en ;
+    skos:notation "1133" ;
+    skos:prefLabel "Cheese and Other Dairy Product Manufacturing"@en ;
+.
+
+icat:114 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Fruit and Vegetable Processing."""@en ;
+    skos:notation "114" ;
+    skos:prefLabel "Fruit and Vegetable Processing"@en ;
+.
+
+icat:1140 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:114 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing canned, bottled, preserved, quick frozen or dried fruit (except sun-dried) and vegetable products. Also included are units mainly engaged in manufacturing dehydrated vegetable products, soups, sauces, pickles and mixed meat and vegetable products.."""@en ;
+    skos:notation "1140" ;
+    skos:prefLabel "Fruit and Vegetable Processing"@en ;
+.
+
+icat:115 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Oil and Fat Manufacturing."""@en ;
+    skos:notation "115" ;
+    skos:prefLabel "Oil and Fat Manufacturing"@en ;
+.
+
+icat:1150 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:115 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing crude vegetable or marine animal oil, fat, cake or meal, margarine, compound cooking oil or fat, blended table or salad oil, or refined or hydrogenated oil or fat not elsewhere classified. Units mainly engaged in manufacturing refined animal oil are also included in this class.."""@en ;
+    skos:notation "1150" ;
+    skos:prefLabel "Oil and Fat Manufacturing"@en ;
+.
+
+icat:116 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Grain Mill and Cereal Product Manufacturing."""@en ;
+    skos:notation "116" ;
+    skos:prefLabel "Grain Mill and Cereal Product Manufacturing"@en ;
+.
+
+icat:1161 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:116 ; 
+    skos:definition """This class consists of units mainly engaged in milling flour or meal intended for human consumption from grains, vegetables or plants. Processes include blending and cleaning the grain, treating it with heat and moisture and then passing it through a succession of rollers to produce a variety of flour grades, from coarsely to finely ground products.."""@en ;
+    skos:notation "1161" ;
+    skos:prefLabel "Grain Mill Product Manufacturing"@en ;
+.
+
+icat:1162 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:116 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing prepared cereal foods (including oatmeal), fresh and dried pasta, and prepared baking mixes.."""@en ;
+    skos:notation "1162" ;
+    skos:prefLabel "Cereal, Pasta and Baking Mix Manufacturing"@en ;
+.
+
+icat:117 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Bakery Product Manufacturing."""@en ;
+    skos:notation "117" ;
+    skos:prefLabel "Bakery Product Manufacturing"@en ;
+.
+
+icat:1171 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:117 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing leavened and unleavened bread from factory based premises. Units mainly engaged in manufacturing bread dough (either fresh or frozen), breadcrumbs, or baking bread from home are also included.."""@en ;
+    skos:notation "1171" ;
+    skos:prefLabel "Bread Manufacturing (Factory based)"@en ;
+.
+
+icat:1172 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:117 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing cakes, pastries, pies or similar bakery products (including frozen bakery products) from either factory based premises or home. Also included are units mainly engaged in finishing cakes (such as adding icing or jam).."""@en ;
+    skos:notation "1172" ;
+    skos:prefLabel "Cake and Pastry Manufacturing (Factory based)"@en ;
+.
+
+icat:1173 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:117 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing biscuits from either factory based premises or home.."""@en ;
+    skos:notation "1173" ;
+    skos:prefLabel "Biscuit Manufacturing (Factory based)"@en ;
+.
+
+icat:1174 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:117 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing and selling directly to consumers from the same premises, bread and other bakery products.."""@en ;
+    skos:notation "1174" ;
+    skos:prefLabel "Bakery Product Manufacturing (Non-factory based)"@en ;
+.
+
+icat:118 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Sugar and Confectionery Manufacturing."""@en ;
+    skos:notation "118" ;
+    skos:prefLabel "Sugar and Confectionery Manufacturing"@en ;
+.
+
+icat:1181 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:118 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing raw or refined sugar or molasses from sugar cane, raw cane sugar or sugar beet.."""@en ;
+    skos:notation "1181" ;
+    skos:prefLabel "Sugar Manufacturing"@en ;
+.
+
+icat:1182 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:118 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing confectionery, chocolate or cocoa products, with or without sugar.."""@en ;
+    skos:notation "1182" ;
+    skos:prefLabel "Confectionery Manufacturing"@en ;
+.
+
+icat:119 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:11 ; 
+    skos:definition """This group includes units mainly engaged in Other Food Product Manufacturing."""@en ;
+    skos:notation "119" ;
+    skos:prefLabel "Other Food Product Manufacturing"@en ;
+.
+
+icat:1191 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:119 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing potato crisps, corn chips and other crisps.."""@en ;
+    skos:notation "1191" ;
+    skos:prefLabel "Potato, Corn and Other Crisp Manufacturing"@en ;
+.
+
+icat:1192 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:119 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing prepared animal or bird feed, including cereal meal, grain offal or crushed grain for use as animal fodder (from whole grain, except from rice or rye). Units may manufacture canned, chilled or dried animal or bird feed or treats, including pet milk.."""@en ;
+    skos:notation "1192" ;
+    skos:prefLabel "Prepared Animal and Bird Feed Manufacturing"@en ;
+.
+
+icat:1199 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:119 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing other food products not elsewhere classified. Included in this class are units mainly engaged in manufacturing coffee and tea, food flavourings, seasonings and colourings, frozen pre-prepared meals and health supplements.."""@en ;
+    skos:notation "1199" ;
+    skos:prefLabel "Other Food Product Manufacturing n.e.c."@en ;
+.
+
+icat:12 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Beverage and Tobacco Product Manufacturing."""@en ;
+    skos:notation "12" ;
+    skos:prefLabel "Beverage and Tobacco Product Manufacturing"@en ;
+.
+
+icat:121 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:12 ; 
+    skos:definition """This group includes units mainly engaged in Beverage Manufacturing."""@en ;
+    skos:notation "121" ;
+    skos:prefLabel "Beverage Manufacturing"@en ;
+.
+
+icat:1211 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:121 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing aerated or carbonated soft drinks, mineral or purified waters, fruit drinks (less than 100 percent pure juice), concentrated cordials, syrups or non-alcoholic brewed beer or cider.."""@en ;
+    skos:notation "1211" ;
+    skos:prefLabel "Soft Drink, Cordial and Syrup Manufacturing"@en ;
+.
+
+icat:1212 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:121 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing beer, ale, stout or porter.."""@en ;
+    skos:notation "1212" ;
+    skos:prefLabel "Beer Manufacturing"@en ;
+.
+
+icat:1213 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:121 ; 
+    skos:definition """This class consists of units mainly engaged in the fermentation, distillation or blending of fortified spirits for human consumption.."""@en ;
+    skos:notation "1213" ;
+    skos:prefLabel "Spirit Manufacturing"@en ;
+.
+
+icat:1214 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:121 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing or blending wine, fermented cider or wine vinegar, or alcoholic beverages not elsewhere classified.."""@en ;
+    skos:notation "1214" ;
+    skos:prefLabel "Wine and Other Alcoholic Beverage Manufacturing"@en ;
+.
+
+icat:122 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:12 ; 
+    skos:definition """This group includes units mainly engaged in Cigarette and Tobacco Product Manufacturing."""@en ;
+    skos:notation "122" ;
+    skos:prefLabel "Cigarette and Tobacco Product Manufacturing"@en ;
+.
+
+icat:1220 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:122 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing cigarettes, cigars, smoking or chewing tobacco, snuff or in redrying tobacco leaf.."""@en ;
+    skos:notation "1220" ;
+    skos:prefLabel "Cigarette and Tobacco Product Manufacturing"@en ;
+.
+
+icat:13 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Textile, Leather, Clothing and Footwear Manufacturing."""@en ;
+    skos:notation "13" ;
+    skos:prefLabel "Textile, Leather, Clothing and Footwear Manufacturing"@en ;
+.
+
+icat:131 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:13 ; 
+    skos:definition """This group includes units mainly engaged in Textile Manufacturing."""@en ;
+    skos:notation "131" ;
+    skos:prefLabel "Textile Manufacturing"@en ;
+.
+
+icat:1311 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:131 ; 
+    skos:definition """This class consists of units mainly engaged in scouring, carbonising, carding or combing of wool or in manufacturing unspun wool tops.."""@en ;
+    skos:notation "1311" ;
+    skos:prefLabel "Wool Scouring"@en ;
+.
+
+icat:1312 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:131 ; 
+    skos:definition """This class consists of units mainly engaged in spinning yarns or weaving fabrics wholly or predominantly made of natural fibres such as cotton or wool. Also included are units mainly engaged in manufacturing yarns or woven fabrics wholly or predominantly made from flax or silk.."""@en ;
+    skos:notation "1312" ;
+    skos:prefLabel "Natural Textile Manufacturing"@en ;
+.
+
+icat:1313 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:131 ; 
+    skos:definition """This class consists of units mainly engaged in spinning yarns or weaving fabrics wholly or predominately made of synthetic fibres.."""@en ;
+    skos:notation "1313" ;
+    skos:prefLabel "Synthetic Textile Manufacturing"@en ;
+.
+
+icat:132 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:13 ; 
+    skos:definition """This group includes units mainly engaged in Leather Tanning, Fur Dressing and Leather Product Manufacturing."""@en ;
+    skos:notation "132" ;
+    skos:prefLabel "Leather Tanning, Fur Dressing and Leather Product Manufacturing"@en ;
+.
+
+icat:1320 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:132 ; 
+    skos:definition """This class consists of units mainly engaged in the production of fellmongered wool, pelt or slipe wool; and in tanning, currying, dressing, finishing, dyeing, embossing or japanning leather, animal skins or fur. Units mainly engaged in manufacturing products (except clothing and footwear) such as suitcases, handbags, wallets, saddlery or harnesses of leather or leather substitutes are also included.."""@en ;
+    skos:notation "1320" ;
+    skos:prefLabel "Leather Tanning, Fur Dressing and Leather Product Manufacturing"@en ;
+.
+
+icat:133 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:13 ; 
+    skos:definition """This group includes units mainly engaged in Textile Product Manufacturing."""@en ;
+    skos:notation "133" ;
+    skos:prefLabel "Textile Product Manufacturing"@en ;
+.
+
+icat:1331 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:133 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing carpets, rugs or other textile floor coverings from natural or synthetic fibres, using weaving and tufting processes. This class also includes units mainly engaged in manufacturing mats or matting of jute or twisted rags.."""@en ;
+    skos:notation "1331" ;
+    skos:prefLabel "Textile Floor Covering Manufacturing"@en ;
+.
+
+icat:1332 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:133 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing rope, cordage, twine, net or related products from natural or synthetic fibres.."""@en ;
+    skos:notation "1332" ;
+    skos:prefLabel "Rope, Cordage and Twine Manufacturing"@en ;
+.
+
+icat:1333 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:133 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing textile products (except apparel) from natural or synthetic fabric, primarily by cutting and sewing. Also included are units mainly engaged in manufacturing cut and sewn textile products from fabrics woven at the same unit.."""@en ;
+    skos:notation "1333" ;
+    skos:prefLabel "Cut and Sewn Textile Product Manufacturing"@en ;
+.
+
+icat:1334 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:133 ; 
+    skos:definition """This class consists of units mainly engaged in finishing textile products, using processes such as automated embroidery, bleaching, dyeing, printing (except screen printing) or pleating on a fee or commission basis. This class also includes units mainly engaged in manufacturing felt, felt products (except clothing) or other textile products not elsewhere classified.."""@en ;
+    skos:notation "1334" ;
+    skos:prefLabel "Textile Finishing and Other Textile Product Manufacturing"@en ;
+.
+
+icat:134 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:13 ; 
+    skos:definition """This group includes units mainly engaged in Knitted Product Manufacturing."""@en ;
+    skos:notation "134" ;
+    skos:prefLabel "Knitted Product Manufacturing"@en ;
+.
+
+icat:1340 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:134 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing knitted or crocheted fabrics or knitted clothing, including hosiery, cardigans, jackets, pullovers or similar garments.."""@en ;
+    skos:notation "1340" ;
+    skos:prefLabel "Knitted Product Manufacturing"@en ;
+.
+
+icat:135 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:13 ; 
+    skos:definition """This group includes units mainly engaged in Clothing and Footwear Manufacturing."""@en ;
+    skos:notation "135" ;
+    skos:prefLabel "Clothing and Footwear Manufacturing"@en ;
+.
+
+icat:1351 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:135 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing clothing (except knitted clothing). Included are units manufacturing outerwear, underwear, sleepwear, infant clothing, headwear, fur or leather clothing and clothing accessories. This class also includes units mainly engaged in providing clothing trade services such as hem stitching, basque knitting or buttonholing.."""@en ;
+    skos:notation "1351" ;
+    skos:prefLabel "Clothing Manufacturing"@en ;
+.
+
+icat:1352 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:135 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing footwear or footwear components such as uppers and upper parts, and outer and inner soles and heels.."""@en ;
+    skos:notation "1352" ;
+    skos:prefLabel "Footwear Manufacturing"@en ;
+.
+
+icat:14 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Wood Product Manufacturing."""@en ;
+    skos:notation "14" ;
+    skos:prefLabel "Wood Product Manufacturing"@en ;
+.
+
+icat:141 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:14 ; 
+    skos:definition """This group includes units mainly engaged in Log Sawmilling and Timber Dressing."""@en ;
+    skos:notation "141" ;
+    skos:prefLabel "Log Sawmilling and Timber Dressing"@en ;
+.
+
+icat:1411 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:141 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing rough sawn timber, and boards.."""@en ;
+    skos:notation "1411" ;
+    skos:prefLabel "Log Sawmilling"@en ;
+.
+
+icat:1412 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:141 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing softwood or hardwood wood chips.."""@en ;
+    skos:notation "1412" ;
+    skos:prefLabel "Wood Chipping"@en ;
+.
+
+icat:1413 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:141 ; 
+    skos:definition """This class consists of units mainly engaged in resawing or dressing timber, timber boards and mouldings. Dressing timber includes seasoning (kiln or air drying) or chemical preservation.."""@en ;
+    skos:notation "1413" ;
+    skos:prefLabel "Timber Resawing and Dressing"@en ;
+.
+
+icat:149 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:14 ; 
+    skos:definition """This group includes units mainly engaged in Other Wood Product Manufacturing."""@en ;
+    skos:notation "149" ;
+    skos:prefLabel "Other Wood Product Manufacturing"@en ;
+.
+
+icat:1491 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:149 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing wooden prefabricated buildings.."""@en ;
+    skos:notation "1491" ;
+    skos:prefLabel "Prefabricated Wooden Building Manufacturing"@en ;
+.
+
+icat:1492 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:149 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing wooden structural fittings and components such as roof trusses, doors, wood-framed doors, wall and window frames, shop fronts and joinery (including kitchen fittings) for buildings.."""@en ;
+    skos:notation "1492" ;
+    skos:prefLabel "Wooden Structural Fitting and Component Manufacturing"@en ;
+.
+
+icat:1493 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:149 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing veneers and plywood.."""@en ;
+    skos:notation "1493" ;
+    skos:prefLabel "Veneer and Plywood Manufacturing"@en ;
+.
+
+icat:1494 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:149 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing wood boards and sheets from reconstituted wood fibres such as wood chips, sawdust, wood shavings, slabwood or off-cuts. Also included are units that manufacture laminations of timber and non-timber materials (including decorative plastic laminates on boards or other substrates).."""@en ;
+    skos:notation "1494" ;
+    skos:prefLabel "Reconstituted Wood Product Manufacturing"@en ;
+.
+
+icat:1499 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:149 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing wood products not elsewhere classified, including wicker ware, cork, bamboo or cane products (excluding furniture).."""@en ;
+    skos:notation "1499" ;
+    skos:prefLabel "Other Wood Product Manufacturing n.e.c."@en ;
+.
+
+icat:15 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Pulp, Paper and Converted Paper Product Manufacturing."""@en ;
+    skos:notation "15" ;
+    skos:prefLabel "Pulp, Paper and Converted Paper Product Manufacturing"@en ;
+.
+
+icat:151 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:15 ; 
+    skos:definition """This group includes units mainly engaged in Pulp, Paper and Paperboard Manufacturing."""@en ;
+    skos:notation "151" ;
+    skos:prefLabel "Pulp, Paper and Paperboard Manufacturing"@en ;
+.
+
+icat:1510 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:151 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing wood pulp (chemical or mechanical), paper or paperboard. It includes the manufacture of bulk paper from any fibre (including used paper) and the production of pulp from used paper.."""@en ;
+    skos:notation "1510" ;
+    skos:prefLabel "Pulp, Paper and Paperboard Manufacturing"@en ;
+.
+
+icat:152 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:15 ; 
+    skos:definition """This group includes units mainly engaged in Converted Paper Product Manufacturing."""@en ;
+    skos:notation "152" ;
+    skos:prefLabel "Converted Paper Product Manufacturing"@en ;
+.
+
+icat:1521 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:152 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing corrugated paperboard containers, sheeting or solid paperboard containers.."""@en ;
+    skos:notation "1521" ;
+    skos:prefLabel "Corrugated Paperboard and Paperboard Container Manufacturing"@en ;
+.
+
+icat:1522 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:152 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing paper bags (including multiwall bags of paper).."""@en ;
+    skos:notation "1522" ;
+    skos:prefLabel "Paper Bag Manufacturing"@en ;
+.
+
+icat:1523 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:152 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing paper stationery products, including paper products used for writing, filing and similar applications.."""@en ;
+    skos:notation "1523" ;
+    skos:prefLabel "Paper Stationery Manufacturing"@en ;
+.
+
+icat:1524 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:152 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing sanitary paper-based products from paper or cellulose wadding.."""@en ;
+    skos:notation "1524" ;
+    skos:prefLabel "Sanitary Paper Product Manufacturing"@en ;
+.
+
+icat:1529 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:152 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing paper products not elsewhere classified.."""@en ;
+    skos:notation "1529" ;
+    skos:prefLabel "Other Converted Paper Product Manufacturing"@en ;
+.
+
+icat:16 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Printing (including the Reproduction of Recorded Media)."""@en ;
+    skos:notation "16" ;
+    skos:prefLabel "Printing (including the Reproduction of Recorded Media)"@en ;
+.
+
+icat:161 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:16 ; 
+    skos:definition """This group includes units mainly engaged in Printing and Printing Support Services."""@en ;
+    skos:notation "161" ;
+    skos:prefLabel "Printing and Printing Support Services"@en ;
+.
+
+icat:1611 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:161 ; 
+    skos:definition """This class consists of units mainly engaged in printing and/or providing reprographic services. Printing methods may include off-set lithographic, reprographic, digital, relief and screen printing. Units may print onto a variety of materials, including paper, plastic and metal. Also included are units mainly engaged in screen printing on wearing apparel.."""@en ;
+    skos:notation "1611" ;
+    skos:prefLabel "Printing"@en ;
+.
+
+icat:1612 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:161 ; 
+    skos:definition """This class consists of units mainly engaged in providing printing support services such as pre-press (e.g. typesetting, colour separation or platemaking), post-press or finishing (e.g. laminating, embossing or book binding) services.."""@en ;
+    skos:notation "1612" ;
+    skos:prefLabel "Printing Support Services"@en ;
+.
+
+icat:162 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:16 ; 
+    skos:definition """This group includes units mainly engaged in Reproduction of Recorded Media."""@en ;
+    skos:notation "162" ;
+    skos:prefLabel "Reproduction of Recorded Media"@en ;
+.
+
+icat:1620 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:162 ; 
+    skos:definition """This class consists of units mainly engaged in the reproduction of pre-recorded audio, video, software and other data on electronic, optical and magnetic media.."""@en ;
+    skos:notation "1620" ;
+    skos:prefLabel "Reproduction of Recorded Media"@en ;
+.
+
+icat:17 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Petroleum and Coal Product Manufacturing."""@en ;
+    skos:notation "17" ;
+    skos:prefLabel "Petroleum and Coal Product Manufacturing"@en ;
+.
+
+icat:170 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:17 ; 
+    skos:definition """This group includes units mainly engaged in Petroleum and Coal Product Manufacturing."""@en ;
+    skos:notation "170" ;
+    skos:prefLabel "Petroleum and Coal Product Manufacturing"@en ;
+.
+
+icat:1701 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:170 ; 
+    skos:definition """This class consists of units mainly engaged in refining heavy and light component crude oil, manufacturing and/or blending materials into petroleum fuels, and manufacturing fuels from the liquefication of petroleum gases.."""@en ;
+    skos:notation "1701" ;
+    skos:prefLabel "Petroleum Refining and Petroleum Fuel Manufacturing"@en ;
+.
+
+icat:1709 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:170 ; 
+    skos:definition """This class consists of units mainly engaged in further refining heavy and light oil components into petroleum and coal products not elsewhere classified, using oil and grease base stocks, as well as synthetic organic compound base stocks. This class also includes units mainly engaged in distilling coal tars and/or manufacturing cyclic organic hydrocarbon intermediate compounds from refined petroleum or natural gas.."""@en ;
+    skos:notation "1709" ;
+    skos:prefLabel "Other Petroleum and Coal Product Manufacturing"@en ;
+.
+
+icat:18 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Basic Chemical and Chemical Product Manufacturing."""@en ;
+    skos:notation "18" ;
+    skos:prefLabel "Basic Chemical and Chemical Product Manufacturing"@en ;
+.
+
+icat:181 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:18 ; 
+    skos:definition """This group includes units mainly engaged in Basic Chemical Manufacturing."""@en ;
+    skos:notation "181" ;
+    skos:prefLabel "Basic Chemical Manufacturing"@en ;
+.
+
+icat:1811 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:181 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing industrial organic and inorganic gas in compressed, liquid or solid forms.."""@en ;
+    skos:notation "1811" ;
+    skos:prefLabel "Industrial Gas Manufacturing"@en ;
+.
+
+icat:1812 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:181 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing basic organic chemicals, including wood or gum chemicals (e.g. organic tanning extracts and charcoal briquettes); high grade activated charcoal and/or carbon black; organic dyes and pigments. This class also includes units mainly engaged in manufacturing organic acids and industrial alcohols such as ethanol, methanol, ethylene glycol and ether.."""@en ;
+    skos:notation "1812" ;
+    skos:prefLabel "Basic Organic Chemical Manufacturing"@en ;
+.
+
+icat:1813 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:181 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing basic inorganic chemicals, including dyes and pigments; chromium sulphate (used in leather tanning); acids; and salts. This class also includes units mainly engaged in manufacturing chlorine, sodium hydroxide and other alkali using electrochemical processes.."""@en ;
+    skos:notation "1813" ;
+    skos:prefLabel "Basic Inorganic Chemical Manufacturing"@en ;
+.
+
+icat:182 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:18 ; 
+    skos:definition """This group includes units mainly engaged in Basic Polymer Manufacturing."""@en ;
+    skos:notation "182" ;
+    skos:prefLabel "Basic Polymer Manufacturing"@en ;
+.
+
+icat:1821 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:182 ; 
+    skos:definition """This class consists of units mainly engaged in the manufacture of synthetic resins, non-vulcanisable elastomers and mixing and blending of resins and polymeric materials. This class also includes units mainly engaged in manufacturing synthetic rubbers and blends.."""@en ;
+    skos:notation "1821" ;
+    skos:prefLabel "Synthetic Resin and Synthetic Rubber Manufacturing"@en ;
+.
+
+icat:1829 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:182 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing other basic polymers (except synthetic resins and synthetic rubbers). Included in this class are units mainly engaged in manufacturing cellulose (e.g. rayon and acetate) and non-cellulose (e.g. nylon, polyolefin and polyester) fibres and filaments.."""@en ;
+    skos:notation "1829" ;
+    skos:prefLabel "Other Basic Polymer Manufacturing"@en ;
+.
+
+icat:183 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:18 ; 
+    skos:definition """This group includes units mainly engaged in Fertiliser and Pesticide Manufacturing."""@en ;
+    skos:notation "183" ;
+    skos:prefLabel "Fertiliser and Pesticide Manufacturing"@en ;
+.
+
+icat:1831 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:183 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing and mixing fertilisers.."""@en ;
+    skos:notation "1831" ;
+    skos:prefLabel "Fertiliser Manufacturing"@en ;
+.
+
+icat:1832 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:183 ; 
+    skos:definition """This class consists of units mainly engaged in the formulation and preparation of pest control chemicals.."""@en ;
+    skos:notation "1832" ;
+    skos:prefLabel "Pesticide Manufacturing"@en ;
+.
+
+icat:184 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:18 ; 
+    skos:definition """This group includes units mainly engaged in Pharmaceutical and Medicinal Product Manufacturing."""@en ;
+    skos:notation "184" ;
+    skos:prefLabel "Pharmaceutical and Medicinal Product Manufacturing"@en ;
+.
+
+icat:1841 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:184 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing pharmaceutical and medicinal products for human use from both natural (plants) and synthetic sources (chemicals). This class also consists of units mainly engaged in manufacturing diagnostic substances for antibodies, antigens and chemical/diagnostic testing agents.."""@en ;
+    skos:notation "1841" ;
+    skos:prefLabel "Human Pharmaceutical and Medicinal Product Manufacturing"@en ;
+.
+
+icat:1842 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:184 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing drugs, medicines, medicinal chemicals, vaccines, serums and other pharmaceutical products for veterinary use.."""@en ;
+    skos:notation "1842" ;
+    skos:prefLabel "Veterinary Pharmaceutical and Medicinal Product Manufacturing"@en ;
+.
+
+icat:185 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:18 ; 
+    skos:definition """This group includes units mainly engaged in Cleaning Compound and Toiletry Preparation Manufacturing."""@en ;
+    skos:notation "185" ;
+    skos:prefLabel "Cleaning Compound and Toiletry Preparation Manufacturing"@en ;
+.
+
+icat:1851 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:185 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing cleaning compounds, including toothpastes, soaps and other detergents, surface active agents, polishes and speciality cleaning preparations.."""@en ;
+    skos:notation "1851" ;
+    skos:prefLabel "Cleaning Compound Manufacturing"@en ;
+.
+
+icat:1852 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:185 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing cosmetic and toiletry preparations.."""@en ;
+    skos:notation "1852" ;
+    skos:prefLabel "Cosmetic and Toiletry Preparation Manufacturing"@en ;
+.
+
+icat:189 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:18 ; 
+    skos:definition """This group includes units mainly engaged in Other Basic Chemical Product Manufacturing."""@en ;
+    skos:notation "189" ;
+    skos:prefLabel "Other Basic Chemical Product Manufacturing"@en ;
+.
+
+icat:1891 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:189 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing photographic sensitised film, paper, cloth, plates and chemicals.."""@en ;
+    skos:notation "1891" ;
+    skos:prefLabel "Photographic Chemical Product Manufacturing"@en ;
+.
+
+icat:1892 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:189 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing explosives.."""@en ;
+    skos:notation "1892" ;
+    skos:prefLabel "Explosive Manufacturing"@en ;
+.
+
+icat:1899 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:189 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing chemical products not elsewhere classified.."""@en ;
+    skos:notation "1899" ;
+    skos:prefLabel "Other Basic Chemical Product Manufacturing n.e.c."@en ;
+.
+
+icat:19 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Polymer Product and Rubber Product Manufacturing."""@en ;
+    skos:notation "19" ;
+    skos:prefLabel "Polymer Product and Rubber Product Manufacturing"@en ;
+.
+
+icat:191 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:19 ; 
+    skos:definition """This group includes units mainly engaged in Polymer Product Manufacturing."""@en ;
+    skos:notation "191" ;
+    skos:prefLabel "Polymer Product Manufacturing"@en ;
+.
+
+icat:1911 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:191 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing unsupported polymer film or polymer sheet into packaging materials. This includes bubble packaging, bags, coatings or laminates in a variety of forms.."""@en ;
+    skos:notation "1911" ;
+    skos:prefLabel "Polymer Film and Sheet Packaging Material Manufacturing"@en ;
+.
+
+icat:1912 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:191 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing rigid or semi-rigid polymer products.."""@en ;
+    skos:notation "1912" ;
+    skos:prefLabel "Rigid and Semi-Rigid Polymer Product Manufacturing"@en ;
+.
+
+icat:1913 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:191 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing polymer foam products. Also included in this class are units mainly engaged in manufacturing polymer filler products used to fill cavities in walls, as well as insulation and cushioning materials for swimming pools and spas, and for marine flotation.."""@en ;
+    skos:notation "1913" ;
+    skos:prefLabel "Polymer Foam Product Manufacturing"@en ;
+.
+
+icat:1914 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:191 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing tyres from synthetic polymers and/or natural rubber, tyre repair materials and inner tubes. This class also includes units mainly engaged in manufacturing retread or rebuilt tyres using both natural and synthetic rubber.."""@en ;
+    skos:notation "1914" ;
+    skos:prefLabel "Tyre Manufacturing"@en ;
+.
+
+icat:1915 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:191 ; 
+    skos:definition """This class consists of units mainly engaged in the manufacture of glues, adhesives and other bonding materials of an organic nature.."""@en ;
+    skos:notation "1915" ;
+    skos:prefLabel "Adhesive Manufacturing"@en ;
+.
+
+icat:1916 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:191 ; 
+    skos:definition """This class consists of units mainly engaged in mixing pigments, solvents and binders into paints and coatings. This class also includes manufacturing allied paint products (e.g. putties, caulking compounds, paint and varnish removers) and rubbing compounds. This class also includes units mainly engaged in manufacturing inks and toners.."""@en ;
+    skos:notation "1916" ;
+    skos:prefLabel "Paint and Coatings Manufacturing"@en ;
+.
+
+icat:1919 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:191 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing polymer composite products such as fibreglass products and resilient floor coverings, as well as other polymer products not elsewhere classified.."""@en ;
+    skos:notation "1919" ;
+    skos:prefLabel "Other Polymer Product Manufacturing"@en ;
+.
+
+icat:192 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:19 ; 
+    skos:definition """This group includes units mainly engaged in Natural Rubber Product Manufacturing."""@en ;
+    skos:notation "192" ;
+    skos:prefLabel "Natural Rubber Product Manufacturing"@en ;
+.
+
+icat:1920 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:192 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing products made solely of natural rubber.."""@en ;
+    skos:notation "1920" ;
+    skos:prefLabel "Natural Rubber Product Manufacturing"@en ;
+.
+
+icat:20 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Non-Metallic Mineral Product Manufacturing."""@en ;
+    skos:notation "20" ;
+    skos:prefLabel "Non-Metallic Mineral Product Manufacturing"@en ;
+.
+
+icat:201 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:20 ; 
+    skos:definition """This group includes units mainly engaged in Glass and Glass Product Manufacturing."""@en ;
+    skos:notation "201" ;
+    skos:prefLabel "Glass and Glass Product Manufacturing"@en ;
+.
+
+icat:2010 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:201 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing glass or glass products.."""@en ;
+    skos:notation "2010" ;
+    skos:prefLabel "Glass and Glass Product Manufacturing"@en ;
+.
+
+icat:202 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:20 ; 
+    skos:definition """This group includes units mainly engaged in Ceramic Product Manufacturing."""@en ;
+    skos:notation "202" ;
+    skos:prefLabel "Ceramic Product Manufacturing"@en ;
+.
+
+icat:2021 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:202 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing clay bricks (except refractory bricks).."""@en ;
+    skos:notation "2021" ;
+    skos:prefLabel "Clay Brick Manufacturing"@en ;
+.
+
+icat:2029 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:202 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing ceramic products not elsewhere classified. This includes shaping and kiln firing clay-based non-metallic minerals to produce ceramic products, including refractory (high temperature) clay, porcelain or vitreous china.."""@en ;
+    skos:notation "2029" ;
+    skos:prefLabel "Other Ceramic Product Manufacturing"@en ;
+.
+
+icat:203 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:20 ; 
+    skos:definition """This group includes units mainly engaged in Cement, Lime, Plaster and Concrete Product Manufacturing."""@en ;
+    skos:notation "203" ;
+    skos:prefLabel "Cement, Lime, Plaster and Concrete Product Manufacturing"@en ;
+.
+
+icat:2031 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:203 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing portland, natural and other hydraulic cement from crushed limestone and clay/shale. Also included are units mainly engaged in manufacturing lime and lime products from calcareous materials.."""@en ;
+    skos:notation "2031" ;
+    skos:prefLabel "Cement and Lime Manufacturing"@en ;
+.
+
+icat:2032 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:203 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing gypsum-based plaster, plasterboard or other plaster products.."""@en ;
+    skos:notation "2032" ;
+    skos:prefLabel "Plaster Product Manufacturing"@en ;
+.
+
+icat:2033 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:203 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing ready-mixed concrete or mortar, dry mix concrete and concrete slurry.."""@en ;
+    skos:notation "2033" ;
+    skos:prefLabel "Ready-Mixed Concrete Manufacturing"@en ;
+.
+
+icat:2034 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:203 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing concrete products. Included in this class are units manufacturing aerated and concrete composite products.."""@en ;
+    skos:notation "2034" ;
+    skos:prefLabel "Concrete Product Manufacturing"@en ;
+.
+
+icat:209 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:20 ; 
+    skos:definition """This group includes units mainly engaged in Other Non-Metallic Mineral Product Manufacturing."""@en ;
+    skos:notation "209" ;
+    skos:prefLabel "Other Non-Metallic Mineral Product Manufacturing"@en ;
+.
+
+icat:2090 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:209 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing abrasives, lightweight aggregates and other expanded non-metallic mineral, or non-metallic mineral products not elsewhere classified. This class also includes the manufacture of synthetic abrasives.."""@en ;
+    skos:notation "2090" ;
+    skos:prefLabel "Other Non-Metallic Mineral Product Manufacturing"@en ;
+.
+
+icat:21 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Primary Metal and Metal Product Manufacturing."""@en ;
+    skos:notation "21" ;
+    skos:prefLabel "Primary Metal and Metal Product Manufacturing"@en ;
+.
+
+icat:211 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:21 ; 
+    skos:definition """This group includes units mainly engaged in Basic Ferrous Metal Manufacturing."""@en ;
+    skos:notation "211" ;
+    skos:prefLabel "Basic Ferrous Metal Manufacturing"@en ;
+.
+
+icat:2110 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:211 ; 
+    skos:definition """This class consists of units mainly engaged in smelting and/or refining iron ore or iron sands into basic iron products such as ingots, billets and slabs. Also included are units mainly engaged in manufacturing steel from iron alloyed with other elements (e.g. with carbon to produce carbon steel; with chromium to produce stainless steel); the conversion of basic iron and steel products (generally by hot or cold rolling) into primary shapes such as sheets, bars and rods; and recycling scrap ferrous metals.."""@en ;
+    skos:notation "2110" ;
+    skos:prefLabel "Iron Smelting and Steel Manufacturing"@en ;
+.
+
+icat:212 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:21 ; 
+    skos:definition """This group includes units mainly engaged in Basic Ferrous Metal Product Manufacturing."""@en ;
+    skos:notation "212" ;
+    skos:prefLabel "Basic Ferrous Metal Product Manufacturing"@en ;
+.
+
+icat:2121 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:212 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing finished iron and steel products by casting (also known as 'founding') molten ferrous metals in moulds.."""@en ;
+    skos:notation "2121" ;
+    skos:prefLabel "Iron and Steel Casting"@en ;
+.
+
+icat:2122 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:212 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing seamless or welded steel pipes or tubes, or ferrous metal pipe or tube fittings (except cast or forged).."""@en ;
+    skos:notation "2122" ;
+    skos:prefLabel "Steel Pipe and Tube Manufacturing"@en ;
+.
+
+icat:213 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:21 ; 
+    skos:definition """This group includes units mainly engaged in Basic Non-Ferrous Metal Manufacturing."""@en ;
+    skos:notation "213" ;
+    skos:prefLabel "Basic Non-Ferrous Metal Manufacturing"@en ;
+.
+
+icat:2131 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:213 ; 
+    skos:definition """This class consists of units mainly engaged in refining bauxite to form alumina (aluminium oxide).."""@en ;
+    skos:notation "2131" ;
+    skos:prefLabel "Alumina Production"@en ;
+.
+
+icat:2132 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:213 ; 
+    skos:definition """This class consists of units mainly engaged in smelting alumina to produce aluminium, or recovering aluminium from scrap. The aluminium is cast into basic shapes or may be cast according to customer specifications. Also included in this class are units manufacturing aluminium alloys from primary aluminium smelted at the same unit.."""@en ;
+    skos:notation "2132" ;
+    skos:prefLabel "Aluminium Smelting"@en ;
+.
+
+icat:2133 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:213 ; 
+    skos:definition """This class consists of units mainly engaged in primary smelting or refining of copper, silver, lead or zinc, or in the recovery of these metals from waste or scrap. The metal is cast into ingots or other basic shapes. This class also includes by-production of sulphuric acid in conjunction with the smelting of these metals.."""@en ;
+    skos:notation "2133" ;
+    skos:prefLabel "Copper, Silver, Lead and Zinc Smelting and Refining"@en ;
+.
+
+icat:2139 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:213 ; 
+    skos:definition """This class consists of units mainly engaged in primary smelting, secondary smelting and refining of other non-ferrous metals, or in the recovery of such metals from drosses, ashes, scrap or other waste material. The metal is cast into ingots or other basic shapes. This class also includes units mainly engaged in manufacturing non-ferrous metal powders or flakes of molybdenum, tantalum or tungsten.."""@en ;
+    skos:notation "2139" ;
+    skos:prefLabel "Other Basic Non-Ferrous Metal Manufacturing"@en ;
+.
+
+icat:214 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:21 ; 
+    skos:definition """This group includes units mainly engaged in Basic Non-Ferrous Metal Product Manufacturing."""@en ;
+    skos:notation "214" ;
+    skos:prefLabel "Basic Non-Ferrous Metal Product Manufacturing"@en ;
+.
+
+icat:2141 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:214 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing finished non-ferrous metal products by casting molten non-ferrous metals in moulds. Also included in this class are units mainly engaged in cleaning and finishing cast non-ferrous products.."""@en ;
+    skos:notation "2141" ;
+    skos:prefLabel "Non-Ferrous Metal Casting"@en ;
+.
+
+icat:2142 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:214 ; 
+    skos:definition """This class consists of units mainly engaged in hot or cold rolling, drawing or extruding aluminium. Also included are units mainly engaged in manufacturing aluminium powders or flakes.."""@en ;
+    skos:notation "2142" ;
+    skos:prefLabel "Aluminium Rolling, Drawing, Extruding"@en ;
+.
+
+icat:2149 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:214 ; 
+    skos:definition """This class consists of units mainly engaged in hot or cold rolling, drawing or extruding non-ferrous metal. Also included are units mainly engaged in manufacturing non-ferrous metal powders or flakes not elsewhere classified.."""@en ;
+    skos:notation "2149" ;
+    skos:prefLabel "Other Basic Non-Ferrous Metal Product Manufacturing"@en ;
+.
+
+icat:22 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Fabricated Metal Product Manufacturing."""@en ;
+    skos:notation "22" ;
+    skos:prefLabel "Fabricated Metal Product Manufacturing"@en ;
+.
+
+icat:221 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:22 ; 
+    skos:definition """This group includes units mainly engaged in Iron and Steel Forging."""@en ;
+    skos:notation "221" ;
+    skos:prefLabel "Iron and Steel Forging"@en ;
+.
+
+icat:2210 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:221 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing finished or semi-finished iron or steel products by forging (compressive force exerted through a die).."""@en ;
+    skos:notation "2210" ;
+    skos:prefLabel "Iron and Steel Forging"@en ;
+.
+
+icat:222 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:22 ; 
+    skos:definition """This group includes units mainly engaged in Structural Metal Product Manufacturing."""@en ;
+    skos:notation "222" ;
+    skos:prefLabel "Structural Metal Product Manufacturing"@en ;
+.
+
+icat:2221 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:222 ; 
+    skos:definition """This class consists of units mainly engaged in fabricating structural steel components of buildings or other structures.."""@en ;
+    skos:notation "2221" ;
+    skos:prefLabel "Structural Steel Fabricating"@en ;
+.
+
+icat:2222 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:222 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing prefabricated metal buildings.."""@en ;
+    skos:notation "2222" ;
+    skos:prefLabel "Prefabricated Metal Building Manufacturing"@en ;
+.
+
+icat:2223 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:222 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing architectural aluminium products such as doors, railings, roofing and guttering, or aluminium framed windows, doors or shower screens (complete with glass).."""@en ;
+    skos:notation "2223" ;
+    skos:prefLabel "Architectural Aluminium Product Manufacturing"@en ;
+.
+
+icat:2224 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:222 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing metal roofing components, including guttering, from sheet metal other than aluminium.."""@en ;
+    skos:notation "2224" ;
+    skos:prefLabel "Metal Roof and Guttering Manufacturing (except Aluminium)"@en ;
+.
+
+icat:2229 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:222 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing architectural steel, wrought iron or other metal (except aluminium) products such as window frames, doors, stairs or staircases, railings, gates, balustrades or ornamental partitions.."""@en ;
+    skos:notation "2229" ;
+    skos:prefLabel "Other Structural Metal Product Manufacturing"@en ;
+.
+
+icat:223 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:22 ; 
+    skos:definition """This group includes units mainly engaged in Metal Container Manufacturing."""@en ;
+    skos:notation "223" ;
+    skos:prefLabel "Metal Container Manufacturing"@en ;
+.
+
+icat:2231 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:223 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing boilers, tanks and other metal containers from heavy gauge metals.."""@en ;
+    skos:notation "2231" ;
+    skos:prefLabel "Boiler, Tank and Other Heavy Gauge Metal Container Manufacturing"@en ;
+.
+
+icat:2239 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:223 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing metal containers not elsewhere classified.."""@en ;
+    skos:notation "2239" ;
+    skos:prefLabel "Other Metal Container Manufacturing"@en ;
+.
+
+icat:224 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:22 ; 
+    skos:definition """This group includes units mainly engaged in Sheet Metal Product Manufacturing (except Metal Structural and Container Products)."""@en ;
+    skos:notation "224" ;
+    skos:prefLabel "Sheet Metal Product Manufacturing (except Metal Structural and Container Products)"@en ;
+.
+
+icat:2240 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:224 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing other sheet metal products not elsewhere classified such as pressed or spun metal holloware, air ducts and bottle closures.."""@en ;
+    skos:notation "2240" ;
+    skos:prefLabel "Sheet Metal Product Manufacturing (except Metal Structural and Container"@en ;
+.
+
+icat:229 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:22 ; 
+    skos:definition """This group includes units mainly engaged in Other Fabricated Metal Product Manufacturing."""@en ;
+    skos:notation "229" ;
+    skos:prefLabel "Other Fabricated Metal Product Manufacturing"@en ;
+.
+
+icat:2291 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:229 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing wire or wire products, cable, wire netting, nails or rolled steel fence posts.."""@en ;
+    skos:notation "2291" ;
+    skos:prefLabel "Spring and Wire Product Manufacturing"@en ;
+.
+
+icat:2292 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:229 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing metal nuts, bolts, screws, rivets, fasteners, metal washers or other precision turned metal items.."""@en ;
+    skos:notation "2292" ;
+    skos:prefLabel "Nut, Bolt, Screw and Rivet Manufacturing"@en ;
+.
+
+icat:2293 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:229 ; 
+    skos:definition """This class consists of units mainly engaged in engraving, polishing, heat treating, plating, galvanising, anodising, colouring, plastic dipping, ceramic or other coating or finishing of client supplied metals or metal products. This class also includes units mainly engaged in metal coating of non-metal products not elsewhere classified.."""@en ;
+    skos:notation "2293" ;
+    skos:prefLabel "Metal Coating and Finishing"@en ;
+.
+
+icat:2299 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:229 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing hand tools (except of wood, pneumatic or power operated), general hardware and other fabricated metal products not elsewhere classified.."""@en ;
+    skos:notation "2299" ;
+    skos:prefLabel "Other Fabricated Metal Product Manufacturing n.e.c."@en ;
+.
+
+icat:23 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Transport Equipment Manufacturing."""@en ;
+    skos:notation "23" ;
+    skos:prefLabel "Transport Equipment Manufacturing"@en ;
+.
+
+icat:231 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:23 ; 
+    skos:definition """This group includes units mainly engaged in Motor Vehicle and Motor Vehicle Part Manufacturing."""@en ;
+    skos:notation "231" ;
+    skos:prefLabel "Motor Vehicle and Motor Vehicle Part Manufacturing"@en ;
+.
+
+icat:2311 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:231 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing motor vehicles or motor vehicle engines.."""@en ;
+    skos:notation "2311" ;
+    skos:prefLabel "Motor Vehicle Manufacturing"@en ;
+.
+
+icat:2312 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:231 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing motor vehicle bodies (including buses and trucks), caravans and trailers, and in vehicle modifications involving permanent changes to bodywork using an existing engine and chassis.."""@en ;
+    skos:notation "2312" ;
+    skos:prefLabel "Motor Vehicle Body and Trailer Manufacturing"@en ;
+.
+
+icat:2313 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:231 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing automotive electrical components, automotive air conditioners or instruments.."""@en ;
+    skos:notation "2313" ;
+    skos:prefLabel "Automotive Electrical Component Manufacturing"@en ;
+.
+
+icat:2319 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:231 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing motor vehicle parts not elsewhere classified. This class also includes factory engine reconditioning on a changeover basis.."""@en ;
+    skos:notation "2319" ;
+    skos:prefLabel "Other Motor Vehicle Parts Manufacturing"@en ;
+.
+
+icat:239 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:23 ; 
+    skos:definition """This group includes units mainly engaged in Other Transport Equipment Manufacturing."""@en ;
+    skos:notation "239" ;
+    skos:prefLabel "Other Transport Equipment Manufacturing"@en ;
+.
+
+icat:2391 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:239 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing or repairing vessels of 50 tonnes and over displacement, submarines or major components for ships and submarines not elsewhere classified.."""@en ;
+    skos:notation "2391" ;
+    skos:prefLabel "Shipbuilding and Repair Services"@en ;
+.
+
+icat:2392 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:239 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing or repairing vessels of under 50 tonnes displacement.."""@en ;
+    skos:notation "2392" ;
+    skos:prefLabel "Boatbuilding and Repair Services"@en ;
+.
+
+icat:2393 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:239 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing or repairing railway locomotives or other rolling stock.."""@en ;
+    skos:notation "2393" ;
+    skos:prefLabel "Railway Rolling Stock Manufacturing and Repair Services"@en ;
+.
+
+icat:2394 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:239 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing or repairing aircraft, aircraft engines and frames, as well as specialist aircraft repair services not elsewhere classified.."""@en ;
+    skos:notation "2394" ;
+    skos:prefLabel "Aircraft Manufacturing and Repair Services"@en ;
+.
+
+icat:2399 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:239 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing bicycles, motorcycles, hovercrafts and other transport equipment not elsewhere classified (including unusual terrain vehicles).."""@en ;
+    skos:notation "2399" ;
+    skos:prefLabel "Other Transport Equipment Manufacturing n.e.c."@en ;
+.
+
+icat:24 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Machinery and Equipment Manufacturing."""@en ;
+    skos:notation "24" ;
+    skos:prefLabel "Machinery and Equipment Manufacturing"@en ;
+.
+
+icat:241 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:24 ; 
+    skos:definition """This group includes units mainly engaged in Professional and Scientific Equipment Manufacturing."""@en ;
+    skos:notation "241" ;
+    skos:prefLabel "Professional and Scientific Equipment Manufacturing"@en ;
+.
+
+icat:2411 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:241 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing photographic equipment (except sensitised photographic film, paper, plates or chemicals), optical instruments or equipment, or ophthalmic equipment. Also included are units mainly engaged in grinding optical lenses.."""@en ;
+    skos:notation "2411" ;
+    skos:prefLabel "Photographic, Optical and Ophthalmic Equipment Manufacturing"@en ;
+.
+
+icat:2412 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:241 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing medical, surgical or dental equipment, including dentures.."""@en ;
+    skos:notation "2412" ;
+    skos:prefLabel "Medical and Surgical Equipment Manufacturing"@en ;
+.
+
+icat:2419 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:241 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing navigational, measuring or other professional and scientific equipment not elsewhere classified such as control or meteorological or surveying equipment or instruments, or specialised parts for such equipment.."""@en ;
+    skos:notation "2419" ;
+    skos:prefLabel "Other Professional and Scientific Equipment Manufacturing"@en ;
+.
+
+icat:242 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:24 ; 
+    skos:definition """This group includes units mainly engaged in Computer and Electronic Equipment Manufacturing."""@en ;
+    skos:notation "242" ;
+    skos:prefLabel "Computer and Electronic Equipment Manufacturing"@en ;
+.
+
+icat:2421 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:242 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing computers, computer peripheral equipment or other electronic office equipment.."""@en ;
+    skos:notation "2421" ;
+    skos:prefLabel "Computer and Electronic Office Equipment Manufacturing"@en ;
+.
+
+icat:2422 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:242 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing electronic and/or studio equipment for television or radio broadcasting; data transmission equipment, such as routers or modems; or telecommunication (including telephone) data communication, receiver or transceiver equipment.."""@en ;
+    skos:notation "2422" ;
+    skos:prefLabel "Communication Equipment Manufacturing"@en ;
+.
+
+icat:2429 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:242 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing audio or visual receiving sets, sound reproducing and/or recording equipment, radio receiving sets (except radio transceivers or radio telegraphic or telephone receivers), television receiving sets, headphones, electronic equipment or components not elsewhere classified.."""@en ;
+    skos:notation "2429" ;
+    skos:prefLabel "Other Electronic Equipment Manufacturing"@en ;
+.
+
+icat:243 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:24 ; 
+    skos:definition """This group includes units mainly engaged in Electrical Equipment Manufacturing."""@en ;
+    skos:notation "243" ;
+    skos:prefLabel "Electrical Equipment Manufacturing"@en ;
+.
+
+icat:2431 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:243 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing cables, wires or strips capable of conducting electricity, including braided or insulated non-ferrous cables, wires or strips. Units mainly engaged in manufacturing optical fibre cables for data transmission, including telecommunications cables are also included.."""@en ;
+    skos:notation "2431" ;
+    skos:prefLabel "Electric Cable and Wire Manufacturing"@en ;
+.
+
+icat:2432 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:243 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing light bulbs, tubes or fittings (except automotive) or electric signs.."""@en ;
+    skos:notation "2432" ;
+    skos:prefLabel "Electric Lighting Equipment Manufacturing"@en ;
+.
+
+icat:2439 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:243 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing batteries, electric motors, generators, electricity transmission or distribution equipment, switchgear, switchboards, transformers or other electrical machinery, equipment, supplies or components not elsewhere classified.."""@en ;
+    skos:notation "2439" ;
+    skos:prefLabel "Other Electrical Equipment Manufacturing"@en ;
+.
+
+icat:244 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:24 ; 
+    skos:definition """This group includes units mainly engaged in Domestic Appliance Manufacturing."""@en ;
+    skos:notation "244" ;
+    skos:prefLabel "Domestic Appliance Manufacturing"@en ;
+.
+
+icat:2441 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:244 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing domestic electric, electronic or gas whiteware appliances. Whiteware includes domestic cooking, refrigeration, freezing or washing appliances. Also included are units mainly engaged in manufacturing food waste disposal units or barbecues.."""@en ;
+    skos:notation "2441" ;
+    skos:prefLabel "Whiteware Appliance Manufacturing"@en ;
+.
+
+icat:2449 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:244 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing electric, electronic or gas domestic appliances not elsewhere classified.."""@en ;
+    skos:notation "2449" ;
+    skos:prefLabel "Other Domestic Appliance Manufacturing"@en ;
+.
+
+icat:245 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:24 ; 
+    skos:definition """This group includes units mainly engaged in Pump, Compressor, Heating and Ventilation Equipment Manufacturing."""@en ;
+    skos:notation "245" ;
+    skos:prefLabel "Pump, Compressor, Heating and Ventilation Equipment Manufacturing"@en ;
+.
+
+icat:2451 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:245 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing air or gas compressors, pumps or pumping machinery (except refrigeration or air conditioning compressors or parts).."""@en ;
+    skos:notation "2451" ;
+    skos:prefLabel "Pump and Compressor Manufacturing"@en ;
+.
+
+icat:2452 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:245 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing commercial or industrial fixed space heating, cooling and air conditioning equipment (except motor vehicle air conditioners) or specialised parts for such equipment. Also included are units mainly engaged in manufacturing commercial or industrial gas heating equipment, refrigerated display counter units or vending machines.."""@en ;
+    skos:notation "2452" ;
+    skos:prefLabel "Fixed Space Heating, Cooling and Ventilation Equipment Manufacturing"@en ;
+.
+
+icat:246 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:24 ; 
+    skos:definition """This group includes units mainly engaged in Specialised Machinery and Equipment Manufacturing."""@en ;
+    skos:notation "246" ;
+    skos:prefLabel "Specialised Machinery and Equipment Manufacturing"@en ;
+.
+
+icat:2461 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:246 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing agricultural machinery or equipment, tractors for agricultural purposes (except crawler tractors), lawn mowers or specialised parts for such equipment.."""@en ;
+    skos:notation "2461" ;
+    skos:prefLabel "Agricultural Machinery and Equipment Manufacturing"@en ;
+.
+
+icat:2462 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:246 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing construction, earthmoving or mining machinery and equipment, or specialised parts for such equipment. Also included are units mainly engaged in manufacturing crawler tractors and tractors for construction or earthmoving purposes.."""@en ;
+    skos:notation "2462" ;
+    skos:prefLabel "Mining and Construction Machinery Manufacturing"@en ;
+.
+
+icat:2463 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:246 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing woodworking or metalworking machinery or equipment, or specialised parts for such equipment. Also included are units mainly engaged in manufacturing pneumatic or power operated hand tools, dies or die sets.."""@en ;
+    skos:notation "2463" ;
+    skos:prefLabel "Machine Tool and Parts Manufacturing"@en ;
+.
+
+icat:2469 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:246 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing specialised machinery and equipment not elsewhere classified or parts for such equipment not elsewhere classified.."""@en ;
+    skos:notation "2469" ;
+    skos:prefLabel "Other Specialised Machinery and Equipment Manufacturing"@en ;
+.
+
+icat:249 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:24 ; 
+    skos:definition """This group includes units mainly engaged in Other Machinery and Equipment Manufacturing."""@en ;
+    skos:notation "249" ;
+    skos:prefLabel "Other Machinery and Equipment Manufacturing"@en ;
+.
+
+icat:2491 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:249 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing forklift trucks, cranes, winches, hoists or hoisting equipment, conveyors or conveying systems, materials handling equipment not elsewhere classified, or specialised parts for such equipment. This class also includes units mainly engaged in manufacturing elevators, escalators or lifts, or in manufacturing tractors not elsewhere classified.."""@en ;
+    skos:notation "2491" ;
+    skos:prefLabel "Lifting and Material Handling Equipment Manufacturing"@en ;
+.
+
+icat:2499 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:249 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing machinery and equipment or parts for such equipment not elsewhere classified.."""@en ;
+    skos:notation "2499" ;
+    skos:prefLabel "Other Machinery and Equipment Manufacturing n.e.c."@en ;
+.
+
+icat:25 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:C ; 
+    skos:definition """This subdivision includes units mainly engaged in Furniture and Other Manufacturing."""@en ;
+    skos:notation "25" ;
+    skos:prefLabel "Furniture and Other Manufacturing"@en ;
+.
+
+icat:251 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:25 ; 
+    skos:definition """This group includes units mainly engaged in Furniture Manufacturing."""@en ;
+    skos:notation "251" ;
+    skos:prefLabel "Furniture Manufacturing"@en ;
+.
+
+icat:2511 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:251 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing furniture of wood or predominantly of wood (except custom-made built-in furniture), complete upholstered seating with wooden or metal frames (including seats convertible into beds) or in upholstering wooden furniture. This class also includes units mainly engaged in manufacturing upholstered seats with frames of any material for transport equipment.."""@en ;
+    skos:notation "2511" ;
+    skos:prefLabel "Wooden Furniture and Upholstered Seat Manufacturing"@en ;
+.
+
+icat:2512 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:251 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing furniture, storage structures, shelving, or parts of furniture predominantly of metal, including sheet metal, tubular metal or other forms of metal.."""@en ;
+    skos:notation "2512" ;
+    skos:prefLabel "Metal Furniture Manufacturing"@en ;
+.
+
+icat:2513 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:251 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing mattresses, including rubber or latex.."""@en ;
+    skos:notation "2513" ;
+    skos:prefLabel "Mattress Manufacturing"@en ;
+.
+
+icat:2519 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:251 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing furniture or parts of furniture from materials not elsewhere classified such as cane, bamboo or rattan.."""@en ;
+    skos:notation "2519" ;
+    skos:prefLabel "Other Furniture Manufacturing"@en ;
+.
+
+icat:259 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:25 ; 
+    skos:definition """This group includes units mainly engaged in Other Manufacturing."""@en ;
+    skos:notation "259" ;
+    skos:prefLabel "Other Manufacturing"@en ;
+.
+
+icat:2591 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:259 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing jewellery or silverware using precious or semi-precious metal and stones, and the cutting of such stones. This class also includes units mainly engaged in manufacturing custom-made or costume jewellery, trophies, badges or medals, or minting coins.."""@en ;
+    skos:notation "2591" ;
+    skos:prefLabel "Jewellery and Silverware Manufacturing"@en ;
+.
+
+icat:2592 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:259 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing toys made from all materials except fur or leather and sporting or recreational products (except vehicles, clothing and footwear).."""@en ;
+    skos:notation "2592" ;
+    skos:prefLabel "Toy, Sporting and Recreational Product Manufacturing"@en ;
+.
+
+icat:2599 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:259 ; 
+    skos:definition """This class consists of units mainly engaged in manufacturing products not elsewhere classified, including musical instruments, umbrellas, brooms, brushes and writing and marking equipment.."""@en ;
+    skos:notation "2599" ;
+    skos:prefLabel "Other Manufacturing n.e.c."@en ;
+.
+
+icat:D a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Electricity, Gas, Water and Waste Services Division comprises units engaged in the provision of electricity; gas through mains systems; water; drainage; and sewage services. This division also includes units mainly engaged in the collection, treatment and disposal of waste materials; remediation of contaminated materials (including land); and materials recovery activities.
+
+Electricity supply activities include the generation, transmission and distribution of electricity and the on-selling of electricity via power distribution systems operated by others.
+
+Gas supply includes the distribution of gas, such as natural gas or liquefied petroleum gas, through mains systems.
+
+Water supply includes the storage, treatment and distribution of water; drainage services include the operation of drainage systems; and sewage services include the collection, treatment and disposal of waste through sewer systems and sewage treatment facilities.."""@en ;
+    skos:notation "D" ;
+    skos:prefLabel "Electricity, Gas, Water and Waste Services"@en ;
+.
+
+icat:26 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:D ; 
+    skos:definition """This subdivision includes units mainly engaged in Electricity Supply."""@en ;
+    skos:notation "26" ;
+    skos:prefLabel "Electricity Supply"@en ;
+.
+
+icat:261 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:26 ; 
+    skos:definition """This group includes units mainly engaged in Electricity Generation."""@en ;
+    skos:notation "261" ;
     skos:prefLabel "Electricity Generation"@en ;
 .
 
-icat:P8200
+icat:2611 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:261 ; 
+    skos:definition """This class consists of units mainly engaged in the generation of electricity using mineral or fossil fuels (e.g. coal or coal derived products, mineral gases, mineral oil or mineral oil derived products) in internal combustion or combustion-turbine conventional steam processes.."""@en ;
+    skos:notation "2611" ;
+    skos:prefLabel "Fossil Fuel Electricity Generation"@en ;
+.
+
+icat:2612 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:261 ; 
+    skos:definition """This class consists of units mainly engaged in the generation of electricity using hydro-electric generation processes. Units that use pumped hydro storage generation processes are included.."""@en ;
+    skos:notation "2612" ;
+    skos:prefLabel "Hydro-Electricity Generation"@en ;
+.
+
+icat:2619 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:261 ; 
+    skos:definition """This class consists of units mainly engaged in the generation of electricity using wind, solar, tidal, biomass not elsewhere classified and other methods of electricity generation not elsewhere classified.."""@en ;
+    skos:notation "2619" ;
+    skos:prefLabel "Other Electricity Generation"@en ;
+.
+
+icat:262 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:26 ; 
+    skos:definition """This group includes units mainly engaged in Electricity Transmission."""@en ;
+    skos:notation "262" ;
+    skos:prefLabel "Electricity Transmission"@en ;
+.
+
+icat:2620 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:262 ; 
+    skos:definition """This class consists of units mainly engaged in operating high voltage electricity transmission systems including lines and transformer stations. These units transmit or facilitate the transmission of electricity from the generating source to the low voltage electricity distribution system.."""@en ;
+    skos:notation "2620" ;
+    skos:prefLabel "Electricity Transmission"@en ;
+.
+
+icat:263 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:26 ; 
+    skos:definition """This group includes units mainly engaged in Electricity Distribution."""@en ;
+    skos:notation "263" ;
+    skos:prefLabel "Electricity Distribution"@en ;
+.
+
+icat:2630 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:263 ; 
+    skos:definition """This class consists of units mainly engaged in operating low voltage electricity distribution systems, including lines, poles, meters and wiring, that deliver electricity to final consumers.."""@en ;
+    skos:notation "2630" ;
+    skos:prefLabel "Electricity Distribution"@en ;
+.
+
+icat:264 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:26 ; 
+    skos:definition """This group includes units mainly engaged in On Selling Electricity and Electricity Market Operation."""@en ;
+    skos:notation "264" ;
+    skos:prefLabel "On Selling Electricity and Electricity Market Operation"@en ;
+.
+
+icat:2640 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:264 ; 
+    skos:definition """This class consists of units mainly engaged in on selling electricity via power distribution systems operated by others. It also includes units mainly engaged in providing services to the electricity market which facilitate the matching of supply and demand for electricity.."""@en ;
+    skos:notation "2640" ;
+    skos:prefLabel "On Selling Electricity and Electricity Market Operation"@en ;
+.
+
+icat:27 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:D ; 
+    skos:definition """This subdivision includes units mainly engaged in Gas Supply."""@en ;
+    skos:notation "27" ;
+    skos:prefLabel "Gas Supply"@en ;
+.
+
+icat:270 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:27 ; 
+    skos:definition """This group includes units mainly engaged in Gas Supply."""@en ;
+    skos:notation "270" ;
+    skos:prefLabel "Gas Supply"@en ;
+.
+
+icat:2700 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:270 ; 
+    skos:definition """This class consists of units primarily engaged in the distribution of gas such as natural gas or liquefied petroleum gas through mains systems.."""@en ;
+    skos:notation "2700" ;
+    skos:prefLabel "Gas Supply"@en ;
+.
+
+icat:28 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:D ; 
+    skos:definition """This subdivision includes units mainly engaged in Water Supply, Sewerage and Drainage Services."""@en ;
+    skos:notation "28" ;
+    skos:prefLabel "Water Supply, Sewerage and Drainage Services"@en ;
+.
+
+icat:281 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:28 ; 
+    skos:definition """This group includes units mainly engaged in Water Supply, Sewerage and Drainage Services."""@en ;
+    skos:notation "281" ;
+    skos:prefLabel "Water Supply, Sewerage and Drainage Services"@en ;
+.
+
+icat:2811 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:281 ; 
+    skos:definition """This class consists of units mainly engaged in the bulk storage or distribution of water. Also included are units mainly engaged in the treatment of water prior to or during distribution in the water supply system. The water supply system may include pumping stations, aqueducts and/or distribution mains.."""@en ;
+    skos:notation "2811" ;
+    skos:prefLabel "Water Supply"@en ;
+.
+
+icat:2812 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:281 ; 
+    skos:definition """This class consists of units mainly engaged in operating sewerage or drainage systems or sewage treatment plants.."""@en ;
+    skos:notation "2812" ;
+    skos:prefLabel "Sewerage and Drainage Services"@en ;
+.
+
+icat:29 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:D ; 
+    skos:definition """This subdivision includes units mainly engaged in Waste Collection, Treatment and Disposal Services."""@en ;
+    skos:notation "29" ;
+    skos:prefLabel "Waste Collection, Treatment and Disposal Services"@en ;
+.
+
+icat:291 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:29 ; 
+    skos:definition """This group includes units mainly engaged in Waste Collection Services."""@en ;
+    skos:notation "291" ;
+    skos:prefLabel "Waste Collection Services"@en ;
+.
+
+icat:2911 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:291 ; 
+    skos:definition """This class consists of units mainly engaged in the collection and haulage (except long distance) of domestic, commercial or industrial solid waste (except through sewerage systems). This class also includes units who provide portable toilets, bins and other receptacles for hire to clients as part of a waste collection service.."""@en ;
+    skos:notation "2911" ;
+    skos:prefLabel "Solid Waste Collection Services"@en ;
+.
+
+icat:2919 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:291 ; 
+    skos:definition """This class consists of units mainly engaged in the collection and haulage (except long distance) of domestic, commercial or industrial liquid waste and other waste types (except through sewerage systems).."""@en ;
+    skos:notation "2919" ;
+    skos:prefLabel "Other Waste Collection Services"@en ;
+.
+
+icat:292 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:29 ; 
+    skos:definition """This group includes units mainly engaged in Waste Treatment, Disposal and Remediation Services."""@en ;
+    skos:notation "292" ;
+    skos:prefLabel "Waste Treatment, Disposal and Remediation Services"@en ;
+.
+
+icat:2921 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:292 ; 
+    skos:definition """This class consists of units mainly engaged in the treatment or disposal of solid, liquid and other waste types (including hazardous). Also, included are units mainly engaged in operating landfills, combustors, incinerators, compost dumps and other treatment facilities (except sewage treatment facilities), including waste transfer stations.."""@en ;
+    skos:notation "2921" ;
+    skos:prefLabel "Waste Treatment and Disposal Services"@en ;
+.
+
+icat:2922 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:292 ; 
+    skos:definition """This class consists of units mainly engaged in the remediation and clean up of contaminated buildings and mine sites, mine reclamation activities, removal of hazardous material such as asbestos and lead paint and other toxic material abatement. This class also includes units mainly engaged in providing materials recovery and sorting services.."""@en ;
+    skos:notation "2922" ;
+    skos:prefLabel "Waste Remediation and Materials Recovery Services"@en ;
+.
+
+icat:E a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Construction Division includes units mainly engaged in the construction of buildings and other structures, additions, alterations, reconstruction, installation, and maintenance and repairs of buildings and other structures.
+
+Units engaged in demolition or wrecking of buildings and other structures, and clearing of building sites are included in Division E Construction. It also includes units engaged in blasting, test drilling, landfill, levelling, earthmoving, excavating, land drainage and other land preparation.."""@en ;
+    skos:notation "E" ;
+    skos:prefLabel "Construction"@en ;
+.
+
+icat:30 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:E ; 
+    skos:definition """This subdivision includes units mainly engaged in Building Construction."""@en ;
+    skos:notation "30" ;
+    skos:prefLabel "Building Construction"@en ;
+.
+
+icat:301 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:30 ; 
+    skos:definition """This group includes units mainly engaged in Residential Building Construction."""@en ;
+    skos:notation "301" ;
+    skos:prefLabel "Residential Building Construction"@en ;
+.
+
+icat:3011 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:301 ; 
+    skos:definition """This class consists of units mainly engaged in the construction of houses (except semi-detached houses) or in carrying out alterations, additions or renovations to houses, or in organising or managing these activities.."""@en ;
+    skos:notation "3011" ;
+    skos:prefLabel "House Construction"@en ;
+.
+
+icat:3019 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:301 ; 
+    skos:definition """This class consists of units mainly engaged in the construction of residential buildings (except freestanding houses) or in carrying out alterations, additions or renovations to such buildings or in organising or managing these activities.."""@en ;
+    skos:notation "3019" ;
+    skos:prefLabel "Other Residential Building Construction"@en ;
+.
+
+icat:302 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:30 ; 
+    skos:definition """This group includes units mainly engaged in Non-Residential Building Construction."""@en ;
+    skos:notation "302" ;
+    skos:prefLabel "Non-Residential Building Construction"@en ;
+.
+
+icat:3020 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:302 ; 
+    skos:definition """This class consists of units mainly engaged in the construction of non-residential buildings such as hotels, motels, hostels, hospitals, prisons or other buildings, in carrying out alterations, additions or renovation to such buildings, or in organising or managing these activities.."""@en ;
+    skos:notation "3020" ;
+    skos:prefLabel "Non-Residential Building Construction"@en ;
+.
+
+icat:31 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:E ; 
+    skos:definition """This subdivision includes units mainly engaged in Heavy and Civil Engineering Construction."""@en ;
+    skos:notation "31" ;
+    skos:prefLabel "Heavy and Civil Engineering Construction"@en ;
+.
+
+icat:310 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:31 ; 
+    skos:definition """This group includes units mainly engaged in Heavy and Civil Engineering Construction."""@en ;
+    skos:notation "310" ;
+    skos:prefLabel "Heavy and Civil Engineering Construction"@en ;
+.
+
+icat:3101 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:310 ; 
+    skos:definition """This class consists of units mainly engaged in the construction or general repair of roads, bridges, aerodrome runways or parking lots, or in organising or managing these activities.."""@en ;
+    skos:notation "3101" ;
+    skos:prefLabel "Road and Bridge Construction"@en ;
+.
+
+icat:3109 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:310 ; 
+    skos:definition """This class consists of units mainly engaged in the construction of railway permanent way, dams, irrigation systems, harbour or river works, water or gas supply systems, oil refineries (except buildings), pipelines or construction projects not elsewhere classified, in the on-site assembly of furnaces or heavy electrical machinery from prefabricated components, or in the general repair of such structures, machinery or equipment, or in organising or managing these activities.."""@en ;
+    skos:notation "3109" ;
+    skos:prefLabel "Other Heavy and Civil Engineering Construction"@en ;
+.
+
+icat:32 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:E ; 
+    skos:definition """This subdivision includes units mainly engaged in Construction Services."""@en ;
+    skos:notation "32" ;
+    skos:prefLabel "Construction Services"@en ;
+.
+
+icat:321 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:32 ; 
+    skos:definition """This group includes units mainly engaged in Land Development and Site Preparation Services."""@en ;
+    skos:notation "321" ;
+    skos:prefLabel "Land Development and Site Preparation Services"@en ;
+.
+
+icat:3211 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:321 ; 
+    skos:definition """This class consists of units primarily engaged in subdividing land into lots and servicing land (such as excavation work for the installation of roads and utility lines), for subsequent sale.."""@en ;
+    skos:notation "3211" ;
+    skos:prefLabel "Land Development and Subdivision"@en ;
+.
+
+icat:3212 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:321 ; 
+    skos:definition """This class consists of units mainly engaged in earthmoving work such as levelling of construction sites, excavation of foundations, trench digging or removal of overburden.."""@en ;
+    skos:notation "3212" ;
+    skos:prefLabel "Site Preparation Services"@en ;
+.
+
+icat:322 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:32 ; 
+    skos:definition """This group includes units mainly engaged in Building Structure Services."""@en ;
+    skos:notation "322" ;
+    skos:prefLabel "Building Structure Services"@en ;
+.
+
+icat:3221 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:322 ; 
+    skos:definition """This class consists of units mainly engaged in concreting work, concrete pouring or other concrete work on construction projects.."""@en ;
+    skos:notation "3221" ;
+    skos:prefLabel "Concreting Services"@en ;
+.
+
+icat:3222 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:322 ; 
+    skos:definition """This class consists of units mainly engaged in bricklaying or concrete block laying.."""@en ;
+    skos:notation "3222" ;
+    skos:prefLabel "Bricklaying Services"@en ;
+.
+
+icat:3223 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:322 ; 
+    skos:definition """This class consists of units mainly engaged in roof tiling, metal roof fixing and the application of roof coatings.."""@en ;
+    skos:notation "3223" ;
+    skos:prefLabel "Roofing Services"@en ;
+.
+
+icat:3224 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:322 ; 
+    skos:definition """This class consists of units mainly engaged in the erection (including on-site fabrication) of metal silos, storage tanks or structural steel components for buildings or other structures such as bridges, overhead cranes or electricity transmission towers.."""@en ;
+    skos:notation "3224" ;
+    skos:prefLabel "Structural Steel Erection Services"@en ;
+.
+
+icat:323 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:32 ; 
+    skos:definition """This group includes units mainly engaged in Building Installation Services."""@en ;
+    skos:notation "323" ;
+    skos:prefLabel "Building Installation Services"@en ;
+.
+
+icat:3231 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:323 ; 
+    skos:definition """This class consists of units mainly engaged in plumbing or drainage (except sewerage or stormwater drainage systems construction). Also included are units mainly engaged in septic tank and other plumbing installation and repair.."""@en ;
+    skos:notation "3231" ;
+    skos:prefLabel "Plumbing Services"@en ;
+.
+
+icat:3232 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:323 ; 
+    skos:definition """This class consists of units mainly engaged in the installation of electrical wiring or fittings in buildings or other construction projects. Electrical work arising from the installation of appliances is included in this class.."""@en ;
+    skos:notation "3232" ;
+    skos:prefLabel "Electrical Services"@en ;
+.
+
+icat:3233 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:323 ; 
+    skos:definition """This class consists of units mainly engaged in the installation of heating equipment, refrigeration equipment, air conditioning equipment, or in the installation of air conditioning duct work.."""@en ;
+    skos:notation "3233" ;
+    skos:prefLabel "Air Conditioning and Heating Services"@en ;
+.
+
+icat:3234 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:323 ; 
+    skos:definition """This class consists of units mainly engaged in the installation of fire protection, detection and control systems, and in installing security systems.."""@en ;
+    skos:notation "3234" ;
+    skos:prefLabel "Fire and Security Alarm Installation Services"@en ;
+.
+
+icat:3239 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:323 ; 
+    skos:definition """This class consists of units mainly engaged in building installation services not elsewhere classified.."""@en ;
+    skos:notation "3239" ;
+    skos:prefLabel "Other Building Installation Services"@en ;
+.
+
+icat:324 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:32 ; 
+    skos:definition """This group includes units mainly engaged in Building Completion Services."""@en ;
+    skos:notation "324" ;
+    skos:prefLabel "Building Completion Services"@en ;
+.
+
+icat:3241 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:324 ; 
+    skos:definition """This class consists of units mainly engaged in plastering, plaster fixing or finishing.."""@en ;
+    skos:notation "3241" ;
+    skos:prefLabel "Plastering and Ceiling Services"@en ;
+.
+
+icat:3242 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:324 ; 
+    skos:definition """This class consists of units mainly engaged in carpentry work or the fixing of wooden formwork on construction projects.."""@en ;
+    skos:notation "3242" ;
+    skos:prefLabel "Carpentry Services"@en ;
+.
+
+icat:3243 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:324 ; 
+    skos:definition """This class consists of units mainly engaged in laying carpet, or setting wall or floor tiles.."""@en ;
+    skos:notation "3243" ;
+    skos:prefLabel "Tiling and Carpeting Services"@en ;
+.
+
+icat:3244 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:324 ; 
+    skos:definition """This class consists of units mainly engaged in painting, decorating or wallpapering houses or other structures.."""@en ;
+    skos:notation "3244" ;
+    skos:prefLabel "Painting and Decorating Services"@en ;
+.
+
+icat:3245 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:324 ; 
+    skos:definition """This class consists of units mainly engaged in glazing, including glass installation and repair work.."""@en ;
+    skos:notation "3245" ;
+    skos:prefLabel "Glazing Services"@en ;
+.
+
+icat:329 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:32 ; 
+    skos:definition """This group includes units mainly engaged in Other Construction Services."""@en ;
+    skos:notation "329" ;
+    skos:prefLabel "Other Construction Services"@en ;
+.
+
+icat:3291 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:329 ; 
+    skos:definition """This class consists of units mainly engaged in constructing landscapes, including landforming and the provision of retaining walls and paths, decks, fences, ponds and similar structures. Units also engaged in garden planting or installation of sprinkler/drainage systems in conjunction with constructing landscapes are included.."""@en ;
+    skos:notation "3291" ;
+    skos:prefLabel "Landscape Construction Services"@en ;
+.
+
+icat:3292 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:329 ; 
+    skos:definition """This class consists of units mainly engaged in hiring construction machinery, plant or equipment with operator(s).."""@en ;
+    skos:notation "3292" ;
+    skos:prefLabel "Hire of Construction Machinery with Operator"@en ;
+.
+
+icat:3299 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:329 ; 
+    skos:definition """This class consists of units mainly engaged in construction services not elsewhere classified.."""@en ;
+    skos:notation "3299" ;
+    skos:prefLabel "Other Construction Services n.e.c."@en ;
+.
+
+icat:F a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Wholesale Trade Division includes units mainly engaged in the purchase and onselling, the commission-based buying, and the commission-based selling of goods, without significant transformation, to businesses. Units are classified to the Wholesale Trade Division in the first instance if they buy goods and then onsell them (including on a commission basis) to businesses.
+
+Wholesalers' premises are usually a warehouse or office with little or no display of their goods, large storage facilities, and are not generally located or designed to attract a high proportion of walk-in customers. Wholesaling is often characterised by high value and/or bulk volume transactions, and customers are generally reached through trade-specific contacts.
+
+The Wholesale Trade Division distinguishes two types of wholesalers:
+
+    - merchant wholesalers who take title to the goods they sell, including import/export merchants; and
+    - units whose main activity is the commission-based buying and/or the commission-based selling of goods, acting as wholesale agents or brokers, or business to business electronic markets, both of whom arrange the sale of goods on behalf of others for a commission or fee without taking title to the goods.
+
+A unit which sells to both businesses and the general public will be classified to the Wholesale Trade Division if it operates from premises such as warehouses or offices with little or no display of goods, has large storage facilities, and is not generally located or designed to attract a high proportion of walk-in customers.
+
+For units that have goods manufactured for them on commission and then sell those goods, the following treatment guidelines are to be followed:
+
+    - units that own the material inputs and own the final outputs, but have the production done by others will be included in the Manufacturing Division;
+    - units that do not own the material inputs but own the final outputs and have the production done by others will not be included in the Manufacturing Division (these may be included in Wholesale Trade or other divisions); and
+    - units that do not own the material inputs, do not own the final outputs but undertake the production for others will be included in the Manufacturing Division.
+
+As a result, units that have goods manufactured for them on commission will be included in the Wholesale Trade Division where they do not own the material inputs to the manufacturing process, but take title to the outputs and sell them in the manner prescribed above for typical wholesaling units.."""@en ;
+    skos:notation "F" ;
+    skos:prefLabel "Wholesale Trade"@en ;
+.
+
+icat:33 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:F ; 
+    skos:definition """This subdivision includes units mainly engaged in Basic Material Wholesaling."""@en ;
+    skos:notation "33" ;
+    skos:prefLabel "Basic Material Wholesaling"@en ;
+.
+
+icat:331 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:33 ; 
+    skos:definition """This group includes units mainly engaged in Agricultural Product Wholesaling."""@en ;
+    skos:notation "331" ;
+    skos:prefLabel "Agricultural Product Wholesaling"@en ;
+.
+
+icat:3311 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:331 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling wool.."""@en ;
+    skos:notation "3311" ;
+    skos:prefLabel "Wool Wholesaling"@en ;
+.
+
+icat:3312 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:331 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling wheat or other cereal grains.."""@en ;
+    skos:notation "3312" ;
+    skos:prefLabel "Cereal Grain Wholesaling"@en ;
+.
+
+icat:3319 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:331 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling skins, hides or tallow, stock feed and other agricultural products not elsewhere classified.."""@en ;
+    skos:notation "3319" ;
+    skos:prefLabel "Other Agricultural Product Wholesaling"@en ;
+.
+
+icat:332 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:33 ; 
+    skos:definition """This group includes units mainly engaged in Mineral, Metal and Chemical Wholesaling."""@en ;
+    skos:notation "332" ;
+    skos:prefLabel "Mineral, Metal and Chemical Wholesaling"@en ;
+.
+
+icat:3321 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:332 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling petroleum or petroleum products, liquefied petroleum gas, heating oil or other fuel oils.."""@en ;
+    skos:notation "3321" ;
+    skos:prefLabel "Petroleum Product Wholesaling"@en ;
+.
+
+icat:3322 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:332 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling pig iron, ingot steel or semi-fabricated products of iron or steel such as sheet, strip, bars, rods, sections, structural steel or tubes; wholesaling minerals (including coal or coke) not elsewhere classified; or wholesaling metal waste or scrap.."""@en ;
+    skos:notation "3322" ;
+    skos:prefLabel "Metal and Mineral Wholesaling"@en ;
+.
+
+icat:3323 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:332 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling industrial or agricultural chemicals or chemical products, including waste or scrap.."""@en ;
+    skos:notation "3323" ;
+    skos:prefLabel "Industrial and Agricultural Chemical Product Wholesaling"@en ;
+.
+
+icat:333 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:33 ; 
+    skos:definition """This group includes units mainly engaged in Timber and Hardware Goods Wholesaling."""@en ;
+    skos:notation "333" ;
+    skos:prefLabel "Timber and Hardware Goods Wholesaling"@en ;
+.
+
+icat:3331 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:333 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling timber (except firewood).."""@en ;
+    skos:notation "3331" ;
+    skos:prefLabel "Timber Wholesaling"@en ;
+.
+
+icat:3332 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:333 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling plumbing goods.."""@en ;
+    skos:notation "3332" ;
+    skos:prefLabel "Plumbing Goods Wholesaling"@en ;
+.
+
+icat:3339 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:333 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling other hardware goods (except timber or plumbing goods), including construction or building materials.."""@en ;
+    skos:notation "3339" ;
+    skos:prefLabel "Other Hardware Goods Wholesaling"@en ;
+.
+
+icat:34 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:F ; 
+    skos:definition """This subdivision includes units mainly engaged in Machinery and Equipment Wholesaling."""@en ;
+    skos:notation "34" ;
+    skos:prefLabel "Machinery and Equipment Wholesaling"@en ;
+.
+
+icat:341 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:34 ; 
+    skos:definition """This group includes units mainly engaged in Specialised Industrial Machinery and Equipment Wholesaling."""@en ;
+    skos:notation "341" ;
+    skos:prefLabel "Specialised Industrial Machinery and Equipment Wholesaling"@en ;
+.
+
+icat:3411 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:341 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling agricultural machinery, agricultural implements, earth-moving or other construction machinery or equipment or parts for such equipment.."""@en ;
+    skos:notation "3411" ;
+    skos:prefLabel "Agricultural and Construction Machinery Wholesaling"@en ;
+.
+
+icat:3419 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:341 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling specialised industrial machinery, parts or equipment not elsewhere classified.."""@en ;
+    skos:notation "3419" ;
+    skos:prefLabel "Other Specialised Industrial Machinery and Equipment Wholesaling"@en ;
+.
+
+icat:349 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:34 ; 
+    skos:definition """This group includes units mainly engaged in Other Machinery and Equipment Wholesaling."""@en ;
+    skos:notation "349" ;
+    skos:prefLabel "Other Machinery and Equipment Wholesaling"@en ;
+.
+
+icat:3491 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:349 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling scientific, medical or other professional equipment (except photographic equipment).."""@en ;
+    skos:notation "3491" ;
+    skos:prefLabel "Professional and Scientific Goods Wholesaling"@en ;
+.
+
+icat:3492 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:349 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling computers or computer peripheral equipment.."""@en ;
+    skos:notation "3492" ;
+    skos:prefLabel "Computer and Computer Peripheral Wholesaling"@en ;
+.
+
+icat:3493 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:349 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling telecommunication goods.."""@en ;
+    skos:notation "3493" ;
+    skos:prefLabel "Telecommunication Goods Wholesaling"@en ;
+.
+
+icat:3494 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:349 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling electrical or electronic goods not elsewhere classified.."""@en ;
+    skos:notation "3494" ;
+    skos:prefLabel "Other Electrical and Electronic Goods Wholesaling"@en ;
+.
+
+icat:3499 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:349 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling machinery and equipment not elsewhere classified.."""@en ;
+    skos:notation "3499" ;
+    skos:prefLabel "Other Machinery and Equipment Wholesaling n.e.c."@en ;
+.
+
+icat:35 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:F ; 
+    skos:definition """This subdivision includes units mainly engaged in Motor Vehicle and Motor Vehicle Parts Wholesaling."""@en ;
+    skos:notation "35" ;
+    skos:prefLabel "Motor Vehicle and Motor Vehicle Parts Wholesaling"@en ;
+.
+
+icat:350 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:35 ; 
+    skos:definition """This group includes units mainly engaged in Motor Vehicle and Motor Vehicle Parts Wholesaling."""@en ;
+    skos:notation "350" ;
+    skos:prefLabel "Motor Vehicle and Motor Vehicle Parts Wholesaling"@en ;
+.
+
+icat:3501 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:350 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling new and used motor cars.."""@en ;
+    skos:notation "3501" ;
+    skos:prefLabel "Car Wholesaling"@en ;
+.
+
+icat:3502 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:350 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling new or used commercial motor vehicles.."""@en ;
+    skos:notation "3502" ;
+    skos:prefLabel "Commercial Vehicle Wholesaling"@en ;
+.
+
+icat:3503 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:350 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling other types of new or used motor vehicles, including motorcycles, and trailers.."""@en ;
+    skos:notation "3503" ;
+    skos:prefLabel "Trailer and Other Motor Vehicle Wholesaling"@en ;
+.
+
+icat:3504 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:350 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling new parts or accessories for motor vehicles and motorcycles.."""@en ;
+    skos:notation "3504" ;
+    skos:prefLabel "Motor Vehicle New Parts Wholesaling"@en ;
+.
+
+icat:3505 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:350 ; 
+    skos:definition """This class consists of units mainly engaged in dismantling motor vehicles or motorcycles, or wholesaling used parts for motor vehicles and motorcycles.."""@en ;
+    skos:notation "3505" ;
+    skos:prefLabel "Motor Vehicle Dismantling and Used Parts Wholesaling"@en ;
+.
+
+icat:36 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:F ; 
+    skos:definition """This subdivision includes units mainly engaged in Grocery, Liquor and Tobacco Product Wholesaling."""@en ;
+    skos:notation "36" ;
+    skos:prefLabel "Grocery, Liquor and Tobacco Product Wholesaling"@en ;
+.
+
+icat:360 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:36 ; 
+    skos:definition """This group includes units mainly engaged in Grocery, Liquor and Tobacco Product Wholesaling."""@en ;
+    skos:notation "360" ;
+    skos:prefLabel "Grocery, Liquor and Tobacco Product Wholesaling"@en ;
+.
+
+icat:3601 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:360 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling a wide range or general line of groceries encompassing a number of grocery types throughout this subdivision.."""@en ;
+    skos:notation "3601" ;
+    skos:prefLabel "General Line Grocery Wholesaling"@en ;
+.
+
+icat:3602 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:360 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling fresh or frozen meat, bacon, ham, smallgoods, poultry or rabbit meat.."""@en ;
+    skos:notation "3602" ;
+    skos:prefLabel "Meat, Poultry and Smallgoods Wholesaling"@en ;
+.
+
+icat:3603 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:360 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling dairy produce, ice cream and other frozen desserts.."""@en ;
+    skos:notation "3603" ;
+    skos:prefLabel "Dairy Produce Wholesaling"@en ;
+.
+
+icat:3604 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:360 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling fresh or frozen fish or other seafood (except canned).."""@en ;
+    skos:notation "3604" ;
+    skos:prefLabel "Fish and Seafood Wholesaling"@en ;
+.
+
+icat:3605 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:360 ; 
+    skos:definition """This class consists of units (including wholesaling units of marketing authorities) mainly engaged in wholesaling fresh fruit or vegetables.."""@en ;
+    skos:notation "3605" ;
+    skos:prefLabel "Fruit and Vegetable Wholesaling"@en ;
+.
+
+icat:3606 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:360 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling beer, wine or spirits; or in wholesaling cigarettes, cigars or other tobacco products (except leaf tobacco).."""@en ;
+    skos:notation "3606" ;
+    skos:prefLabel "Liquor and Tobacco Product Wholesaling"@en ;
+.
+
+icat:3609 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:360 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling specific grocery or food items not elsewhere classified. This class also includes units that repack groceries such as flour, cereal foods or dried fruits and wholesale them.."""@en ;
+    skos:notation "3609" ;
+    skos:prefLabel "Other Grocery Wholesaling"@en ;
+.
+
+icat:37 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:F ; 
+    skos:definition """This subdivision includes units mainly engaged in Other Goods Wholesaling."""@en ;
+    skos:notation "37" ;
+    skos:prefLabel "Other Goods Wholesaling"@en ;
+.
+
+icat:371 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:37 ; 
+    skos:definition """This group includes units mainly engaged in Textile, Clothing and Footwear Wholesaling."""@en ;
+    skos:notation "371" ;
+    skos:prefLabel "Textile, Clothing and Footwear Wholesaling"@en ;
+.
+
+icat:3711 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:371 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling textiles or textile products not elsewhere classified.."""@en ;
+    skos:notation "3711" ;
+    skos:prefLabel "Textile Product Wholesaling"@en ;
+.
+
+icat:3712 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:371 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling clothing or footwear.."""@en ;
+    skos:notation "3712" ;
+    skos:prefLabel "Clothing and Footwear Wholesaling"@en ;
+.
+
+icat:372 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:37 ; 
+    skos:definition """This group includes units mainly engaged in Pharmaceutical and Toiletry Goods Wholesaling."""@en ;
+    skos:notation "372" ;
+    skos:prefLabel "Pharmaceutical and Toiletry Goods Wholesaling"@en ;
+.
+
+icat:3720 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:372 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling human pharmaceuticals, medicines, cosmetics, perfumes and toiletries. Also included are units mainly engaged in wholesaling veterinary drugs or medicines.."""@en ;
+    skos:notation "3720" ;
+    skos:prefLabel "Pharmaceutical and Toiletry Goods Wholesaling"@en ;
+.
+
+icat:373 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:37 ; 
+    skos:definition """This group includes units mainly engaged in Furniture, Floor Covering and Other Goods Wholesaling."""@en ;
+    skos:notation "373" ;
+    skos:prefLabel "Furniture, Floor Covering and Other Goods Wholesaling"@en ;
+.
+
+icat:3731 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:373 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling furniture or floor coverings (except ceramic floor tiles).."""@en ;
+    skos:notation "3731" ;
+    skos:prefLabel "Furniture and Floor Covering Wholesaling"@en ;
+.
+
+icat:3732 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:373 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling watches or clocks (including parts), jewellery, precious stones or precious metals.."""@en ;
+    skos:notation "3732" ;
+    skos:prefLabel "Jewellery and Watch Wholesaling"@en ;
+.
+
+icat:3733 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:373 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling china, glassware, crockery and other kitchen and dining ware.."""@en ;
+    skos:notation "3733" ;
+    skos:prefLabel "Kitchen and Diningware Wholesaling"@en ;
+.
+
+icat:3734 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:373 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling toys, bicycles or bicycle parts, firearms, ammunition, fireworks or sporting equipment (except tents, sports clothing or footwear).."""@en ;
+    skos:notation "3734" ;
+    skos:prefLabel "Toy and Sporting Goods Wholesaling"@en ;
+.
+
+icat:3735 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:373 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling books, periodicals and magazines.."""@en ;
+    skos:notation "3735" ;
+    skos:prefLabel "Book and Magazine Wholesaling"@en ;
+.
+
+icat:3736 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:373 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling paper stationery, greeting cards and paper or paper products not elsewhere classified.."""@en ;
+    skos:notation "3736" ;
+    skos:prefLabel "Paper Product Wholesaling"@en ;
+.
+
+icat:3739 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:373 ; 
+    skos:definition """This class consists of units mainly engaged in wholesaling travel goods, containers (except of paper or paper board), musical instruments, second-hand goods, or other goods not elsewhere classified.."""@en ;
+    skos:notation "3739" ;
+    skos:prefLabel "Other Goods Wholesaling n.e.c."@en ;
+.
+
+icat:38 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:F ; 
+    skos:definition """This subdivision includes units mainly engaged in Commission-Based Wholesaling."""@en ;
+    skos:notation "38" ;
+    skos:prefLabel "Commission-Based Wholesaling"@en ;
+.
+
+icat:380 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:38 ; 
+    skos:definition """This group includes units mainly engaged in Commission-Based Wholesaling."""@en ;
+    skos:notation "380" ;
+    skos:prefLabel "Commission-Based Wholesaling"@en ;
+.
+
+icat:3800 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:380 ; 
+    skos:definition """This class consists of units mainly engaged in the purchase and/or sale of goods or through the provision of sales services to businesses on behalf of one or more principals on a fee or commission basis. These activities include units who arrange the sale of goods on behalf of a principal, but do not take title to the goods.."""@en ;
+    skos:notation "3800" ;
+    skos:prefLabel "Commission-Based Wholesaling"@en ;
+.
+
+icat:G a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Retail Trade Division includes units mainly engaged in the purchase and/or onselling, the commission-based buying, and the commission-based selling of goods, without significant transformation, to the general public. The Retail Trade Division also includes units that purchase and onsell goods to the general public using non-traditional means, including the internet. Units are classified to the Retail Trade Division in the first instance if they buy finished goods and then onsell them (including on a commission basis) to the general public.
+
+Retail units generally operate from premises located and designed to attract a high volume of walk-in customers, have an extensive display of goods, and/or use mass media advertising designed to attract customers. The display and advertising of goods may be physical or electronic.
+
+Physical display and advertising includes shops, printed catalogues, billboards and print advertisements. Electronic display and advertising includes catalogues, internet websites, television and radio advertisements and infomercials. While non-store retailers, by definition, do not posses the physical characteristics of traditional retail units with a physical shop-front location, these units share the requisite function of the purchasing and onselling of goods to the general public, and are therefore included in this division.
+
+A unit which sells to both businesses and the general public will be classified to the Retail Trade Division if it operates from shop-front premises, arranges and displays stock to attract a high proportion of walk-in customers and utilises mass media advertising to attract customers.."""@en ;
+    skos:notation "G" ;
+    skos:prefLabel "Retail Trade"@en ;
+.
+
+icat:39 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:G ; 
+    skos:definition """This subdivision includes units mainly engaged in Motor Vehicle and Motor Vehicle Parts Retailing."""@en ;
+    skos:notation "39" ;
+    skos:prefLabel "Motor Vehicle and Motor Vehicle Parts Retailing"@en ;
+.
+
+icat:391 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:39 ; 
+    skos:definition """This group includes units mainly engaged in Motor Vehicle Retailing."""@en ;
+    skos:notation "391" ;
+    skos:prefLabel "Motor Vehicle Retailing"@en ;
+.
+
+icat:3911 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:391 ; 
+    skos:definition """This class consists of units mainly engaged in retailing new or used cars.."""@en ;
+    skos:notation "3911" ;
+    skos:prefLabel "Car Retailing"@en ;
+.
+
+icat:3912 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:391 ; 
+    skos:definition """This class consists of units mainly engaged in retailing new or used motorcycles or scooters.."""@en ;
+    skos:notation "3912" ;
+    skos:prefLabel "Motor Cycle Retailing"@en ;
+.
+
+icat:3913 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:391 ; 
+    skos:definition """This class consists of units mainly engaged in retailing caravans, trailers and other motor vehicles, including mobile homes or cabins.."""@en ;
+    skos:notation "3913" ;
+    skos:prefLabel "Trailer and Other Motor Vehicle Retailing"@en ;
+.
+
+icat:392 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:39 ; 
+    skos:definition """This group includes units mainly engaged in Motor Vehicle Parts and Tyre Retailing."""@en ;
+    skos:notation "392" ;
+    skos:prefLabel "Motor Vehicle Parts and Tyre Retailing"@en ;
+.
+
+icat:3921 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:392 ; 
+    skos:definition """This class consists of units mainly engaged in retailing new or used parts or accessories for motor vehicles.."""@en ;
+    skos:notation "3921" ;
+    skos:prefLabel "Motor Vehicle Parts Retailing"@en ;
+.
+
+icat:3922 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:392 ; 
+    skos:definition """This class consists of units mainly engaged in retailing motor vehicle or motorcycle tyres (new or reconditioned) or tubes.."""@en ;
+    skos:notation "3922" ;
+    skos:prefLabel "Tyre Retailing"@en ;
+.
+
+icat:40 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:G ; 
+    skos:definition """This subdivision includes units mainly engaged in Fuel Retailing."""@en ;
+    skos:notation "40" ;
+    skos:prefLabel "Fuel Retailing"@en ;
+.
+
+icat:400 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:40 ; 
+    skos:definition """This group includes units mainly engaged in Fuel Retailing."""@en ;
+    skos:notation "400" ;
+    skos:prefLabel "Fuel Retailing"@en ;
+.
+
+icat:4000 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:400 ; 
+    skos:definition """This class consists of units mainly engaged in retailing fuels, including petrol, LPG or lubricating oils.."""@en ;
+    skos:notation "4000" ;
+    skos:prefLabel "Fuel Retailing"@en ;
+.
+
+icat:41 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:G ; 
+    skos:definition """This subdivision includes units mainly engaged in Food Retailing."""@en ;
+    skos:notation "41" ;
+    skos:prefLabel "Food Retailing"@en ;
+.
+
+icat:411 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:41 ; 
+    skos:definition """This group includes units mainly engaged in Supermarket and Grocery Stores."""@en ;
+    skos:notation "411" ;
+    skos:prefLabel "Supermarket and Grocery Stores"@en ;
+.
+
+icat:4110 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:411 ; 
+    skos:definition """This class consists of units mainly engaged in retailing groceries or non-specialised food lines (including convenience stores), whether or not the selling is organised on a self-service basis.."""@en ;
+    skos:notation "4110" ;
+    skos:prefLabel "Supermarket and Grocery Stores"@en ;
+.
+
+icat:412 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:41 ; 
+    skos:definition """This group includes units mainly engaged in Specialised Food Retailing."""@en ;
+    skos:notation "412" ;
+    skos:prefLabel "Specialised Food Retailing"@en ;
+.
+
+icat:4121 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:412 ; 
+    skos:definition """This class consists of units mainly engaged in retailing fresh meat, fish or poultry.."""@en ;
+    skos:notation "4121" ;
+    skos:prefLabel "Fresh Meat, Fish and Poultry Retailing"@en ;
+.
+
+icat:4122 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:412 ; 
+    skos:definition """This class consists of units mainly engaged in retailing fresh fruit or vegetables.."""@en ;
+    skos:notation "4122" ;
+    skos:prefLabel "Fruit and Vegetable Retailing"@en ;
+.
+
+icat:4123 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:412 ; 
+    skos:definition """This class consists of units mainly engaged in retailing beer, wine or spirits for consumption off the premises only.."""@en ;
+    skos:notation "4123" ;
+    skos:prefLabel "Liquor Retailing"@en ;
+.
+
+icat:4129 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:412 ; 
+    skos:definition """This class consists of units mainly engaged in retailing specialised food lines, such as confectionery or smallgoods or bread and cakes (not manufactured on the same premises).."""@en ;
+    skos:notation "4129" ;
+    skos:prefLabel "Other Specialised Food Retailing"@en ;
+.
+
+icat:42 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:G ; 
+    skos:definition """This subdivision includes units mainly engaged in Other Store-Based Retailing."""@en ;
+    skos:notation "42" ;
+    skos:prefLabel "Other Store-Based Retailing"@en ;
+.
+
+icat:421 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:42 ; 
+    skos:definition """This group includes units mainly engaged in Furniture, Floor Coverings, Houseware and Textile Goods Retailing."""@en ;
+    skos:notation "421" ;
+    skos:prefLabel "Furniture, Floor Coverings, Houseware and Textile Goods Retailing"@en ;
+.
+
+icat:4211 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:421 ; 
+    skos:definition """This class consists of units mainly engaged in retailing furniture, blinds or awnings.."""@en ;
+    skos:notation "4211" ;
+    skos:prefLabel "Furniture Retailing"@en ;
+.
+
+icat:4212 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:421 ; 
+    skos:definition """This class consists of units mainly engaged in retailing floor coverings (except ceramic floor tiles).."""@en ;
+    skos:notation "4212" ;
+    skos:prefLabel "Floor Coverings Retailing"@en ;
+.
+
+icat:4213 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:421 ; 
+    skos:definition """This class consists of units mainly engaged in retailing kitchenware, china, glassware, silverware or other houseware goods.."""@en ;
+    skos:notation "4213" ;
+    skos:prefLabel "Houseware Retailing"@en ;
+.
+
+icat:4214 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:421 ; 
+    skos:definition """This class consists of units mainly engaged in retailing fabrics, curtains or household textiles.."""@en ;
+    skos:notation "4214" ;
+    skos:prefLabel "Manchester and Other Textile Goods Retailing"@en ;
+.
+
+icat:422 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:42 ; 
+    skos:definition """This group includes units mainly engaged in Electrical and Electronic Goods Retailing."""@en ;
+    skos:notation "422" ;
+    skos:prefLabel "Electrical and Electronic Goods Retailing"@en ;
+.
+
+icat:4221 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:422 ; 
+    skos:definition """This class consists of units mainly engaged in retailing electrical, electronic or gas appliances (except computers and computer peripherals).."""@en ;
+    skos:notation "4221" ;
+    skos:prefLabel "Electrical, Electronic and Gas Appliance Retailing"@en ;
+.
+
+icat:4222 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:422 ; 
+    skos:definition """This class consists of units mainly engaged in retailing computers or computer peripheral equipment.."""@en ;
+    skos:notation "4222" ;
+    skos:prefLabel "Computer and Computer Peripheral Retailing"@en ;
+.
+
+icat:4229 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:422 ; 
+    skos:definition """This class consists of units mainly engaged in retailing electrical and electronic goods not elsewhere classified.."""@en ;
+    skos:notation "4229" ;
+    skos:prefLabel "Other Electrical and Electronic Goods Retailing"@en ;
+.
+
+icat:423 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:42 ; 
+    skos:definition """This group includes units mainly engaged in Hardware, Building and Garden Supplies Retailing."""@en ;
+    skos:notation "423" ;
+    skos:prefLabel "Hardware, Building and Garden Supplies Retailing"@en ;
+.
+
+icat:4231 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:423 ; 
+    skos:definition """This class consists of units mainly engaged in retailing hardware or building supplies.."""@en ;
+    skos:notation "4231" ;
+    skos:prefLabel "Hardware and Building Supplies Retailing"@en ;
+.
+
+icat:4232 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:423 ; 
+    skos:definition """This class consists of units mainly engaged in retailing garden supplies or nursery goods.."""@en ;
+    skos:notation "4232" ;
+    skos:prefLabel "Garden Supplies Retailing"@en ;
+.
+
+icat:424 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:42 ; 
+    skos:definition """This group includes units mainly engaged in Recreational Goods Retailing."""@en ;
+    skos:notation "424" ;
+    skos:prefLabel "Recreational Goods Retailing"@en ;
+.
+
+icat:4241 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:424 ; 
+    skos:definition """This class consists of units mainly engaged in retailing sporting goods, camping equipment or bicycles.."""@en ;
+    skos:notation "4241" ;
+    skos:prefLabel "Sport and Camping Equipment Retailing"@en ;
+.
+
+icat:4242 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:424 ; 
+    skos:definition """This class consists of units mainly engaged in retailing audio tapes, compact discs, computer games, digital versatile discs or video cassettes.."""@en ;
+    skos:notation "4242" ;
+    skos:prefLabel "Entertainment Media Retailing"@en ;
+.
+
+icat:4243 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:424 ; 
+    skos:definition """This class consists of units mainly engaged in retailing toys or games (except computer games).."""@en ;
+    skos:notation "4243" ;
+    skos:prefLabel "Toy and Game Retailing"@en ;
+.
+
+icat:4244 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:424 ; 
+    skos:definition """This class consists of units mainly engaged in retailing books, periodicals and newspapers.."""@en ;
+    skos:notation "4244" ;
+    skos:prefLabel "Newspaper and Book Retailing"@en ;
+.
+
+icat:4245 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:424 ; 
+    skos:definition """This class consists of units mainly engaged in retailing new or used boats or boat accessories.."""@en ;
+    skos:notation "4245" ;
+    skos:prefLabel "Marine Equipment Retailing"@en ;
+.
+
+icat:425 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:42 ; 
+    skos:definition """This group includes units mainly engaged in Clothing, Footwear and Personal Accessory Retailing."""@en ;
+    skos:notation "425" ;
+    skos:prefLabel "Clothing, Footwear and Personal Accessory Retailing"@en ;
+.
+
+icat:4251 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:425 ; 
+    skos:definition """This class consists of units mainly engaged in retailing clothing or clothing accessories.."""@en ;
+    skos:notation "4251" ;
+    skos:prefLabel "Clothing Retailing"@en ;
+.
+
+icat:4252 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:425 ; 
+    skos:definition """This class consists of units mainly engaged in retailing boots, shoes or other footwear.."""@en ;
+    skos:notation "4252" ;
+    skos:prefLabel "Footwear Retailing"@en ;
+.
+
+icat:4253 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:425 ; 
+    skos:definition """This class consists of units mainly engaged in retailing new watches and jewellery (except clocks and silverware).."""@en ;
+    skos:notation "4253" ;
+    skos:prefLabel "Watch and Jewellery Retailing"@en ;
+.
+
+icat:4259 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:425 ; 
+    skos:definition """This class consists of units mainly engaged in retailing other personal accessories, including new handbags, sunglasses, leather goods, luggage and other personal accessories not elsewhere classified.."""@en ;
+    skos:notation "4259" ;
+    skos:prefLabel "Other Personal Accessory Retailing"@en ;
+.
+
+icat:426 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:42 ; 
+    skos:definition """This group includes units mainly engaged in Department Stores."""@en ;
+    skos:notation "426" ;
+    skos:prefLabel "Department Stores"@en ;
+.
+
+icat:4260 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:426 ; 
+    skos:definition """This class consists of units engaged in retailing a wide variety of goods, other than food or groceries, but the variety is such that no predominant activity can be determined.."""@en ;
+    skos:notation "4260" ;
+    skos:prefLabel "Department Stores"@en ;
+.
+
+icat:427 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:42 ; 
+    skos:definition """This group includes units mainly engaged in Pharmaceutical and Other Store-Based Retailing."""@en ;
+    skos:notation "427" ;
+    skos:prefLabel "Pharmaceutical and Other Store-Based Retailing"@en ;
+.
+
+icat:4271 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:427 ; 
+    skos:definition """This class consists of units mainly engaged in retailing prescription drugs or patent medicines, cosmetics or toiletries.."""@en ;
+    skos:notation "4271" ;
+    skos:prefLabel "Pharmaceutical, Cosmetic and Toiletry Goods Retailing"@en ;
+.
+
+icat:4272 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:427 ; 
+    skos:definition """This class consists of units mainly engaged in retailing stationery goods and writing materials.."""@en ;
+    skos:notation "4272" ;
+    skos:prefLabel "Stationery Goods Retailing"@en ;
+.
+
+icat:4273 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:427 ; 
+    skos:definition """This class consists of units mainly engaged in retailing antiques or second-hand goods (except motor vehicles or motorcycles and parts).."""@en ;
+    skos:notation "4273" ;
+    skos:prefLabel "Antique and Used Goods Retailing"@en ;
+.
+
+icat:4274 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:427 ; 
+    skos:definition """This class consists of units mainly engaged in retailing cut flowers or display foliage.."""@en ;
+    skos:notation "4274" ;
+    skos:prefLabel "Flower Retailing"@en ;
+.
+
+icat:4279 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:427 ; 
+    skos:definition """This class consists of units mainly engaged in retailing goods not elsewhere classified from store-based premises.."""@en ;
+    skos:notation "4279" ;
+    skos:prefLabel "Other Store-Based Retailing n.e.c."@en ;
+.
+
+icat:43 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:G ; 
+    skos:definition """This subdivision includes units mainly engaged in Non-Store Retailing and Retail Commission-Based Buying and/or Selling."""@en ;
+    skos:notation "43" ;
+    skos:prefLabel "Non-Store Retailing and Retail Commission-Based Buying and/or Selling"@en ;
+.
+
+icat:431 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:43 ; 
+    skos:definition """This group includes units mainly engaged in Non-Store Retailing."""@en ;
+    skos:notation "431" ;
+    skos:prefLabel "Non-Store Retailing"@en ;
+.
+
+icat:4310 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:431 ; 
+    skos:definition """This class consists of units mainly engaged in retailing goods without the use of a shopfront or physical store presence, including milk vendors, sole e-commerce retailers and direct shopping units.."""@en ;
+    skos:notation "4310" ;
+    skos:prefLabel "Non-Store Retailing"@en ;
+.
+
+icat:432 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:43 ; 
+    skos:definition """This group includes units mainly engaged in Retail Commission-Based Buying and/or Selling."""@en ;
+    skos:notation "432" ;
+    skos:prefLabel "Retail Commission-Based Buying and/or Selling"@en ;
+.
+
+icat:4320 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:432 ; 
+    skos:definition """This class consists of units mainly engaged in buying and/or selling goods to the general public on a fee or commission basis. These activities include units who arrange the sale of goods on behalf of a principal, but do not take title to the goods themselves.."""@en ;
+    skos:notation "4320" ;
+    skos:prefLabel "Retail Commission-Based Buying and/or Selling"@en ;
+.
+
+icat:H a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Accommodation and Food Services Division includes units mainly engaged in providing short-term accommodation for visitors. Also included are units mainly engaged in providing food and beverage services, such as the preparation and serving of meals and the serving of alcoholic beverages for consumption by customers, both on and off-site.."""@en ;
+    skos:notation "H" ;
+    skos:prefLabel "Accommodation and Food Services"@en ;
+.
+
+icat:44 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:H ; 
+    skos:definition """This subdivision includes units mainly engaged in Accommodation."""@en ;
+    skos:notation "44" ;
+    skos:prefLabel "Accommodation"@en ;
+.
+
+icat:440 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:44 ; 
+    skos:definition """This group includes units mainly engaged in Accommodation."""@en ;
+    skos:notation "440" ;
+    skos:prefLabel "Accommodation"@en ;
+.
+
+icat:4400 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:440 ; 
+    skos:definition """This class consists of units mainly engaged in providing accommodation for visitors, such as hotels, motels and similar units.."""@en ;
+    skos:notation "4400" ;
+    skos:prefLabel "Accommodation"@en ;
+.
+
+icat:45 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:H ; 
+    skos:definition """This subdivision includes units mainly engaged in Food and Beverage Services."""@en ;
+    skos:notation "45" ;
+    skos:prefLabel "Food and Beverage Services"@en ;
+.
+
+icat:451 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:45 ; 
+    skos:definition """This group includes units mainly engaged in Cafes, Restaurants and Takeaway Food Services."""@en ;
+    skos:notation "451" ;
+    skos:prefLabel "Cafes, Restaurants and Takeaway Food Services"@en ;
+.
+
+icat:4511 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:451 ; 
+    skos:definition """This class consists of units mainly engaged in providing food and beverage serving services for consumption on the premises. Customers generally order and are served while seated (i.e. waiter/waitress service) and pay after eating.."""@en ;
+    skos:notation "4511" ;
+    skos:prefLabel "Cafes and Restaurants"@en ;
+.
+
+icat:4512 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:451 ; 
+    skos:definition """This class consists of units mainly engaged in providing food services ready to be taken away for immediate consumption. Customers order or select items and pay before eating. Items are usually provided in takeaway containers or packaging. Food is either consumed on the premises in limited seating facilities, taken away by the customer or delivered. This class also includes units mainly engaged in supplying food services in food halls and food courts.."""@en ;
+    skos:notation "4512" ;
+    skos:prefLabel "Takeaway Food Services"@en ;
+.
+
+icat:4513 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:451 ; 
+    skos:definition """This class consists of units mainly engaged in providing catering services at specified locations or events such as airline catering. Meals and snacks may be transported and/or prepared and served on or off the premises, as required by the customer.."""@en ;
+    skos:notation "4513" ;
+    skos:prefLabel "Catering Services"@en ;
+.
+
+icat:452 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:45 ; 
+    skos:definition """This group includes units mainly engaged in Pubs, Taverns and Bars."""@en ;
+    skos:notation "452" ;
+    skos:prefLabel "Pubs, Taverns and Bars"@en ;
+.
+
+icat:4520 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:452 ; 
+    skos:definition """This class consists of hotels, bars or similar units (except hospitality clubs) mainly engaged in serving alcoholic beverages for consumption on the premises, or selling alcoholic beverages both for consumption on and off the premises. These units may also provide food services, gambling services and/or present live entertainment.."""@en ;
+    skos:notation "4520" ;
+    skos:prefLabel "Pubs, Taverns and Bars"@en ;
+.
+
+icat:453 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:45 ; 
+    skos:definition """This group includes units mainly engaged in Clubs (Hospitality)."""@en ;
+    skos:notation "453" ;
+    skos:prefLabel "Clubs (Hospitality)"@en ;
+.
+
+icat:4530 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:453 ; 
+    skos:definition """This class consists of associations mainly engaged in providing hospitality services to members. These hospitality services include gambling, sporting or other social or entertainment facilities.."""@en ;
+    skos:notation "4530" ;
+    skos:prefLabel "Clubs (Hospitality)"@en ;
+.
+
+icat:I a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Transport, Postal and Warehousing Division includes units mainly engaged in providing transportation of passengers and freight by road, rail, water or air. Other transportation activities such as postal services, pipeline transport and scenic and sightseeing transport are included in this division.
+
+Units mainly engaged in providing goods warehousing and storage activities are also included.
+
+The division also includes units mainly engaged in providing support services for the transportation of passengers and freight. These activities include stevedoring services, harbour services, navigation services, airport operations and customs agency services.."""@en ;
+    skos:notation "I" ;
+    skos:prefLabel "Transport, Postal and Warehousing"@en ;
+.
+
+icat:46 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Road Transport."""@en ;
+    skos:notation "46" ;
+    skos:prefLabel "Road Transport"@en ;
+.
+
+icat:461 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:46 ; 
+    skos:definition """This group includes units mainly engaged in Road Freight Transport."""@en ;
+    skos:notation "461" ;
+    skos:prefLabel "Road Freight Transport"@en ;
+.
+
+icat:4610 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:461 ; 
+    skos:definition """This class consists of units mainly engaged in the transportation of freight by road. It also includes units mainly engaged in renting trucks with drivers for road freight transport and road vehicle towing service.."""@en ;
+    skos:notation "4610" ;
+    skos:prefLabel "Road Freight Transport"@en ;
+.
+
+icat:462 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:46 ; 
+    skos:definition """This group includes units mainly engaged in Road Passenger Transport."""@en ;
+    skos:notation "462" ;
+    skos:prefLabel "Road Passenger Transport"@en ;
+.
+
+icat:4621 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:462 ; 
+    skos:definition """This class consists of units mainly engaged in operating buses for the transportation of passengers over regular routes and on regular schedules, mainly outside metropolitan areas or over long distances.."""@en ;
+    skos:notation "4621" ;
+    skos:prefLabel "Interurban and Rural Bus Transport"@en ;
+.
+
+icat:4622 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:462 ; 
+    skos:definition """This class consists of units mainly engaged in operating urban buses and tramways for the transportation of passengers, over regular routes and on regular schedules, mainly in a metropolitan area.."""@en ;
+    skos:notation "4622" ;
+    skos:prefLabel "Urban Bus Transport (Including Tramway)"@en ;
+.
+
+icat:4623 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:462 ; 
+    skos:definition """This class consists of units mainly engaged in operating taxi cabs or hire cars with drivers, or other forms of road vehicles not elsewhere classified, for the transportation of passengers.."""@en ;
+    skos:notation "4623" ;
+    skos:prefLabel "Taxi and Other Road Transport"@en ;
+.
+
+icat:47 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Rail Transport."""@en ;
+    skos:notation "47" ;
+    skos:prefLabel "Rail Transport"@en ;
+.
+
+icat:471 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:47 ; 
+    skos:definition """This group includes units mainly engaged in Rail Freight Transport."""@en ;
+    skos:notation "471" ;
+    skos:prefLabel "Rail Freight Transport"@en ;
+.
+
+icat:4710 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:471 ; 
+    skos:definition """This class consists of units mainly engaged in operating railways for the transportation of freight by rail.."""@en ;
+    skos:notation "4710" ;
+    skos:prefLabel "Rail Freight Transport"@en ;
+.
+
+icat:472 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:47 ; 
+    skos:definition """This group includes units mainly engaged in Rail Passenger Transport."""@en ;
+    skos:notation "472" ;
+    skos:prefLabel "Rail Passenger Transport"@en ;
+.
+
+icat:4720 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:472 ; 
+    skos:definition """This class consists of units mainly engaged in operating railways (except tramways) for the transportation of passengers over short and long distances.."""@en ;
+    skos:notation "4720" ;
+    skos:prefLabel "Rail Passenger Transport"@en ;
+.
+
+icat:48 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Water Transport."""@en ;
+    skos:notation "48" ;
+    skos:prefLabel "Water Transport"@en ;
+.
+
+icat:481 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:48 ; 
+    skos:definition """This group includes units mainly engaged in Water Freight Transport."""@en ;
+    skos:notation "481" ;
+    skos:prefLabel "Water Freight Transport"@en ;
+.
+
+icat:4810 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:481 ; 
+    skos:definition """This class consists of units mainly engaged in the operation of vessels for the transportation of freight or cargo by water.."""@en ;
+    skos:notation "4810" ;
+    skos:prefLabel "Water Freight Transport"@en ;
+.
+
+icat:482 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:48 ; 
+    skos:definition """This group includes units mainly engaged in Water Passenger Transport."""@en ;
+    skos:notation "482" ;
+    skos:prefLabel "Water Passenger Transport"@en ;
+.
+
+icat:4820 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:482 ; 
+    skos:definition """This class consists of units mainly engaged in the operation of vessels for the transportation of passengers by water.."""@en ;
+    skos:notation "4820" ;
+    skos:prefLabel "Water Passenger Transport"@en ;
+.
+
+icat:49 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Air and Space Transport."""@en ;
+    skos:notation "49" ;
+    skos:prefLabel "Air and Space Transport"@en ;
+.
+
+icat:490 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:49 ; 
+    skos:definition """This group includes units mainly engaged in Air and Space Transport."""@en ;
+    skos:notation "490" ;
+    skos:prefLabel "Air and Space Transport"@en ;
+.
+
+icat:4900 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:490 ; 
+    skos:definition """This class consists of units mainly engaged in operating aircraft for the transportation of freight and passengers.."""@en ;
+    skos:notation "4900" ;
+    skos:prefLabel "Air and Space Transport"@en ;
+.
+
+icat:50 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Other Transport."""@en ;
+    skos:notation "50" ;
+    skos:prefLabel "Other Transport"@en ;
+.
+
+icat:501 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:50 ; 
+    skos:definition """This group includes units mainly engaged in Scenic and Sightseeing Transport."""@en ;
+    skos:notation "501" ;
+    skos:prefLabel "Scenic and Sightseeing Transport"@en ;
+.
+
+icat:5010 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:501 ; 
+    skos:definition """This class consists of units mainly engaged in operating transportation equipment for scenic and sightseeing activities. This form of transport is distinguished from transit passenger services, as the emphasis is not on the efficiency or speed of the transport service but rather on providing recreation and entertainment. The service provided is usually local in nature and generally includes tour commentary, highlighting features of the scenery and/or the vehicle.."""@en ;
+    skos:notation "5010" ;
+    skos:prefLabel "Scenic and Sightseeing Transport"@en ;
+.
+
+icat:502 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:50 ; 
+    skos:definition """This group includes units mainly engaged in Pipeline and Other Transport."""@en ;
+    skos:notation "502" ;
+    skos:prefLabel "Pipeline and Other Transport"@en ;
+.
+
+icat:5021 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:502 ; 
+    skos:definition """This class consists of units mainly engaged in the transportation of natural gas, oil or other materials via pipelines.."""@en ;
+    skos:notation "5021" ;
+    skos:prefLabel "Pipeline Transport"@en ;
+.
+
+icat:5029 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:502 ; 
+    skos:definition """This class consists of units mainly engaged in passenger and freight transportation not elsewhere classified.."""@en ;
+    skos:notation "5029" ;
+    skos:prefLabel "Other Transport n.e.c."@en ;
+.
+
+icat:51 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Postal and Courier Pick-Up and Delivery Services."""@en ;
+    skos:notation "51" ;
+    skos:prefLabel "Postal and Courier Pick-up and Delivery Services"@en ;
+.
+
+icat:510 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:51 ; 
+    skos:definition """This group includes units mainly engaged in Postal and Courier Pick-Up and Delivery Services."""@en ;
+    skos:notation "510" ;
+    skos:prefLabel "Postal and Courier Pick-up and Delivery Services"@en ;
+.
+
+icat:5101 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:510 ; 
+    skos:definition """This class consists of units mainly engaged in the pick-up and delivery of letters, documents and parcels (usually weighing less than 30 kgs). Rather than being from the sender’s location, the pick-up activity is from pre-determined collection points (e.g. post offices and postal agencies). Also included are units mainly engaged in the operation/provision of predetermined collection points (such as post offices or postal agents).."""@en ;
+    skos:notation "5101" ;
+    skos:prefLabel "Postal Services"@en ;
+.
+
+icat:5102 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:510 ; 
+    skos:definition """This class consists of units mainly engaged in the door to door pick-up (i.e. from the customer’s residence or place of business), transport and delivery of letters, documents, parcels and other items weighing less than 30 kgs.."""@en ;
+    skos:notation "5102" ;
+    skos:prefLabel "Courier Pick-up and Delivery Services"@en ;
+.
+
+icat:52 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Transport Support Services."""@en ;
+    skos:notation "52" ;
+    skos:prefLabel "Transport Support Services"@en ;
+.
+
+icat:521 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:52 ; 
+    skos:definition """This group includes units mainly engaged in Water Transport Support Services."""@en ;
+    skos:notation "521" ;
+    skos:prefLabel "Water Transport Support Services"@en ;
+.
+
+icat:5211 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:521 ; 
+    skos:definition """This class consists of units mainly engaged in providing stevedoring services for the loading or unloading of vessels.."""@en ;
+    skos:notation "5211" ;
+    skos:prefLabel "Stevedoring Services"@en ;
+.
+
+icat:5212 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:521 ; 
+    skos:definition """This class consists of units mainly engaged in the maintenance and leasing of port facilities to facilitate the land-sea transition of goods and passengers. Also included are units mainly engaged in the operation of ship mooring facilities or water transport terminals for passenger or freight (including sea cargo container terminals and coal or grain loaders).."""@en ;
+    skos:notation "5212" ;
+    skos:prefLabel "Port and Water Transport Terminal Operations"@en ;
+.
+
+icat:5219 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:521 ; 
+    skos:definition """This class consists of units mainly engaged in providing water transport support services not elsewhere classified.."""@en ;
+    skos:notation "5219" ;
+    skos:prefLabel "Other Water Transport Support Services"@en ;
+.
+
+icat:522 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:52 ; 
+    skos:definition """This group includes units mainly engaged in Airport Operations and Other Air Transport Support Services."""@en ;
+    skos:notation "522" ;
+    skos:prefLabel "Airport Operations and Other Air Transport Support Services"@en ;
+.
+
+icat:5220 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:522 ; 
+    skos:definition """This class consists of units mainly engaged in operating international, national or civil airports. Also included are units mainly engaged in providing other services to air transport such as airport terminals, runways, air traffic control services, aerospace navigation or baggage handling services.."""@en ;
+    skos:notation "5220" ;
+    skos:prefLabel "Airport Operations and Other Air Transport Support Services"@en ;
+.
+
+icat:529 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:52 ; 
+    skos:definition """This group includes units mainly engaged in Other Transport Support Services."""@en ;
+    skos:notation "529" ;
+    skos:prefLabel "Other Transport Support Services"@en ;
+.
+
+icat:5291 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:529 ; 
+    skos:definition """This class consists of units mainly engaged in providing advice on import and export procedures and documentation, and other related services.."""@en ;
+    skos:notation "5291" ;
+    skos:prefLabel "Customs Agency Services"@en ;
+.
+
+icat:5292 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:529 ; 
+    skos:definition """This class consists of units mainly engaged in contracting the transportation of goods for other enterprises, using one or more different enterprises to perform the contracted services by road, rail, air, sea freight transport or any combination of the modes of transport. (In these cases, the ’forwarding’ unit takes prime responsibility for the entire transport operation).."""@en ;
+    skos:notation "5292" ;
+    skos:prefLabel "Freight Forwarding Services"@en ;
+.
+
+icat:5299 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:529 ; 
+    skos:definition """This class consists of units mainly engaged in providing transport support services not elsewhere classified.."""@en ;
+    skos:notation "5299" ;
+    skos:prefLabel "Other Transport Support Services n.e.c."@en ;
+.
+
+icat:53 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:I ; 
+    skos:definition """This subdivision includes units mainly engaged in Warehousing and Storage Services."""@en ;
+    skos:notation "53" ;
+    skos:prefLabel "Warehousing and Storage Services"@en ;
+.
+
+icat:530 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:53 ; 
+    skos:definition """This group includes units mainly engaged in Warehousing and Storage Services."""@en ;
+    skos:notation "530" ;
+    skos:prefLabel "Warehousing and Storage Services"@en ;
+.
+
+icat:5301 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:530 ; 
+    skos:definition """This class consists of units mainly engaged in the storage of cereal grains.."""@en ;
+    skos:notation "5301" ;
+    skos:prefLabel "Grain Storage Services"@en ;
+.
+
+icat:5309 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:530 ; 
+    skos:definition """This class consists of units mainly engaged in operating warehousing and storage facilities (except cereal grain storage).."""@en ;
+    skos:notation "5309" ;
+    skos:prefLabel "Other Warehousing and Storage Services"@en ;
+.
+
+icat:J a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Information Media and Telecommunications Division includes units mainly engaged in:
+
+    - creating, enhancing and storing information products in media that allows for their dissemination;
+    - transmitting information products using analogue and digital signals (via electronic, wireless, optical and other means); and
+    - providing transmission services and/or operating the infrastructure to enable the transmission and storage of information and information products.
+
+Information products are defined as those which are not necessarily tangible, and, unlike traditional goods, are not associated with a particular form. The value of the information products is embedded in their content rather than in the format in which they are distributed. For example, a movie can be screened at a cinema, telecast on television or copied to video for sale or rental. The division includes some activities that primarily create, enhance and disseminate information products, subject to copyright.
+
+It is the intangible nature of the information products which determines their unique dissemination process, which may include via a broadcast, electronic means, or physical form. They do not usually require direct contact between the supplier/producer and the consumer, which distinguishes them from distribution activities included in the Wholesale Trade and Retail Trade Divisions.
+
+Excluded from the division are units mainly engaged in:
+
+    - the mass storage or duplication of information products such as printing newspapers, CDs, DVDs, etc. (Manufacturing Division);
+    - purchasing and on-selling information products in their tangible form (Wholesale Trade and Retail Trade Divisions);
+    - providing specialised computer services such as programming and systems design services, graphic design services and advertising services, as well as gathering, tabulating and presenting marketing and opinion data (Professional, Scientific and Technical Services Division);
+    - providing a range of creative artistic activities such as the creation of an artistic original (e.g. a painting), or the provision of a live musical performance by a group or artist (Arts and Recreation Services Division); and
+    - units undertaking a range of activities such as directing, acting, writing and performing (Arts and Recreation Services Division).."""@en ;
+    skos:notation "J" ;
+    skos:prefLabel "Information Media and Telecommunications"@en ;
+.
+
+icat:54 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:J ; 
+    skos:definition """This subdivision includes units mainly engaged in Publishing (except Internet and Music Publishing)."""@en ;
+    skos:notation "54" ;
+    skos:prefLabel "Publishing (except Internet and Music Publishing)"@en ;
+.
+
+icat:541 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:54 ; 
+    skos:definition """This group includes units mainly engaged in Newspaper, Periodical, Book and Directory Publishing."""@en ;
+    skos:notation "541" ;
+    skos:prefLabel "Newspaper, Periodical, Book and Directory Publishing"@en ;
+.
+
+icat:5411 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:541 ; 
+    skos:definition """This class consists of units mainly engaged in publishing (creating and disseminating) newspapers. Included in this class are units whose main source of income is the sale of advertising space in their own newspapers.."""@en ;
+    skos:notation "5411" ;
+    skos:prefLabel "Newspaper Publishing"@en ;
+.
+
+icat:5412 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:541 ; 
+    skos:definition """This class consists of units mainly engaged in publishing (creating and disseminating) magazines, journals and other periodicals. Included in this class are units whose main source of income is the sale of advertising space in their own periodicals.."""@en ;
+    skos:notation "5412" ;
+    skos:prefLabel "Magazine and Other Periodical Publishing"@en ;
+.
+
+icat:5413 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:541 ; 
+    skos:definition """This class consists of units mainly engaged in publishing (creating and disseminating) books including atlases, textbooks and travel guides.."""@en ;
+    skos:notation "5413" ;
+    skos:prefLabel "Book Publishing"@en ;
+.
+
+icat:5414 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:541 ; 
+    skos:definition """This class consists of units mainly engaged in publishing (creating and disseminating) directories, mailing lists and collections or compilations of fact such as mailing addresses and telephone directories.."""@en ;
+    skos:notation "5414" ;
+    skos:prefLabel "Directory and Mailing List Publishing"@en ;
+.
+
+icat:5419 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:541 ; 
+    skos:definition """This class consists of units mainly engaged in other publishing (creating and disseminating) activities (except software, music and internet publishing) such as greeting card, postcard and art print publishing.."""@en ;
+    skos:notation "5419" ;
+    skos:prefLabel "Other Publishing (except Software, Music and Internet)"@en ;
+.
+
+icat:542 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:54 ; 
+    skos:definition """This group includes units mainly engaged in Software Publishing."""@en ;
+    skos:notation "542" ;
+    skos:prefLabel "Software Publishing"@en ;
+.
+
+icat:5420 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:542 ; 
+    skos:definition """This class consists of units mainly engaged in creating and disseminating ready-made (non-customised) computer software.."""@en ;
+    skos:notation "5420" ;
+    skos:prefLabel "Software Publishing"@en ;
+.
+
+icat:55 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:J ; 
+    skos:definition """This subdivision includes units mainly engaged in Motion Picture and Sound Recording Activities."""@en ;
+    skos:notation "55" ;
+    skos:prefLabel "Motion Picture and Sound Recording Activities"@en ;
+.
+
+icat:551 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:55 ; 
+    skos:definition """This group includes units mainly engaged in Motion Picture and Video Activities."""@en ;
+    skos:notation "551" ;
+    skos:prefLabel "Motion Picture and Video Activities"@en ;
+.
+
+icat:5511 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:551 ; 
+    skos:definition """This class consists of units mainly engaged in producing motion pictures, videos and television programs or commercials. These productions are recorded and stored on a variety of analogue or digital visual media such as film, video tape or DVD.."""@en ;
+    skos:notation "5511" ;
+    skos:prefLabel "Motion Picture and Video Production"@en ;
+.
+
+icat:5512 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:551 ; 
+    skos:definition """This class consists of units mainly engaged in acquiring distribution rights and distributing motion pictures and videos. These products are distributed (through leasing and wholesale channels) to a range of exhibitors such as motion picture theatres and television stations using a variety of visual media.."""@en ;
+    skos:notation "5512" ;
+    skos:prefLabel "Motion Picture and Video Distribution"@en ;
+.
+
+icat:5513 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:551 ; 
+    skos:definition """This class consists of units mainly engaged in screening motion pictures using a variety of visual media. Included in this class are units screening productions at festivals and other similar events.."""@en ;
+    skos:notation "5513" ;
+    skos:prefLabel "Motion Picture Exhibition"@en ;
+.
+
+icat:5514 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:551 ; 
+    skos:definition """This class consists of units mainly engaged in providing post-production services and other motion picture and video activities, including specialised motion picture or video post-production services such as editing, film/tape transfers, titling, subtitling, credits, closed captioning and computer-produced graphics, animation and special effects, as well as developing and processing motion picture film.."""@en ;
+    skos:notation "5514" ;
+    skos:prefLabel "Post-production Services and Other Motion Picture and Video Activities"@en ;
+.
+
+icat:552 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:55 ; 
+    skos:definition """This group includes units mainly engaged in Sound Recording and Music Publishing."""@en ;
+    skos:notation "552" ;
+    skos:prefLabel "Sound Recording and Music Publishing"@en ;
+.
+
+icat:5521 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:552 ; 
+    skos:definition """This class consists of units mainly engaged in acquiring and registering copyrights for musical compositions and promoting and authorising the use of these compositions in recordings, radio, television, motion pictures, live performances, print, or other media. Units in this class represent the interest of the composing unit, or other owners of musical compositions, to produce revenues from the use of such works, usually through licensing agreements. These units may own the copyright or act as administrator of the music copyrights on behalf of copyright owners. Also included in this class are units publishing sheet music (including in bound book form).."""@en ;
+    skos:notation "5521" ;
+    skos:prefLabel "Music Publishing"@en ;
+.
+
+icat:5522 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:552 ; 
+    skos:definition """This class consists of units mainly engaged in producing original (sound) master recordings such as tapes and CDs and releasing and distributing these sound recordings to wholesalers, retailers or directly to the public. Also included in this class are units engaged in operating sound recording studios and in the production of pre-recorded radio programs.."""@en ;
+    skos:notation "5522" ;
+    skos:prefLabel "Music and Other Sound Recording Activities"@en ;
+.
+
+icat:56 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:J ; 
+    skos:definition """This subdivision includes units mainly engaged in Broadcasting (except Internet)."""@en ;
+    skos:notation "56" ;
+    skos:prefLabel "Broadcasting (except Internet)"@en ;
+.
+
+icat:561 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:56 ; 
+    skos:definition """This group includes units mainly engaged in Radio Broadcasting."""@en ;
+    skos:notation "561" ;
+    skos:prefLabel "Radio Broadcasting"@en ;
+.
+
+icat:5610 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:561 ; 
+    skos:definition """This class consists of units mainly engaged in broadcasting audio signals, using radio broadcasting studios and facilities, to transmit aerial programming.."""@en ;
+    skos:notation "5610" ;
+    skos:prefLabel "Radio Broadcasting"@en ;
+.
+
+icat:562 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:56 ; 
+    skos:definition """This group includes units mainly engaged in Television Broadcasting."""@en ;
+    skos:notation "562" ;
+    skos:prefLabel "Television Broadcasting"@en ;
+.
+
+icat:5621 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:562 ; 
+    skos:definition """This class consists of units mainly engaged in free-to-air television broadcasting of visual content, in the form of electronic images together with sound, through broadcasting studios and facilities. These units may also produce or transmit visual programming to affiliated broadcast television stations, which in turn broadcast the programs on a pre-determined schedule. Transmissions are made available without cost to the viewer.."""@en ;
+    skos:notation "5621" ;
+    skos:prefLabel "Free-to-Air Television Broadcasting"@en ;
+.
+
+icat:5622 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:562 ; 
+    skos:definition """This class consists of units mainly engaged in broadcasting television programs on a subscription or fee basis (such as subscription cable or satellite television broadcasting) to viewers.."""@en ;
+    skos:notation "5622" ;
+    skos:prefLabel "Cable and Other Subscription Broadcasting"@en ;
+.
+
+icat:57 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:J ; 
+    skos:definition """This subdivision includes units mainly engaged in Internet Publishing and Broadcasting."""@en ;
+    skos:notation "57" ;
+    skos:prefLabel "Internet Publishing and Broadcasting"@en ;
+.
+
+icat:570 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:57 ; 
+    skos:definition """This group includes units mainly engaged in Internet Publishing and Broadcasting."""@en ;
+    skos:notation "570" ;
+    skos:prefLabel "Internet Publishing and Broadcasting"@en ;
+.
+
+icat:5700 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:570 ; 
+    skos:definition """This class consists of units mainly engaged in publishing and/or broadcasting content on the internet. Units in this class provide textual, audio and/or video content of general or specific interest on the internet. These units do not provide traditional (non-internet) versions of the content they publish or broadcast.."""@en ;
+    skos:notation "5700" ;
+    skos:prefLabel "Internet Publishing and Broadcasting"@en ;
+.
+
+icat:58 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:J ; 
+    skos:definition """This subdivision includes units mainly engaged in Telecommunications Services."""@en ;
+    skos:notation "58" ;
+    skos:prefLabel "Telecommunications Services"@en ;
+.
+
+icat:580 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:58 ; 
+    skos:definition """This group includes units mainly engaged in Telecommunications Services."""@en ;
+    skos:notation "580" ;
+    skos:prefLabel "Telecommunications Services"@en ;
+.
+
+icat:5801 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:580 ; 
+    skos:definition """This class consists of units mainly engaged in operating, maintaining or providing access to facilities for the transmission of voice, data, text, sound and video using wired telecommunications networks. Units operate fixed (wired) telecommunications infrastructure, but may also utilise other types of technologies in order to deliver services.."""@en ;
+    skos:notation "5801" ;
+    skos:prefLabel "Wired Telecommunications Network Operation"@en ;
+.
+
+icat:5802 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:580 ; 
+    skos:definition """This class consists of units mainly engaged in operating and maintaining switching and transmission facilities that provide omni-directional or point-to point communications via wireless telecommunication networks. Transmission facilities may be based on a single technology or a combination of technologies, including communications via airwaves and through satellite systems.."""@en ;
+    skos:notation "5802" ;
+    skos:prefLabel "Other Telecommunications Network Operation"@en ;
+.
+
+icat:5809 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:580 ; 
+    skos:definition """This class consists of units mainly engaged in providing a range of other telecommunication services such as paging services and other specialised telecommunications applications. Also included in this class are units of telecommunications resellers purchasing access and network capacity from telecommunication carriers.."""@en ;
+    skos:notation "5809" ;
+    skos:prefLabel "Other Telecommunications Services"@en ;
+.
+
+icat:59 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:J ; 
+    skos:definition """This subdivision includes units mainly engaged in Internet Service Providers, Web Search Portals and Data Processing Services."""@en ;
+    skos:notation "59" ;
+    skos:prefLabel "Internet Service Providers, Web Search Portals and Data Processing Services"@en ;
+.
+
+icat:591 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:59 ; 
+    skos:definition """This group includes units mainly engaged in Internet Service Providers and Web Search Portals."""@en ;
+    skos:notation "591" ;
+    skos:prefLabel "Internet Service Providers and Web Search Portals"@en ;
+.
+
+icat:5910 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:591 ; 
+    skos:definition """This class consists of units mainly engaged in providing internet access services. Also included are units which provide web search portals used to search the internet.."""@en ;
+    skos:notation "5910" ;
+    skos:prefLabel "Internet Service Providers and Web Search Portals"@en ;
+.
+
+icat:592 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:59 ; 
+    skos:definition """This group includes units mainly engaged in Data Processing, Web Hosting and Electronic Information Storage Services."""@en ;
+    skos:notation "592" ;
+    skos:prefLabel "Data Processing, Web Hosting and Electronic Information Storage Services"@en ;
+.
+
+icat:5921 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:592 ; 
+    skos:definition """This class consists of units mainly engaged in providing electronic data processing or hosting services. These units provide specialised hosting activities such as web hosting, streaming services or application hosting, provide application service provisioning, or provide general timesharing mainframe facilities to customers. These units provide complete processing and specialised reports from data supplied by customers or provide automated data processing and data entry services.."""@en ;
+    skos:notation "5921" ;
+    skos:prefLabel "Data Processing and Web Hosting Services"@en ;
+.
+
+icat:5922 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:592 ; 
+    skos:definition """This class consists of units mainly engaged in providing electronic information storage and retrieval services (except library services).."""@en ;
+    skos:notation "5922" ;
+    skos:prefLabel "Electronic Information Storage Services"@en ;
+.
+
+icat:60 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:J ; 
+    skos:definition """This subdivision includes units mainly engaged in Library and Other Information Services."""@en ;
+    skos:notation "60" ;
+    skos:prefLabel "Library and Other Information Services"@en ;
+.
+
+icat:601 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:60 ; 
+    skos:definition """This group includes units mainly engaged in Libraries and Archives."""@en ;
+    skos:notation "601" ;
+    skos:prefLabel "Libraries and Archives"@en ;
+.
+
+icat:6010 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:601 ; 
+    skos:definition """This class consists of units mainly engaged in providing library or archive services. The units maintain collections of documents (e.g. books, journals, newspaper and music) and facilitate the use of such documents (recorded information regardless of its physical form and characteristics). All or parts of these collections may be accessible electronically.."""@en ;
+    skos:notation "6010" ;
+    skos:prefLabel "Libraries and Archives"@en ;
+.
+
+icat:602 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:60 ; 
+    skos:definition """This group includes units mainly engaged in Other Information Services."""@en ;
+    skos:notation "602" ;
+    skos:prefLabel "Other Information Services"@en ;
+.
+
+icat:6020 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:602 ; 
+    skos:definition """This class consists of units mainly engaged in providing other information services.."""@en ;
+    skos:notation "6020" ;
+    skos:prefLabel "Other Information Services"@en ;
+.
+
+icat:K a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Financial and Insurance Services Division includes units mainly engaged in financial transactions involving the creation, liquidation, or change in ownership of financial assets, and/or in facilitating financial transactions.
+
+The range of activities include raising funds by taking deposits and/or issuing securities and, in the process, incurring liabilities; units investing their own funds in a range of financial assets; pooling risk by underwriting insurance and annuities; separately constituted funds engaged in the provision of retirement incomes; and specialised services facilitating or supporting financial intermediation, insurance and employee benefit programs.
+
+Also included in this division are central banking, monetary control and the regulation of financial activities.."""@en ;
+    skos:notation "K" ;
+    skos:prefLabel "Financial and Insurance Services"@en ;
+.
+
+icat:62 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:K ; 
+    skos:definition """This subdivision includes units mainly engaged in Finance."""@en ;
+    skos:notation "62" ;
+    skos:prefLabel "Finance"@en ;
+.
+
+icat:621 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:62 ; 
+    skos:definition """This group includes units mainly engaged in Central Banking."""@en ;
+    skos:notation "621" ;
+    skos:prefLabel "Central Banking"@en ;
+.
+
+icat:6210 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:621 ; 
+    skos:definition """This class consists of units mainly engaged in formulating monetary policy and performing central banking functions, such as issuing currency, managing the nation's money supply and foreign reserves, holding deposits that represent the reserves of other banks, and acting as fiscal agent for governments. This class also includes units primarily engaged in the prudential regulation, licensing and inspection of the financial sector.."""@en ;
+    skos:notation "6210" ;
+    skos:prefLabel "Central Banking"@en ;
+.
+
+icat:622 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:62 ; 
+    skos:definition """This group includes units mainly engaged in Depository Financial Intermediation."""@en ;
+    skos:notation "622" ;
+    skos:prefLabel "Depository Financial Intermediation"@en ;
+.
+
+icat:6221 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:622 ; 
+    skos:definition """This class consists of units mainly engaged in operating banks (except merchant banks). Banks incur liabilities by accepting demand and other deposits and make commercial, industrial and consumer loans.."""@en ;
+    skos:notation "6221" ;
+    skos:prefLabel "Banking"@en ;
+.
+
+icat:6222 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:622 ; 
+    skos:definition """This class consists of units mainly engaged in operating building societies which accept deposits and provide specialised financing for home building or purchasing purposes.."""@en ;
+    skos:notation "6222" ;
+    skos:prefLabel "Building Society Operation"@en ;
+.
+
+icat:6223 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:622 ; 
+    skos:definition """This class consists of units mainly engaged in operating credit unions which accept members’ share deposits and provide loans to their members for various purposes.."""@en ;
+    skos:notation "6223" ;
+    skos:prefLabel "Credit Union Operation"@en ;
+.
+
+icat:6229 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:622 ; 
+    skos:definition """This class consists of units mainly engaged in accepting deposits and providing finance (except units operating banks, building societies and credit unions). Also included are deposit-taking units engaged in money market dealing and operating deposit-taking merchant banks or finance companies.."""@en ;
+    skos:notation "6229" ;
+    skos:prefLabel "Other Depository Financial Intermediation"@en ;
+.
+
+icat:623 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:62 ; 
+    skos:definition """This group includes units mainly engaged in Non-Depository Financing."""@en ;
+    skos:notation "623" ;
+    skos:prefLabel "Non-Depository Financing"@en ;
+.
+
+icat:6230 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:623 ; 
+    skos:definition """This class consists of units mainly engaged in non-depository finance. Non-deposit financiers do not incur deposit liabilities and are mainly engaged in providing credit or lending money, or in leasing machinery, plant or equipment purely on a financial service basis (i.e. without physically handling the goods). Units of co-operative housing societies (except co-operative housing society management services on a commission or fee basis) are included.."""@en ;
+    skos:notation "6230" ;
+    skos:prefLabel "Non-Depository Financing"@en ;
+.
+
+icat:624 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:62 ; 
+    skos:definition """This group includes units mainly engaged in Financial Asset Investing."""@en ;
+    skos:notation "624" ;
+    skos:prefLabel "Financial Asset Investing"@en ;
+.
+
+icat:6240 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:624 ; 
+    skos:definition """This class consists of units mainly engaged in investing money on their own account in predominantly financial assets such as shares, bonds, bills and financial derivatives (including mortgages), excluding units of separately constituted superannuation funds. Also included are investment type unit trusts mainly engaged in holding financial assets, as well as financial holding companies holding shares in subsidiary companies.."""@en ;
+    skos:notation "6240" ;
+    skos:prefLabel "Financial Asset Investing"@en ;
+.
+
+icat:63 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:K ; 
+    skos:definition """This subdivision includes units mainly engaged in Insurance and Superannuation Funds."""@en ;
+    skos:notation "63" ;
+    skos:prefLabel "Insurance and Superannuation Funds"@en ;
+.
+
+icat:631 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:63 ; 
+    skos:definition """This group includes units mainly engaged in Life Insurance."""@en ;
+    skos:notation "631" ;
+    skos:prefLabel "Life Insurance"@en ;
+.
+
+icat:6310 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:631 ; 
+    skos:definition """This class consists of units mainly engaged in providing life insurance and life reinsurance covers.."""@en ;
+    skos:notation "6310" ;
+    skos:prefLabel "Life Insurance"@en ;
+.
+
+icat:632 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:63 ; 
+    skos:definition """This group includes units mainly engaged in Health and General Insurance."""@en ;
+    skos:notation "632" ;
+    skos:prefLabel "Health and General Insurance"@en ;
+.
+
+icat:6321 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:632 ; 
+    skos:definition """This class consists of units mainly engaged in providing insurance cover for hospital, medical, dental, pharmaceutical or funeral expenses or costs.."""@en ;
+    skos:notation "6321" ;
+    skos:prefLabel "Health Insurance"@en ;
+.
+
+icat:6322 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:632 ; 
+    skos:definition """This class consists of units mainly engaged in providing general insurance cover (except life and health insurance).."""@en ;
+    skos:notation "6322" ;
+    skos:prefLabel "General Insurance"@en ;
+.
+
+icat:633 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:63 ; 
+    skos:definition """This group includes units mainly engaged in Superannuation Funds."""@en ;
+    skos:notation "633" ;
+    skos:prefLabel "Superannuation Funds"@en ;
+.
+
+icat:6330 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:633 ; 
+    skos:definition """This class consists of units of separately constituted funds mainly engaged in providing retirement benefits.."""@en ;
+    skos:notation "6330" ;
+    skos:prefLabel "Superannuation Funds"@en ;
+.
+
+icat:64 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:K ; 
+    skos:definition """This subdivision includes units mainly engaged in Auxiliary Finance and Insurance Services."""@en ;
+    skos:notation "64" ;
+    skos:prefLabel "Auxiliary Finance and Insurance Services"@en ;
+.
+
+icat:641 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:64 ; 
+    skos:definition """This group includes units mainly engaged in Auxiliary Finance and Investment Services."""@en ;
+    skos:notation "641" ;
+    skos:prefLabel "Auxiliary Finance and Investment Services"@en ;
+.
+
+icat:6411 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:641 ; 
+    skos:definition """This class consists of units mainly engaged in trading in stocks, shares or other financial assets on behalf of others, or in underwriting financial asset issues. Also included in this class are units mainly engaged in buying, selling and trading in mortgage documents for others.."""@en ;
+    skos:notation "6411" ;
+    skos:prefLabel "Financial Asset Broking Services"@en ;
+.
+
+icat:6419 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:641 ; 
+    skos:definition """This class consists of units mainly engaged in providing nominee, trustee, investment management or advisory services, arranging home loans for others, or other auxiliary finance or investment services not elsewhere classified. Also included in this class are units of incorporated stock exchanges.."""@en ;
+    skos:notation "6419" ;
+    skos:prefLabel "Other Auxiliary Finance and Investment Services"@en ;
+.
+
+icat:642 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:64 ; 
+    skos:definition """This group includes units mainly engaged in Auxiliary Insurance Services."""@en ;
+    skos:notation "642" ;
+    skos:prefLabel "Auxiliary Insurance Services"@en ;
+.
+
+icat:6420 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:642 ; 
+    skos:definition """This class consists of units mainly engaged in providing insurance broking or agency services, or other services to insurance such as consultant, claim assessment or adjustment services.."""@en ;
+    skos:notation "6420" ;
+    skos:prefLabel "Auxiliary Insurance Services"@en ;
+.
+
+icat:L a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Rental, Hiring and Real Estate Services Division includes units mainly engaged in renting, hiring, or otherwise allowing the use of tangible or intangible assets (except copyrights), and units providing related services.
+
+The assets may be tangible, as in the case of real estate and equipment, or intangible, as in the case with patents and trademarks.
+
+The division also includes units engaged in providing real estate services such as selling, renting and/or buying real estate for others, managing real estate for others and appraising real estate.."""@en ;
+    skos:notation "L" ;
+    skos:prefLabel "Rental, Hiring and Real Estate Services"@en ;
+.
+
+icat:66 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:L ; 
+    skos:definition """This subdivision includes units mainly engaged in Rental and Hiring Services (except Real Estate)."""@en ;
+    skos:notation "66" ;
+    skos:prefLabel "Rental and Hiring Services (except Real Estate)"@en ;
+.
+
+icat:661 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:66 ; 
+    skos:definition """This group includes units mainly engaged in Motor Vehicle and Transport Equipment Rental and Hiring."""@en ;
+    skos:notation "661" ;
+    skos:prefLabel "Motor Vehicle and Transport Equipment Rental and Hiring"@en ;
+.
+
+icat:6611 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:661 ; 
+    skos:definition """This class consists of units mainly engaged in hiring, leasing or renting passenger cars without drivers. Passenger cars include station wagons and minibuses.."""@en ;
+    skos:notation "6611" ;
+    skos:prefLabel "Passenger Car Rental and Hiring"@en ;
+.
+
+icat:6619 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:661 ; 
+    skos:definition """This class consists of units mainly engaged in hiring, leasing or renting transport equipment (except passenger cars), including trucks, buses, ships, boats and aircraft. Rental is of the vehicle or equipment only; it does not include hire of a driver, pilot or other operator. Also included are units mainly engaged in the rental of shipping containers, including refrigerated containers.."""@en ;
+    skos:notation "6619" ;
+    skos:prefLabel "Other Motor Vehicle and Transport Equipment Rental and Hiring"@en ;
+.
+
+icat:662 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:66 ; 
+    skos:definition """This group includes units mainly engaged in Farm Animal and Bloodstock Leasing."""@en ;
+    skos:notation "662" ;
+    skos:prefLabel "Farm Animal and Bloodstock Leasing"@en ;
+.
+
+icat:6620 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:662 ; 
+    skos:definition """This class consists of units mainly engaged in leasing farm animals or bloodstock but not engaged in handling the animals. The animals are leased to other units that take direct control and responsibility for their management.."""@en ;
+    skos:notation "6620" ;
+    skos:prefLabel "Farm Animal and Bloodstock Leasing"@en ;
+.
+
+icat:663 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:66 ; 
+    skos:definition """This group includes units mainly engaged in Other Goods and Equipment Rental and Hiring."""@en ;
+    skos:notation "663" ;
+    skos:prefLabel "Other Goods and Equipment Rental and Hiring"@en ;
+.
+
+icat:6631 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:663 ; 
+    skos:definition """This class consists of units mainly engaged in hiring, leasing or renting, without operators, heavy machinery and scaffolding (including mobile platforms) from stock physically held for the purpose.."""@en ;
+    skos:notation "6631" ;
+    skos:prefLabel "Heavy Machinery and Scaffolding Rental and Hiring"@en ;
+.
+
+icat:6632 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:663 ; 
+    skos:definition """This class consists of units mainly engaged in renting or hiring pre-recorded video tapes, discs and other electronic media.."""@en ;
+    skos:notation "6632" ;
+    skos:prefLabel "Video and Other Electronic Media Rental and Hiring"@en ;
+.
+
+icat:6639 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:663 ; 
+    skos:definition """This class consists of units mainly engaged in hiring, leasing or renting goods and equipment not elsewhere classified.."""@en ;
+    skos:notation "6639" ;
+    skos:prefLabel "Other Goods and Equipment Rental and Hiring n.e.c."@en ;
+.
+
+icat:664 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:66 ; 
+    skos:definition """This group includes units mainly engaged in Non-Financial Intangible Assets (Except Copyrights) Leasing."""@en ;
+    skos:notation "664" ;
+    skos:prefLabel "Non-Financial Intangible Assets (Except Copyrights) Leasing"@en ;
+.
+
+icat:6640 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:664 ; 
+    skos:definition """This class consists of units mainly engaged in holding intellectual property (including trademarks) or other non-financial intangible assets (except copyright). The units derive income from fees paid to them for the use of the assets, including the right to reproduce the assets.."""@en ;
+    skos:notation "6640" ;
+    skos:prefLabel "Non-Financial Intangible Assets (Except Copyrights) Leasing"@en ;
+.
+
+icat:67 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:L ; 
+    skos:definition """This subdivision includes units mainly engaged in Property Operators and Real Estate Services."""@en ;
+    skos:notation "67" ;
+    skos:prefLabel "Property Operators and Real Estate Services"@en ;
+.
+
+icat:671 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:67 ; 
+    skos:definition """This group includes units mainly engaged in Property Operators."""@en ;
+    skos:notation "671" ;
+    skos:prefLabel "Property Operators"@en ;
+.
+
+icat:6711 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:671 ; 
+    skos:definition """This class consists of units mainly engaged in renting or leasing residential properties, (other than holiday houses or holiday flats) including space in such properties. The units may be owner lessors or they may sublease properties of which they are themselves lessees.."""@en ;
+    skos:notation "6711" ;
+    skos:prefLabel "Residential Property Operators"@en ;
+.
+
+icat:6712 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:671 ; 
+    skos:definition """This class consists of units mainly engaged in renting or leasing non-residential properties.."""@en ;
+    skos:notation "6712" ;
+    skos:prefLabel "Non-Residential Property Operators"@en ;
+.
+
+icat:672 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:67 ; 
+    skos:definition """This group includes units mainly engaged in Real Estate Services."""@en ;
+    skos:notation "672" ;
+    skos:prefLabel "Real Estate Services"@en ;
+.
+
+icat:6720 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:672 ; 
+    skos:definition """This class consists of units mainly engaged in valuing, purchasing, selling (by auction or private treaty), managing or renting real estate for others.."""@en ;
+    skos:notation "6720" ;
+    skos:prefLabel "Real Estate Services"@en ;
+.
+
+icat:M a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Professional, Scientific and Technical Services Division includes units mainly engaged in providing professional, scientific and technical services. Units engaged in providing these services apply common processes where labour inputs are integral to the production or service delivery. Units in this division specialise and sell their expertise. In most cases, equipment and materials are not major inputs. The activities undertaken generally require a high level of expertise and training and formal (usually tertiary level) qualifications.
+
+These services include scientific research, architecture, engineering, computer systems design, law, accountancy, advertising, market research, management and other consultancy, veterinary science and professional photography.
+
+Excluded are units mainly engaged in providing health care and social assistance services, which are included in Division Q Health Care and Social Assistance.."""@en ;
+    skos:notation "M" ;
+    skos:prefLabel "Professional, Scientific and Technical Services"@en ;
+.
+
+icat:69 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:M ; 
+    skos:definition """This subdivision includes units mainly engaged in Professional, Scientific and Technical Services (Except Computer System Design and Related Services)."""@en ;
+    skos:notation "69" ;
+    skos:prefLabel "Professional, Scientific and Technical Services (Except Computer System Design and Related Services)"@en ;
+.
+
+icat:691 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Scientific Research Services."""@en ;
+    skos:notation "691" ;
+    skos:prefLabel "Scientific Research Services"@en ;
+.
+
+icat:6910 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:691 ; 
+    skos:definition """This class consists of units mainly engaged in undertaking research in the agricultural, biological, physical or social sciences. Units may undertake the research for themselves or others.."""@en ;
+    skos:notation "6910" ;
+    skos:prefLabel "Scientific Research Services"@en ;
+.
+
+icat:692 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Architectural, Engineering and Technical Services."""@en ;
+    skos:notation "692" ;
+    skos:prefLabel "Architectural, Engineering and Technical Services"@en ;
+.
+
+icat:6921 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:692 ; 
+    skos:definition """This class consists of units mainly engaged in providing architectural services such as planning and designing buildings and structures; or planning and designing the development of land. Units apply knowledge of design, construction procedures, zoning regulations, location and land use, building codes and building materials.."""@en ;
+    skos:notation "6921" ;
+    skos:prefLabel "Architectural Services"@en ;
+.
+
+icat:6922 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:692 ; 
+    skos:definition """This class consists of units mainly engaged in providing surveying and mapping services (including exploration surveying services on contract). Units in this class use a variety of surveying techniques depending on the purpose of the survey, including magnetic surveys, gravity surveys, seismic surveys or electrical and electromagnetic surveys. These services may also include surveying and mapping of areas above or below the surface of the earth.."""@en ;
+    skos:notation "6922" ;
+    skos:prefLabel "Surveying and Mapping Services"@en ;
+.
+
+icat:6923 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:692 ; 
+    skos:definition """This class consists of units mainly engaged in providing engineering consulting services. These units are primarily involved in applying physical laws and principles of engineering in the design, development and utilisation of machines, materials, instruments, structures, processes and systems. Units provide advice, prepare feasibility studies, prepare preliminary and final plans and designs, provide technical services during the construction or installation phase, inspect and evaluate engineering projects, and related services.."""@en ;
+    skos:notation "6923" ;
+    skos:prefLabel "Engineering Design and Engineering Consulting Services"@en ;
+.
+
+icat:6924 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:692 ; 
+    skos:definition """This class consists of units mainly engaged in providing specialised design services not elsewhere classified.."""@en ;
+    skos:notation "6924" ;
+    skos:prefLabel "Other Specialised Design Services"@en ;
+.
+
+icat:6925 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:692 ; 
+    skos:definition """This class consists of units mainly engaged in providing scientific testing and analysis services such as physical or chemical testing, calibration testing, mechanical testing, thermal testing and biological testing (except medical or veterinary). The testing may occur in a laboratory or on site.."""@en ;
+    skos:notation "6925" ;
+    skos:prefLabel "Scientific Testing and Analysis Services"@en ;
+.
+
+icat:693 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Legal and Accounting Services."""@en ;
+    skos:notation "693" ;
+    skos:prefLabel "Legal and Accounting Services"@en ;
+.
+
+icat:6931 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:693 ; 
+    skos:definition """This class consists of units mainly engaged in providing legal representation and advice and the preparation of legal documents. Also included are units mainly engaged in establishing the legal ownership of a property such as title-searching services.."""@en ;
+    skos:notation "6931" ;
+    skos:prefLabel "Legal Services"@en ;
+.
+
+icat:6932 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:693 ; 
+    skos:definition """This class consists of units mainly engaged in providing accounting services such as auditing of accounting records, preparing financial statements, preparing tax returns and bookkeeping.."""@en ;
+    skos:notation "6932" ;
+    skos:prefLabel "Accounting Services"@en ;
+.
+
+icat:694 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Advertising Services."""@en ;
+    skos:notation "694" ;
+    skos:prefLabel "Advertising Services"@en ;
+.
+
+icat:6940 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:694 ; 
+    skos:definition """This class consists of units mainly engaged in providing advertising services such as the creation of advertising campaigns and materials; and media planning and buying (i.e. placing advertisements).."""@en ;
+    skos:notation "6940" ;
+    skos:prefLabel "Advertising Services"@en ;
+.
+
+icat:695 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Market Research and Statistical Services."""@en ;
+    skos:notation "695" ;
+    skos:prefLabel "Market Research and Statistical Services"@en ;
+.
+
+icat:6950 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:695 ; 
+    skos:definition """This class consists of units mainly engaged in providing market research or statistical services such as the systematic gathering, recording, tabulating and presenting of marketing and public opinion data.."""@en ;
+    skos:notation "6950" ;
+    skos:prefLabel "Market Research and Statistical Services"@en ;
+.
+
+icat:696 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Management and Related Consulting Services."""@en ;
+    skos:notation "696" ;
+    skos:prefLabel "Management and Related Consulting Services"@en ;
+.
+
+icat:6961 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:696 ; 
+    skos:definition """This class consists of units mainly engaged in overseeing and managing, exercising operational control and/or undertaking the strategic or organisational planning and decision-making roles of related units. Units in this class may also hold the securities of the related units for which they undertake these activities.."""@en ;
+    skos:notation "6961" ;
+    skos:prefLabel "Corporate Head Office Management Services"@en ;
+.
+
+icat:6962 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:696 ; 
+    skos:definition """This class consists of units mainly engaged in providing management advice and related consulting services not elsewhere classified. This includes providing advice on business or personnel management policies or practices. Also included are units mainly engaged in managing public figures such as entertainers.."""@en ;
+    skos:notation "6962" ;
+    skos:prefLabel "Management Advice and Related Consulting Services"@en ;
+.
+
+icat:697 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Veterinary Services."""@en ;
+    skos:notation "697" ;
+    skos:prefLabel "Veterinary Services"@en ;
+.
+
+icat:6970 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:697 ; 
+    skos:definition """This class consists of units mainly engaged in the practice of veterinary medicine or surgical services for domestic animals or livestock. Also included are units mainly engaged in operating animal hospitals.."""@en ;
+    skos:notation "6970" ;
+    skos:prefLabel "Veterinary Services"@en ;
+.
+
+icat:699 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:69 ; 
+    skos:definition """This group includes units mainly engaged in Other Professional, Scientific and Technical Services."""@en ;
+    skos:notation "699" ;
+    skos:prefLabel "Other Professional, Scientific and Technical Services"@en ;
+.
+
+icat:6991 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:699 ; 
+    skos:definition """This class consists of units mainly engaged in providing still, video or computer photography services, including the video taping of special events such as weddings.."""@en ;
+    skos:notation "6991" ;
+    skos:prefLabel "Professional Photographic Services"@en ;
+.
+
+icat:6999 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:699 ; 
+    skos:definition """This class consists of units primarily engaged in providing professional, scientific and technical services not elsewhere classified.."""@en ;
+    skos:notation "6999" ;
+    skos:prefLabel "Other Professional, Scientific and Technical Services n.e.c."@en ;
+.
+
+icat:70 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:M ; 
+    skos:definition """This subdivision includes units mainly engaged in Computer System Design and Related Services."""@en ;
+    skos:notation "70" ;
+    skos:prefLabel "Computer System Design and Related Services"@en ;
+.
+
+icat:700 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:70 ; 
+    skos:definition """This group includes units mainly engaged in Computer System Design and Related Services."""@en ;
+    skos:notation "700" ;
+    skos:prefLabel "Computer System Design and Related Services"@en ;
+.
+
+icat:7000 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:700 ; 
+    skos:definition """This class consists of units mainly engaged in providing expertise in the field of information technologies such as writing, modifying, testing or supporting software to meet the needs of a particular consumer; or planning and designing computer systems that integrate computer hardware, software and communication technologies.."""@en ;
+    skos:notation "7000" ;
+    skos:prefLabel "Computer System Design and Related Services"@en ;
+.
+
+icat:N a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Administrative and Support Services Division includes units mainly engaged in performing routine support activities for the day-to-day operations of other businesses or organisations.
+
+Units providing administrative support services are mainly engaged in activities such as office administration; hiring and placing personnel for others; preparing documents; taking orders for clients by telephone; providing credit reporting or collecting services; and arranging travel and travel tours.
+
+Units providing other types of support services are mainly engaged in activities such as building and other cleaning services; pest control services; gardening services; and packaging products for others.
+
+The activities undertaken by units in this division are often integral parts of the activities of units found in all sectors of the economy. Recent trends have moved more towards the outsourcing of such non-core activities. The units classified in this division specialise in one or more of these activities and can, therefore, provide services to a variety of clients.."""@en ;
+    skos:notation "N" ;
+    skos:prefLabel "Administrative and Support Services"@en ;
+.
+
+icat:72 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:N ; 
+    skos:definition """This subdivision includes units mainly engaged in Administrative Services."""@en ;
+    skos:notation "72" ;
+    skos:prefLabel "Administrative Services"@en ;
+.
+
+icat:721 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:72 ; 
+    skos:definition """This group includes units mainly engaged in Employment Services."""@en ;
+    skos:notation "721" ;
+    skos:prefLabel "Employment Services"@en ;
+.
+
+icat:7211 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:721 ; 
+    skos:definition """This class consists of units mainly engaged in listing employment vacancies and in referring or placing applicants for employment in any field. The services are provided to either employers or potential employees, and include the formulation of job descriptions, the screening and testing of applicants and the investigation of references. Also included in this class are units that provide executive search services.."""@en ;
+    skos:notation "7211" ;
+    skos:prefLabel "Employment Placement and Recruitment Services"@en ;
+.
+
+icat:7212 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:721 ; 
+    skos:definition """This class consists of units mainly engaged in supplying their own employees to clients' businesses on a fee or contract basis. Assignments are usually temporary and performed under the supervision of staff of the client unit, at the client’s work site.."""@en ;
+    skos:notation "7212" ;
+    skos:prefLabel "Labour Supply Services"@en ;
+.
+
+icat:722 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:72 ; 
+    skos:definition """This group includes units mainly engaged in Travel Agency and Tour Arrangement Services."""@en ;
+    skos:notation "722" ;
+    skos:prefLabel "Travel Agency and Tour Arrangement Services"@en ;
+.
+
+icat:7220 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:722 ; 
+    skos:definition """This class consists of units mainly engaged in acting as agents in selling travel, tour and accommodation services as well as units providing travel arrangement and reservation services for airlines, cars, hotels and restaurants. Also included are units mainly engaged in arranging, assembling, wholesaling and retailing tours.."""@en ;
+    skos:notation "7220" ;
+    skos:prefLabel "Travel Agency and Tour Arrangement Services"@en ;
+.
+
+icat:729 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:72 ; 
+    skos:definition """This group includes units mainly engaged in Other Administrative Services."""@en ;
+    skos:notation "729" ;
+    skos:prefLabel "Other Administrative Services"@en ;
+.
+
+icat:7291 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:729 ; 
+    skos:definition """This class consists of units mainly engaged in providing a range of day-to-day office administrative services such as clerical, billing and record-keeping, and payroll services on a contract or fee basis. These units support the operation of a business but do not provide operating staff to carry out the complete operations of an organisation.."""@en ;
+    skos:notation "7291" ;
+    skos:prefLabel "Office Administrative Services"@en ;
+.
+
+icat:7292 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:729 ; 
+    skos:definition """This class consists of units mainly engaged in providing document preparation services that include typing and word processing; letter or resume writing, document editing or proofreading; and stenographic, transcription and other document preparation services. Also included in this class are units that provide desktop publishing services.."""@en ;
+    skos:notation "7292" ;
+    skos:prefLabel "Document Preparation Services"@en ;
+.
+
+icat:7293 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:729 ; 
+    skos:definition """This class consists of units mainly engaged in compiling information such as a vehicle’s legal status and credit or employment histories on individuals or businesses. Also included in this class are units mainly engaged in collecting payments for claims, remitting payments collected to their clients and providing repossession services.."""@en ;
+    skos:notation "7293" ;
+    skos:prefLabel "Credit Reporting and Debt Collection Services"@en ;
+.
+
+icat:7294 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:729 ; 
+    skos:definition """This class consists of units mainly engaged in answering telephone calls and relaying messages to clients and/or in providing telemarketing services on a contract or fee basis for others. Units engaged in providing telemarketing services promote clients' products or services; take orders; solicit contributions or donations; and provide information. Units engaged in providing telemarketing services do not own the product or provide the service they represent.."""@en ;
+    skos:notation "7294" ;
+    skos:prefLabel "Call Centre Operation"@en ;
+.
+
+icat:7299 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:729 ; 
+    skos:definition """This class consists of units mainly engaged in providing administrative services not elsewhere classified.."""@en ;
+    skos:notation "7299" ;
+    skos:prefLabel "Other Administrative Services n.e.c."@en ;
+.
+
+icat:73 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:N ; 
+    skos:definition """This subdivision includes units mainly engaged in Building Cleaning, Pest Control and Other Support Services."""@en ;
+    skos:notation "73" ;
+    skos:prefLabel "Building Cleaning, Pest Control and Other Support Services"@en ;
+.
+
+icat:731 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:73 ; 
+    skos:definition """This group includes units mainly engaged in Building Cleaning, Pest Control and Gardening Services."""@en ;
+    skos:notation "731" ;
+    skos:prefLabel "Building Cleaning, Pest Control and Gardening Services"@en ;
+.
+
+icat:7311 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:731 ; 
+    skos:definition """This class consists of units mainly engaged in the interior cleaning of buildings or transportation equipment, and the exterior cleaning of buildings (except steam, sand and other abrasive blasting). Also included are units mainly engaged in providing other industrial cleaning services such as street cleaning or road sweeping.."""@en ;
+    skos:notation "7311" ;
+    skos:prefLabel "Building and Other Industrial Cleaning Services"@en ;
+.
+
+icat:7312 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:731 ; 
+    skos:definition """This class consists of units mainly engaged in providing commercial and domestic pest control services. Such services include exterminating and controlling mosquitoes, birds, rodents, termites and other insects and pests (except agricultural or forestry pest control services). Also included in this class are units providing fumigation and weed control services (except agricultural and forestry).."""@en ;
+    skos:notation "7312" ;
+    skos:prefLabel "Building Pest Control Services"@en ;
+.
+
+icat:7313 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:731 ; 
+    skos:definition """This class consists of units mainly engaged in providing gardening services only.."""@en ;
+    skos:notation "7313" ;
+    skos:prefLabel "Gardening Services"@en ;
+.
+
+icat:732 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:73 ; 
+    skos:definition """This group includes units mainly engaged in Packaging Services."""@en ;
+    skos:notation "732" ;
+    skos:prefLabel "Packaging Services"@en ;
+.
+
+icat:7320 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:732 ; 
+    skos:definition """This class consists of units mainly engaged in packing goods in bottles, cans, cartons, collapsible tubes, plastic sachets, plastic film or bags or other containers or materials on a contract or fee basis.."""@en ;
+    skos:notation "7320" ;
+    skos:prefLabel "Packaging Services"@en ;
+.
+
+icat:O a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Public Administration and Safety Division includes units mainly engaged in Central, State or Local Government legislative, executive and judicial activities; in providing physical, social, economic and general public safety and security services; and in enforcing regulations. Also included are units of military defence, government representation and international government organisations.
+
+Central, State or Local Government legislative, executive and judicial activities include the setting of policy; the oversight of government programs; collecting revenue to fund government programs; creating statute laws and by-laws; creating case law through the judicial processes of civil, criminal and other courts; and distributing public funds.
+
+The provision of physical, social, economic and general public safety and security services, and enforcing regulations, includes units that provide police services; investigation and security services; fire protection and other emergency services; correctional and detention services; regulatory services; border control; and other public order and safety services.
+
+Also included are units of military defence, government representation and international government organisations.
+
+Government ownership is not a criterion for classification to this industry division. Government units producing 'private sector like' goods and services are classified to the same industry as private sector units engaged in similar activities. Private sector units engaged in public administration or military defence are classified to the Public Administration and Safety Division. Units that engage in a combination of public administration and service delivery activities are to be classified to this division.."""@en ;
+    skos:notation "O" ;
+    skos:prefLabel "Public Administration and Safety"@en ;
+.
+
+icat:75 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:O ; 
+    skos:definition """This subdivision includes units mainly engaged in Public Administration."""@en ;
+    skos:notation "75" ;
+    skos:prefLabel "Public Administration"@en ;
+.
+
+icat:751 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:75 ; 
+    skos:definition """This group includes units mainly engaged in Central Government Administration."""@en ;
+    skos:notation "751" ;
+    skos:prefLabel "Central Government Administration"@en ;
+.
+
+icat:7510 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:751 ; 
+    skos:definition """This class consists of units engaged in the setting of central government policy; the oversight of central government programs (excluding military defence); collecting revenue to fund central government programs; creating statute laws and by-laws (excluding creating case law through the judicial processes of civil, criminal and other court operation); and distributing central government funds.."""@en ;
+    skos:notation "7510" ;
+    skos:prefLabel "Central Government Administration"@en ;
+.
+
+icat:752 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:75 ; 
+    skos:definition """This group includes units mainly engaged in State Government Administration."""@en ;
+    skos:notation "752" ;
+    skos:prefLabel "State Government Administration"@en ;
+.
+
+icat:7520 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:752 ; 
+    skos:definition """This class consists of units engaged in the setting of state government policy; the oversight of state government programs (except military defence); collecting revenue to fund state government programs; creating statute law and by-laws (excluding creating case law through the judicial processes of civil, criminal and other court operation); and distributing state government funds.."""@en ;
+    skos:notation "7520" ;
+    skos:prefLabel "State Government Administration"@en ;
+.
+
+icat:753 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:75 ; 
+    skos:definition """This group includes units mainly engaged in Local Government Administration."""@en ;
+    skos:notation "753" ;
+    skos:prefLabel "Local Government Administration"@en ;
+.
+
+icat:7530 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:753 ; 
+    skos:definition """This class consists of units engaged in the setting of local government policy; the oversight of local government programs; collecting revenue to fund local government programs; creating by-laws (excluding creating case law through the judicial processes of civil, criminal and other court operations); and distributing local government funds.."""@en ;
+    skos:notation "7530" ;
+    skos:prefLabel "Local Government Administration"@en ;
+.
+
+icat:754 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:75 ; 
+    skos:definition """This group includes units mainly engaged in Justice."""@en ;
+    skos:notation "754" ;
+    skos:prefLabel "Justice"@en ;
+.
+
+icat:7540 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:754 ; 
+    skos:definition """This class consists of units mainly engaged in the operation or administration of judicial authorities or commission including civil and criminal courts, royal commissions and similarly constituted inquiries, and in creating case law through the judicial processes of civil, criminal and other court operations.."""@en ;
+    skos:notation "7540" ;
+    skos:prefLabel "Justice"@en ;
+.
+
+icat:755 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:75 ; 
+    skos:definition """This group includes units mainly engaged in Government Representation."""@en ;
+    skos:notation "755" ;
+    skos:prefLabel "Government Representation"@en ;
+.
+
+icat:7551 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:755 ; 
+    skos:definition """This class includes units of domestic government mainly engaged in the operation of diplomatic and consular missions abroad.."""@en ;
+    skos:notation "7551" ;
+    skos:prefLabel "Domestic Government Representation"@en ;
+.
+
+icat:7552 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:755 ; 
+    skos:definition """This class consists of units of foreign governments mainly engaged in governmental service activities such as the provision of consular or diplomatic services. This class also includes representatives of joint international government organisations such as the United Nations.."""@en ;
+    skos:notation "7552" ;
+    skos:prefLabel "Foreign Government Representation"@en ;
+.
+
+icat:76 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:O ; 
+    skos:definition """This subdivision includes units mainly engaged in Defence."""@en ;
+    skos:notation "76" ;
+    skos:prefLabel "Defence"@en ;
+.
+
+icat:760 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:76 ; 
+    skos:definition """This group includes units mainly engaged in Defence."""@en ;
+    skos:notation "760" ;
+    skos:prefLabel "Defence"@en ;
+.
+
+icat:7600 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:760 ; 
+    skos:definition """This class consists of units of military defence (including those staffed by civilian personnel) stationed at home or abroad. Included are units mainly engaged in defence administration; the administration of defence research and development policies and associated funds; contingency planning; and carrying out military exercises in which civilian institutions and populations are involved.."""@en ;
+    skos:notation "7600" ;
+    skos:prefLabel "Defence"@en ;
+.
+
+icat:77 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:O ; 
+    skos:definition """This subdivision includes units mainly engaged in Public Order, Safety and Regulatory Services."""@en ;
+    skos:notation "77" ;
+    skos:prefLabel "Public Order, Safety and Regulatory Services"@en ;
+.
+
+icat:771 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:77 ; 
+    skos:definition """This group includes units mainly engaged in Public Order and Safety Services."""@en ;
+    skos:notation "771" ;
+    skos:prefLabel "Public Order and Safety Services"@en ;
+.
+
+icat:7711 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:771 ; 
+    skos:definition """This class consists of units mainly engaged in criminal and civil law enforcement and other activities related to the enforcement of law and the preservation of order.."""@en ;
+    skos:notation "7711" ;
+    skos:prefLabel "Police Services"@en ;
+.
+
+icat:7712 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:771 ; 
+    skos:definition """This class consists of units mainly engaged in investigation and security services (except police).."""@en ;
+    skos:notation "7712" ;
+    skos:prefLabel "Investigation and Security Services"@en ;
+.
+
+icat:7713 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:771 ; 
+    skos:definition """This class consists of units mainly engaged in providing fire fighting or related civil emergency services (except police and ambulance services).."""@en ;
+    skos:notation "7713" ;
+    skos:prefLabel "Fire Protection and Other Emergency Services"@en ;
+.
+
+icat:7714 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:771 ; 
+    skos:definition """This class consists of units mainly engaged in managing and operating correctional institutions (including prisons and remand centres) and detention centres. The facility is generally designed for confinement, correction and rehabilitation of individuals.."""@en ;
+    skos:notation "7714" ;
+    skos:prefLabel "Correctional and Detention Services"@en ;
+.
+
+icat:7719 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:771 ; 
+    skos:definition """The class consists of units mainly engaged in providing public order and safety services not elsewhere classified such as border surveillance.."""@en ;
+    skos:notation "7719" ;
+    skos:prefLabel "Other Public Order and Safety Services"@en ;
+.
+
+icat:772 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:77 ; 
+    skos:definition """This group includes units mainly engaged in Regulatory Services."""@en ;
+    skos:notation "772" ;
+    skos:prefLabel "Regulatory Services"@en ;
+.
+
+icat:7720 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:772 ; 
+    skos:definition """This class consists of units both public and private mainly engaged in enforcing regulations, licensing and inspection activities (except regulation of financial and insurance markets, electricity markets and regulatory units with a dual role of regulation and public administration with a significant amount of public administration). The regulations enforced in this class are established by Acts of Parliament and cover technical details that may be subject to frequent change. They are signed into law through the Cabinet Committee, Executive Council or some other body less than Parliament.."""@en ;
+    skos:notation "7720" ;
+    skos:prefLabel "Regulatory Services"@en ;
+.
+
+icat:P a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Education and Training Division includes units mainly engaged in the provision and support of education and training, except those engaged in the training of animals e.g. dog obedience training, horse training.
+
+Education may be provided in a range of settings, such as educational institutions, the workplace, or the home. Generally, instruction is delivered through face-to-face interaction between teachers/instructors and students, although other means and mediums of delivery, such as by correspondence, radio, television or the internet, may be used.
+
+Education and training is delivered by teachers or instructors who explain, tell or demonstrate a wide variety of subjects. The commonality of processes involved, such as the labour inputs of teachers and instructors, and their subject matter knowledge and teaching expertise, uniquely distinguishes this industry from other industries.
+
+Education support services include a range of support services which assist in the provision of education, such as curriculum setting and examination marking.."""@en ;
+    skos:notation "P" ;
+    skos:prefLabel "Education and Training"@en ;
+.
+
+icat:80 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:P ; 
+    skos:definition """This subdivision includes units mainly engaged in Preschool and School Education."""@en ;
+    skos:notation "80" ;
+    skos:prefLabel "Preschool and School Education"@en ;
+.
+
+icat:801 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:80 ; 
+    skos:definition """This group includes units mainly engaged in Preschool Education."""@en ;
+    skos:notation "801" ;
+    skos:prefLabel "Preschool Education"@en ;
+.
+
+icat:8010 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:801 ; 
+    skos:definition """This class consists of units mainly engaged in providing accredited pre-primary school education. Pre-school programs are educational in nature and are designed to introduce children to ideas, attitudes and behaviour required in a school environment. They are usually directed at children aged three to five years, are generally sessional in nature and are provided by staff that have training in an educational field.."""@en ;
+    skos:notation "8010" ;
+    skos:prefLabel "Preschool Education"@en ;
+.
+
+icat:802 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:80 ; 
+    skos:definition """This group includes units mainly engaged in School Education."""@en ;
+    skos:notation "802" ;
+    skos:prefLabel "School Education"@en ;
+.
+
+icat:8021 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:802 ; 
+    skos:definition """This class consists of units mainly engaged in providing primary school education (except combined primary/secondary school education).."""@en ;
+    skos:notation "8021" ;
+    skos:prefLabel "Primary Education"@en ;
+.
+
+icat:8022 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:802 ; 
+    skos:definition """This class consists of units mainly engaged in providing secondary school education (except combined primary/secondary school education).."""@en ;
+    skos:notation "8022" ;
+    skos:prefLabel "Secondary Education"@en ;
+.
+
+icat:8023 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:802 ; 
+    skos:definition """This class consists of units mainly engaged in providing both primary and secondary school education.."""@en ;
+    skos:notation "8023" ;
+    skos:prefLabel "Combined Primary and Secondary Education"@en ;
+.
+
+icat:8024 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:802 ; 
+    skos:definition """This class consists of units mainly engaged in providing special education and training for children with disabilities and special needs (except those provided in mainstream primary, secondary or combined primary and secondary schools).."""@en ;
+    skos:notation "8024" ;
+    skos:prefLabel "Special School Education"@en ;
+.
+
+icat:81 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:P ; 
+    skos:definition """This subdivision includes units mainly engaged in Tertiary Education."""@en ;
+    skos:notation "81" ;
+    skos:prefLabel "Tertiary Education"@en ;
+.
+
+icat:810 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:81 ; 
+    skos:definition """This group includes units mainly engaged in Tertiary Education."""@en ;
+    skos:notation "810" ;
+    skos:prefLabel "Tertiary Education"@en ;
+.
+
+icat:8101 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:810 ; 
+    skos:definition """This class consists of units mainly engaged in providing technical and vocational education and training. These units offer a large variety of courses covering a range of subjects or specialise in a particular field of education such as computer and business management training.."""@en ;
+    skos:notation "8101" ;
+    skos:prefLabel "Technical and Vocational Education and Training"@en ;
+.
+
+icat:8102 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:810 ; 
+    skos:definition """This class consists of units mainly engaged in providing undergraduate or postgraduate teaching.."""@en ;
+    skos:notation "8102" ;
+    skos:prefLabel "Higher Education"@en ;
+.
+
+icat:82 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:P ; 
+    skos:definition """This subdivision includes units mainly engaged in Adult, Community and Other Education."""@en ;
+    skos:notation "82" ;
+    skos:prefLabel "Adult, Community and Other Education"@en ;
+.
+
+icat:821 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:82 ; 
+    skos:definition """This group includes units mainly engaged in Adult, Community and Other Education."""@en ;
+    skos:notation "821" ;
+    skos:prefLabel "Adult, Community and Other Education"@en ;
+.
+
+icat:8211 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:821 ; 
+    skos:definition """This class consists of units mainly engaged in providing non-vocational instruction in sporting and physical recreation activities.."""@en ;
+    skos:notation "8211" ;
+    skos:prefLabel "Sports and Physical Recreation Instruction"@en ;
+.
+
+icat:8212 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:821 ; 
+    skos:definition """This class consists of units mainly engaged in providing non-vocational instruction in the arts, including art, dance, drama and music.."""@en ;
+    skos:notation "8212" ;
+    skos:prefLabel "Arts Education"@en ;
+.
+
+icat:8219 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:821 ; 
+    skos:definition """This class consists of units mainly engaged in providing adult, community and other education not elsewhere classified.."""@en ;
+    skos:notation "8219" ;
+    skos:prefLabel "Adult, Community and Other Education n.e.c."@en ;
+.
+
+icat:822 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:82 ; 
+    skos:definition """This group includes units mainly engaged in Educational Support Services."""@en ;
+    skos:notation "822" ;
+    skos:prefLabel "Educational Support Services"@en ;
+.
+
+icat:8220 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:822 ; 
+    skos:definition """This class consists of units mainly engaged in providing non-instructional services that support educational processes or systems.."""@en ;
+    skos:notation "8220" ;
+    skos:prefLabel "Educational Support Services"@en ;
+.
+
+icat:Q a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Health Care and Social Assistance Division includes units mainly engaged in providing human health care and social assistance. Units engaged in providing these services apply common processes, where the labour inputs of practitioners with the requisite expertise and qualifications are integral to production or service delivery.."""@en ;
+    skos:notation "Q" ;
+    skos:prefLabel "Health Care and Social Assistance"@en ;
+.
+
+icat:84 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:Q ; 
+    skos:definition """This subdivision includes units mainly engaged in Hospitals."""@en ;
+    skos:notation "84" ;
+    skos:prefLabel "Hospitals"@en ;
+.
+
+icat:840 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:84 ; 
+    skos:definition """This group includes units mainly engaged in Hospitals."""@en ;
+    skos:notation "840" ;
+    skos:prefLabel "Hospitals"@en ;
+.
+
+icat:8401 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:840 ; 
+    skos:definition """This class consists of units of hospitals (except psychiatric hospitals) mainly engaged in providing facilities and services such as diagnostic, medical or surgical services as well as continuous in-patient medical care in specialised accommodation. Also included are units providing both hospital facilities and training of medical and nursing staff.."""@en ;
+    skos:notation "8401" ;
+    skos:prefLabel "Hospitals (Except Psychiatric Hospitals)"@en ;
+.
+
+icat:8402 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:840 ; 
+    skos:definition """This class consists of units of psychiatric hospitals mainly engaged in providing services for patients with psychiatric, mental or behavioural disorders. Also included are units providing both psychiatric hospital facilities and training of medical and nursing staff.."""@en ;
+    skos:notation "8402" ;
+    skos:prefLabel "Psychiatric Hospitals"@en ;
+.
+
+icat:85 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:Q ; 
+    skos:definition """This subdivision includes units mainly engaged in Medical and Other Health Care Services."""@en ;
+    skos:notation "85" ;
+    skos:prefLabel "Medical and Other Health Care Services"@en ;
+.
+
+icat:851 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:85 ; 
+    skos:definition """This group includes units mainly engaged in Medical Services."""@en ;
+    skos:notation "851" ;
+    skos:prefLabel "Medical Services"@en ;
+.
+
+icat:8511 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:851 ; 
+    skos:definition """This class consists of units mainly engaged in the independent practice of general medicine. These units consist of registered medical practitioners who generally operate private or group practices in medical clinics or centres.."""@en ;
+    skos:notation "8511" ;
+    skos:prefLabel "General Practice Medical Services"@en ;
+.
+
+icat:8512 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:851 ; 
+    skos:definition """This class consists of units mainly engaged in the independent practice of specialised medicine, other than pathology and diagnostic imaging services. These units consist of specialist medical practitioners who generally operate private or group practices in medical clinics or centres.."""@en ;
+    skos:notation "8512" ;
+    skos:prefLabel "Specialist Medical Services"@en ;
+.
+
+icat:852 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:85 ; 
+    skos:definition """This group includes units mainly engaged in Pathology and Diagnostic Imaging Services."""@en ;
+    skos:notation "852" ;
+    skos:prefLabel "Pathology and Diagnostic Imaging Services"@en ;
+.
+
+icat:8520 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:852 ; 
+    skos:definition """This class consists of units mainly engaged in the provision of pathology laboratory or diagnostic imaging services such as analytical services including body fluid analysis, ultrasound or x-ray services.."""@en ;
+    skos:notation "8520" ;
+    skos:prefLabel "Pathology and Diagnostic Imaging Services"@en ;
+.
+
+icat:853 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:85 ; 
+    skos:definition """This group includes units mainly engaged in Allied Health Services."""@en ;
+    skos:notation "853" ;
+    skos:prefLabel "Allied Health Services"@en ;
+.
+
+icat:8531 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:853 ; 
+    skos:definition """This class consists of units mainly engaged in the practice of general or specialised dentistry. These units consist of registered dentists who generally operate private or group practices. Also included are dental hospitals providing out-patient services only.."""@en ;
+    skos:notation "8531" ;
+    skos:prefLabel "Dental Services"@en ;
+.
+
+icat:8532 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:853 ; 
+    skos:definition """This class consists of units of registered optometrists mainly engaged in testing sight, diagnosing sight defects or in prescribing or dispensing spectacles or contact lenses on prescription.."""@en ;
+    skos:notation "8532" ;
+    skos:prefLabel "Optometry and Optical Dispensing"@en ;
+.
+
+icat:8533 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:853 ; 
+    skos:definition """This class consists of units of physiotherapists mainly engaged in providing assessment, diagnosis, treatment (such as manipulation, massage and therapeutic exercise) and help in preventing disorders of human movement.."""@en ;
+    skos:notation "8533" ;
+    skos:prefLabel "Physiotherapy Services"@en ;
+.
+
+icat:8534 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:853 ; 
+    skos:definition """This class consists of units of chiropractors mainly engaged in manual adjustment of the spinal column as a method of healing to remove nerve interference. Also included are units of osteopaths mainly engaged in massage and manipulation as a system of healing or treatment.."""@en ;
+    skos:notation "8534" ;
+    skos:prefLabel "Chiropractic and Osteopathic Services"@en ;
+.
+
+icat:8539 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:853 ; 
+    skos:definition """This class consists of units mainly engaged in providing allied health care services not elsewhere classified. These units consist of independent allied health practitioners not elsewhere classified mainly engaged in providing health care and treatment services.."""@en ;
+    skos:notation "8539" ;
+    skos:prefLabel "Other Allied Health Services"@en ;
+.
+
+icat:859 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:85 ; 
+    skos:definition """This group includes units mainly engaged in Other Health Care Services."""@en ;
+    skos:notation "859" ;
+    skos:prefLabel "Other Health Care Services"@en ;
+.
+
+icat:8591 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:859 ; 
+    skos:definition """This class consists of units mainly engaged in transporting patients by ground or air in conjunction with medical care.."""@en ;
+    skos:notation "8591" ;
+    skos:prefLabel "Ambulance Services"@en ;
+.
+
+icat:8599 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:859 ; 
+    skos:definition """This class consists of units mainly engaged in providing health care services not elsewhere classified.."""@en ;
+    skos:notation "8599" ;
+    skos:prefLabel "Other Health Care Services n.e.c."@en ;
+.
+
+icat:86 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:Q ; 
+    skos:definition """This subdivision includes units mainly engaged in Residential Care Services."""@en ;
+    skos:notation "86" ;
+    skos:prefLabel "Residential Care Services"@en ;
+.
+
+icat:860 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:86 ; 
+    skos:definition """This group includes units mainly engaged in Residential Care Services."""@en ;
+    skos:notation "860" ;
+    skos:prefLabel "Residential Care Services"@en ;
+.
+
+icat:8601 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:860 ; 
+    skos:definition """This class consists of units mainly engaged in providing residential aged care combined with either nursing, supervisory or other types of care as required (including medical).."""@en ;
+    skos:notation "8601" ;
+    skos:prefLabel "Aged Care Residential Services"@en ;
+.
+
+icat:8609 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:860 ; 
+    skos:definition """This class consists of units mainly engaged in providing residential care (except aged care) combined with either nursing, supervisory or other types of care as required (including medical).."""@en ;
+    skos:notation "8609" ;
+    skos:prefLabel "Other Residential Care Services"@en ;
+.
+
+icat:87 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:Q ; 
+    skos:definition """This subdivision includes units mainly engaged in Social Assistance Services."""@en ;
+    skos:notation "87" ;
+    skos:prefLabel "Social Assistance Services"@en ;
+.
+
+icat:871 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:87 ; 
+    skos:definition """This group includes units mainly engaged in Child Care Services."""@en ;
+    skos:notation "871" ;
+    skos:prefLabel "Child Care Services"@en ;
+.
+
+icat:8710 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:871 ; 
+    skos:definition """This class consists of units mainly engaged in providing day care of infants or children.."""@en ;
+    skos:notation "8710" ;
+    skos:prefLabel "Child Care Services"@en ;
+.
+
+icat:879 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:87 ; 
+    skos:definition """This group includes units mainly engaged in Other Social Assistance Services."""@en ;
+    skos:notation "879" ;
+    skos:prefLabel "Other Social Assistance Services"@en ;
+.
+
+icat:8790 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:879 ; 
+    skos:definition """This class consists of units mainly engaged in providing a wide variety of social support services directly to their clients. These services do not include accommodation services, except on a short stay basis.."""@en ;
+    skos:notation "8790" ;
+    skos:prefLabel "Other Social Assistance Services"@en ;
+.
+
+icat:R a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Arts and Recreation Services Division includes units mainly engaged in the preservation and exhibition of objects and sites of historical, cultural or educational interest; the production of original artistic works and/or participation in live performances, events, or exhibits intended for public viewing; and the operation of facilities or the provision of services that enable patrons to participate in sporting or recreational activities, or to pursue amusement interests.
+
+This division excludes units that are involved in the production, or production and distribution of motion pictures, videos, television programs or television and video commercials. These units are included in the Information Media and Telecommunications Division.."""@en ;
+    skos:notation "R" ;
+    skos:prefLabel "Arts and Recreation Services"@en ;
+.
+
+icat:89 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:R ; 
+    skos:definition """This subdivision includes units mainly engaged in Heritage Activities."""@en ;
+    skos:notation "89" ;
+    skos:prefLabel "Heritage Activities"@en ;
+.
+
+icat:891 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:89 ; 
+    skos:definition """This group includes units mainly engaged in Museum Operation."""@en ;
+    skos:notation "891" ;
+    skos:prefLabel "Museum Operation"@en ;
+.
+
+icat:8910 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:891 ; 
+    skos:definition """This class consists of units mainly engaged in the preservation and exhibition of heritage objects and artefacts and/or visual arts and crafts with aesthetic, historical, cultural, and/or educational value. This class also includes units operating historical places, sites or houses.."""@en ;
+    skos:notation "8910" ;
+    skos:prefLabel "Museum Operation"@en ;
+.
+
+icat:892 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:89 ; 
+    skos:definition """This group includes units mainly engaged in Parks and Gardens Operations."""@en ;
+    skos:notation "892" ;
+    skos:prefLabel "Parks and Gardens Operations"@en ;
+.
+
+icat:8921 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:892 ; 
+    skos:definition """This class consists of units mainly engaged in the active management, breeding, preservation, study and exhibition of live plants and animals in a controlled environment such as zoological or botanical gardens.."""@en ;
+    skos:notation "8921" ;
+    skos:prefLabel "Zoological and Botanical Gardens Operation"@en ;
+.
+
+icat:8922 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:892 ; 
+    skos:definition """This class consists of units mainly engaged in the preservation of flora and fauna in their natural environment such as nature reserves and conservation parks.."""@en ;
+    skos:notation "8922" ;
+    skos:prefLabel "Nature Reserves and Conservation Parks Operation"@en ;
+.
+
+icat:90 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:R ; 
+    skos:definition """This subdivision includes units mainly engaged in Creative and Performing Arts Activities."""@en ;
+    skos:notation "90" ;
+    skos:prefLabel "Creative and Performing Arts Activities"@en ;
+.
+
+icat:900 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:90 ; 
+    skos:definition """This group includes units mainly engaged in Creative and Performing Arts Activities."""@en ;
+    skos:notation "900" ;
+    skos:prefLabel "Creative and Performing Arts Activities"@en ;
+.
+
+icat:9001 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:900 ; 
+    skos:definition """This class consists of units mainly engaged in providing or producing live theatrical or musical presentations or performances. These units are not usually involved in the creation of original artistic or cultural works.."""@en ;
+    skos:notation "9001" ;
+    skos:prefLabel "Performing Arts Operation"@en ;
+.
+
+icat:9002 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:900 ; 
+    skos:definition """This class consists of units of independent (freelance) individuals or groups mainly engaged in the regular creation of original artistic or cultural works who may or may not also produce and perform their works. This class also includes units providing independent technical expertise necessary for these productions, and celebrities mainly engaged in endorsing products or making speeches or public appearances for which they receive a fee.."""@en ;
+    skos:notation "9002" ;
+    skos:prefLabel "Creative Artists, Musicians, Writers and Performers"@en ;
+.
+
+icat:9003 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:900 ; 
+    skos:definition """This class consists of units mainly engaged in operating venues for the presentation and rehearsal of performing arts.."""@en ;
+    skos:notation "9003" ;
+    skos:prefLabel "Performing Arts Venue Operation"@en ;
+.
+
+icat:91 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:R ; 
+    skos:definition """This subdivision includes units mainly engaged in Sports and Recreation Activities."""@en ;
+    skos:notation "91" ;
+    skos:prefLabel "Sports and Recreation Activities"@en ;
+.
+
+icat:911 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:91 ; 
+    skos:definition """This group includes units mainly engaged in Sports and Physical Recreation Activities."""@en ;
+    skos:notation "911" ;
+    skos:prefLabel "Sports and Physical Recreation Activities"@en ;
+.
+
+icat:9111 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:911 ; 
+    skos:definition """This class consists of units mainly engaged in operating health clubs, fitness centres and gymnasia. Units in this class provide a range of fitness and exercise services.."""@en ;
+    skos:notation "9111" ;
+    skos:prefLabel "Health and Fitness Centres and Gymnasia Operation"@en ;
+.
+
+icat:9112 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:911 ; 
+    skos:definition """This class consists of units mainly engaged in operating individual sports or physical recreation clubs or teams which provide sporting or physical recreation opportunities to participants, or entertainment for spectators. This class also includes sports professionals.."""@en ;
+    skos:notation "9112" ;
+    skos:prefLabel "Sports and Physical Recreation Clubs and Sports Professionals"@en ;
+.
+
+icat:9113 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:911 ; 
+    skos:definition """This class consists of units mainly engaged in operating indoor or outdoor sports and physical recreation venues, grounds and facilities (except health and fitness centres and gymnasia).."""@en ;
+    skos:notation "9113" ;
+    skos:prefLabel "Sports and Physical Recreation Venues, Grounds and Facilities Operation"@en ;
+.
+
+icat:9114 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:911 ; 
+    skos:definition """This class consists of units mainly engaged in the administration and/or control of sports or physical recreation organisations. These units are responsible for the policies, rules and regulations governing the conduct of an individual sporting or physical recreation discipline.."""@en ;
+    skos:notation "9114" ;
+    skos:prefLabel "Sports and Physical Recreation Administrative Service"@en ;
+.
+
+icat:912 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:91 ; 
+    skos:definition """This group includes units mainly engaged in Horse and Dog Racing Activities."""@en ;
+    skos:notation "912" ;
+    skos:prefLabel "Horse and Dog Racing Activities"@en ;
+.
+
+icat:9121 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:912 ; 
+    skos:definition """This class consists of units mainly engaged in administering horse and dog racing activities, or operating venues for horse and dog racing.."""@en ;
+    skos:notation "9121" ;
+    skos:prefLabel "Horse and Dog Racing Administration and Track Operation"@en ;
+.
+
+icat:9129 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:912 ; 
+    skos:definition """This class consists of units mainly engaged in the operation of horse racing stables or dog racing kennels. This class also includes horse and dog racing training services.."""@en ;
+    skos:notation "9129" ;
+    skos:prefLabel "Other Horse and Dog Racing Activities"@en ;
+.
+
+icat:913 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:91 ; 
+    skos:definition """This group includes units mainly engaged in Amusement and Other Recreation Activities."""@en ;
+    skos:notation "913" ;
+    skos:prefLabel "Amusement and Other Recreation Activities"@en ;
+.
+
+icat:9131 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:913 ; 
+    skos:definition """This class consists of units mainly engaged in providing amusement and recreation services in the form of amusement parks, arcades or centres. This class includes units operating from fixed or permanent sites and also includes selected mobile amusement operators.."""@en ;
+    skos:notation "9131" ;
+    skos:prefLabel "Amusement Parks and Centres Operation"@en ;
+.
+
+icat:9139 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:913 ; 
+    skos:definition """This class consists of units mainly engaged in providing amusement and other recreational services not elsewhere classified. Included in this class are units that provide outdoor recreational services such as bungy jumping and white water rafting.."""@en ;
+    skos:notation "9139" ;
+    skos:prefLabel "Amusement and Other Recreational Activities n.e.c."@en ;
+.
+
+icat:92 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:R ; 
+    skos:definition """This subdivision includes units mainly engaged in Gambling Activities."""@en ;
+    skos:notation "92" ;
+    skos:prefLabel "Gambling Activities"@en ;
+.
+
+icat:920 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:92 ; 
+    skos:definition """This group includes units mainly engaged in Gambling Activities."""@en ;
+    skos:notation "920" ;
+    skos:prefLabel "Gambling Activities"@en ;
+.
+
+icat:9201 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:920 ; 
+    skos:definition """This class consists of units mainly engaged in operating facilities with a range of gambling services such as table wagering games and poker/gaming machines.."""@en ;
+    skos:notation "9201" ;
+    skos:prefLabel "Casino Operation"@en ;
+.
+
+icat:9202 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:920 ; 
+    skos:definition """This class consists of units mainly engaged in operating lotteries or selling lottery products. Also included are units operating lotto-style games and football pools.."""@en ;
+    skos:notation "9202" ;
+    skos:prefLabel "Lottery Operation"@en ;
+.
+
+icat:9209 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:920 ; 
+    skos:definition """This class consists of units mainly engaged in operating other gambling services such as totalisator or betting services. Also included in this class are units offering gambling services through the internet.."""@en ;
+    skos:notation "9209" ;
+    skos:prefLabel "Other Gambling Activities"@en ;
+.
+
+icat:S a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:topConceptOf icatcs: ; 
+    skos:definition """The Other Services Division includes a broad range of personal services; religious, civic, professional and other interest group services; selected repair and maintenance activities; and private households employing staff. Units in this division are mainly engaged in providing a range of personal care services, such as hair, beauty and diet and weight management services; providing death care services; promoting or administering religious events or activities; or promoting and defending the interests of their members.
+
+Also included are units mainly engaged in repairing and/or maintaining equipment and machinery (except ships, boats, aircraft, or railway rolling stock) or other items (except buildings); as well as units of private households that engage in employing workers on or about the premises in activities primarily concerned with the operation of households.
+
+The Other Services Division excludes units mainly engaged in providing buildings or dwellings repair and maintenance services (included in the Construction or Administrative and Support Services Divisions as appropriate), and units mainly engaged in providing repair and maintenance services of books, ships, boats, aircraft or railway rolling stock (included in the Manufacturing Division).."""@en ;
+    skos:notation "S" ;
+    skos:prefLabel "Other Services"@en ;
+.
+
+icat:94 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:S ; 
+    skos:definition """This subdivision includes units mainly engaged in Repair and Maintenance."""@en ;
+    skos:notation "94" ;
+    skos:prefLabel "Repair and Maintenance"@en ;
+.
+
+icat:941 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:94 ; 
+    skos:definition """This group includes units mainly engaged in Automotive Repair and Maintenance."""@en ;
+    skos:notation "941" ;
+    skos:prefLabel "Automotive Repair and Maintenance"@en ;
+.
+
+icat:9411 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:941 ; 
+    skos:definition """This class consists of units mainly engaged in installing and repairing automotive electrical products in a range of automotive vehicles.."""@en ;
+    skos:notation "9411" ;
+    skos:prefLabel "Automotive Electrical Services"@en ;
+.
+
+icat:9412 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:941 ; 
+    skos:definition """This class consists of units mainly engaged in repairing, panel beating and/or spray painting smashed or damaged automotive vehicles. Also included are units mainly engaged in replacing, repairing and/or tinting automotive vehicle glass, units repairing the interior/exterior of automotive vehicle as well as units providing car wash or cleaning services.."""@en ;
+    skos:notation "9412" ;
+    skos:prefLabel "Automotive Body, Paint and Interior Repair"@en ;
+.
+
+icat:9419 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:941 ; 
+    skos:definition """This class consists of units mainly engaged in providing a wide range of mechanical and repair and maintenance services for automotive vehicles. Included are units which specialise in the repair and maintenance of particular automotive components such as brakes, clutches, mufflers, transmissions, gearboxes and other parts. Also included are units providing automotive engine repair and replacement services (except factory replacement), and motorcycle repair and maintenance services.."""@en ;
+    skos:notation "9419" ;
+    skos:prefLabel "Other Automotive Repair and Maintenance"@en ;
+.
+
+icat:942 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:94 ; 
+    skos:definition """This group includes units mainly engaged in Machinery and Equipment Repair and Maintenance."""@en ;
+    skos:notation "942" ;
+    skos:prefLabel "Machinery and Equipment Repair and Maintenance"@en ;
+.
+
+icat:9421 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:942 ; 
+    skos:definition """This class consists of units mainly engaged in repairing and maintaining electrical, electronic and gas domestic appliances.."""@en ;
+    skos:notation "9421" ;
+    skos:prefLabel "Domestic Appliance Repair and Maintenance"@en ;
+.
+
+icat:9422 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:942 ; 
+    skos:definition """This class consists of units mainly engaged in repairing and maintaining electronic equipment (except domestic appliances) such as computers and communications equipment, and/or highly specialised precision instruments.."""@en ;
+    skos:notation "9422" ;
+    skos:prefLabel "Electronic (except Domestic Appliance) and Precision Equipment Repair"@en ;
+.
+
+icat:9429 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:942 ; 
+    skos:definition """This class consists of units mainly engaged in the repair and maintenance of machinery and equipment not elsewhere classified. Also included in this class are units which either sharpen/install blades and saws or provide welding repair services.."""@en ;
+    skos:notation "9429" ;
+    skos:prefLabel "Other Machinery and Equipment Repair and Maintenance"@en ;
+.
+
+icat:949 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:94 ; 
+    skos:definition """This group includes units mainly engaged in Other Repair and Maintenance."""@en ;
+    skos:notation "949" ;
+    skos:prefLabel "Other Repair and Maintenance"@en ;
+.
+
+icat:9491 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:949 ; 
+    skos:definition """This class consists of units mainly engaged in repairing clothing and footwear.."""@en ;
+    skos:notation "9491" ;
+    skos:prefLabel "Clothing and Footwear Repair"@en ;
+.
+
+icat:9499 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:949 ; 
+    skos:definition """This class consists of units mainly engaged in other repair and maintenance not elsewhere classified such as furniture, sporting equipment, musical instruments, jewellery, watches and clocks.."""@en ;
+    skos:notation "9499" ;
+    skos:prefLabel "Other Repair and Maintenance n.e.c."@en ;
+.
+
+icat:95 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:S ; 
+    skos:definition """This subdivision includes units mainly engaged in Personal and Other Services."""@en ;
+    skos:notation "95" ;
+    skos:prefLabel "Personal and Other Services"@en ;
+.
+
+icat:951 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:95 ; 
+    skos:definition """This group includes units mainly engaged in Personal Care Services."""@en ;
+    skos:notation "951" ;
+    skos:prefLabel "Personal Care Services"@en ;
+.
+
+icat:9511 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:951 ; 
+    skos:definition """This class consists of units mainly engaged in providing hairdressing services or in providing beauty services such as nail care services, facials or applying make-up.."""@en ;
+    skos:notation "9511" ;
+    skos:prefLabel "Hairdressing and Beauty Services"@en ;
+.
+
+icat:9512 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:951 ; 
+    skos:definition """This class consists of units mainly engaged in operating diet and weight reducing centres.."""@en ;
+    skos:notation "9512" ;
+    skos:prefLabel "Diet and Weight Reduction Centre Operation"@en ;
+.
+
+icat:952 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:95 ; 
+    skos:definition """This group includes units mainly engaged in Funeral, Crematorium and Cemetery Services."""@en ;
+    skos:notation "952" ;
+    skos:prefLabel "Funeral, Crematorium and Cemetery Services"@en ;
+.
+
+icat:9520 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:952 ; 
+    skos:definition """This class consists of units mainly engaged in preparing deceased for burial, internment or cremation in organising funerals. Also included are units operating cemeteries.."""@en ;
+    skos:notation "9520" ;
+    skos:prefLabel "Funeral, Crematorium and Cemetery Services"@en ;
+.
+
+icat:953 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:95 ; 
+    skos:definition """This group includes units mainly engaged in Other Personal Services."""@en ;
+    skos:notation "953" ;
+    skos:prefLabel "Other Personal Services"@en ;
+.
+
+icat:9531 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:953 ; 
+    skos:definition """This class consists of units mainly engaged in providing a range of laundry and/or dry-cleaning services. The services provided may be operated by customers (i.e. coin-operated or similar self-service facilities) or may be operated by the units themselves. Also included are units mainly engaged in baby napkin, linen and/or uniform hire.."""@en ;
+    skos:notation "9531" ;
+    skos:prefLabel "Laundry and Dry-Cleaning Services"@en ;
+.
+
+icat:9532 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:953 ; 
+    skos:definition """This class consists of units mainly engaged in developing film and/or making photographic slides, prints and enlargements.."""@en ;
+    skos:notation "9532" ;
+    skos:prefLabel "Photographic Film Processing"@en ;
+.
+
+icat:9533 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:953 ; 
+    skos:definition """This class consists of units mainly engaged in providing parking space for motor vehicles, usually on an hourly, daily or monthly basis. Also included are units providing valet parking services.."""@en ;
+    skos:notation "9533" ;
+    skos:prefLabel "Parking Services"@en ;
+.
+
+icat:9534 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:953 ; 
+    skos:definition """This class consists of units mainly engaged in operating brothels and providing escort and prostitution services.."""@en ;
+    skos:notation "9534" ;
+    skos:prefLabel "Brothel Keeping and Prostitution Services"@en ;
+.
+
+icat:9539 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:953 ; 
+    skos:definition """This class consists of units mainly engaged in providing personal services not elsewhere classified.."""@en ;
+    skos:notation "9539" ;
+    skos:prefLabel "Other Personal Services n.e.c."@en ;
+.
+
+icat:954 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:95 ; 
+    skos:definition """This group includes units mainly engaged in Religious Services."""@en ;
+    skos:notation "954" ;
+    skos:prefLabel "Religious Services"@en ;
+.
+
+icat:9540 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:954 ; 
+    skos:definition """This class consists of units mainly engaged in providing religious services and/or operating facilities such as churches, mosques, religious temples and monasteries. Also included are units which administer an organised religion or promote religious activities.."""@en ;
+    skos:notation "9540" ;
+    skos:prefLabel "Religious Services"@en ;
+.
+
+icat:955 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:95 ; 
+    skos:definition """This group includes units mainly engaged in Civic, Professional and Other Interest Group Services."""@en ;
+    skos:notation "955" ;
+    skos:prefLabel "Civic, Professional and Other Interest Group Services"@en ;
+.
+
+icat:9551 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:955 ; 
+    skos:definition """This class consists of units mainly engaged in promoting the business interests of their members (except of organised labour associations and union members).."""@en ;
+    skos:notation "9551" ;
+    skos:prefLabel "Business and Professional Association Services"@en ;
+.
+
+icat:9552 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:955 ; 
+    skos:definition """This class consists of units mainly engaged in promoting the interests of organised labour and union employees. Also included are units of associations and councils promoting such interests.."""@en ;
+    skos:notation "9552" ;
+    skos:prefLabel "Labour Association Services"@en ;
+.
+
+icat:9559 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:955 ; 
+    skos:definition """This class consists of units mainly engaged in activities which promote the interests of their members (except religious, business and professional, and labour association services). Included in this class are units providing a range of community or sectional interests or in providing civic and social advocacy services not elsewhere classified.."""@en ;
+    skos:notation "9559" ;
+    skos:prefLabel "Other Interest Group Services n.e.c."@en ;
+.
+
+icat:96 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:S ; 
+    skos:definition """This subdivision includes units mainly engaged in Private Households Employing Staff and Undifferentiated Goods- and Service-Producing Activities of Households for Own Use."""@en ;
+    skos:notation "96" ;
+    skos:prefLabel "Private Households Employing Staff and Undifferentiated Goods and Service Producing Activities of Households for Own Use"@en ;
+.
+
+icat:960 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:96 ; 
+    skos:definition """This group includes units mainly engaged in Private Households Employing Staff and Undifferentiated Goods- and Service-Producing Activities of Households for Own Use."""@en ;
+    skos:notation "960" ;
+    skos:prefLabel "Private Households Employing Staff and Undifferentiated Goods and Service Producing Activities of Households for Own Use"@en ;
+.
+
+icat:9601 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:960 ; 
+    skos:definition """This class consists of units mainly engaged in employing workers on or about household premises in activities primarily concerned with the operation of the household. These units may employ individuals such as cooks, maids, nannies, butlers and chauffeurs, as well as outside workers such as gardeners, caretakers and other maintenance workers.."""@en ;
+    skos:notation "9601" ;
+    skos:prefLabel "Private Households Employing Staff"@en ;
+.
+
+icat:9602 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:960 ; 
+    skos:definition """This class consists of units mainly engaged in a range of subsistence goods-producing activities relating to households’ production of goods for their own subsistence. These activities include hunting and gathering, farming and the production of shelter, clothing and other goods by the household for its own subsistence.."""@en ;
+    skos:notation "9602" ;
+    skos:prefLabel "Undifferentiated Goods-Producing Activities of Private Households for Own Use"@en ;
+.
+
+icat:9603 a skos:Concept ;
+    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:inScheme icatcs: ;
+    skos:broader icat:960 ; 
+    skos:definition """This class consists of units mainly engaged in a range of subsistence services-producing activities relating to households. These activities include cooking, teaching, caring for household members and other services produced by the household for its own subsistence.."""@en ;
+    skos:notation "9603" ;
+    skos:prefLabel "Undifferentiated Service-Producing Activities of Private Households for Own Use"@en ;
+.
+
+
+icat:X
     a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:P0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Adult, Community and Other Education."@en ;
-    skos:inScheme cs: ;
-    skos:notation "P8200" ;
-    skos:prefLabel "Adult, Community and Other Education"@en ;
+    rdfs:isDefinedBy icatcs: ;
+    skos:definition "An individual business entity whose predominant economic activity is Undefined Industry."@en ;
+    skos:inScheme icatcs: ;
+    skos:notation "X" ;
+    skos:prefLabel "Undefined Industry"@en ;
+    skos:topConceptOf icatcs: ;
 .
 
 icat:X9800
     a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
+    rdfs:isDefinedBy icatcs: ;
     skos:altLabel
         "Other"@en ,
         "Other Industry"@en ;
-    skos:broader icat:X0000 ;
+    skos:broader icat:X ;
     skos:definition "An individual business entity whose predominant economic activity is unspecified or is not available for selection with provided list. This typically applies to a known industrial classification that is not relevant to a high degree of specificity in a specific use case."@en ;
-    skos:inScheme cs: ;
+    skos:inScheme icatcs: ;
     skos:notation "X9800" ;
     skos:prefLabel "Unspecified Industry"@en ;
 .
@@ -2396,915 +8935,27 @@ icat:X9800
 icat:X9900
     a skos:Concept ;
     dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
+    rdfs:isDefinedBy icatcs: ;
     skos:altLabel "Unknown Industry"@en ;
-    skos:broader icat:X0000 ;
+    skos:broader icat:X ;
     skos:definition "An individual business entity whose predominant economic activity is unknown."@en ;
-    skos:inScheme cs: ;
+    skos:inScheme icatcs: ;
     skos:notation "X9900" ;
     skos:prefLabel "Unknown"@en ;
 .
 
-icat:A0400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Fishing, Hunting and Trapping."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0400" ;
-    skos:prefLabel "Fishing, Hunting and Trapping"@en ;
+#COLLECTIONS
+
+icat:coal-buyer
+    a skos:Collection ;
+    skos:definition "Industry categorisations as applicable to coal sales."@en ;
+    skos:member
+        icat:060 ,
+        icat:C ,
+        icat:21 ,
+        icat:261 ,
+        icat:X9800 ,
+        icat:X9900 ;
+    skos:prefLabel "Coal Buyer Industry"@en ;
+    prov:wasDerivedFrom icatcs: ;
 .
-
-icat:A0500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Agriculture, Forestry and Fishing Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0500" ;
-    skos:prefLabel "Agriculture, Forestry and Fishing Support Services"@en ;
-.
-
-icat:B0900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Non-Metallic Mineral Mining and Quarrying."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B0900" ;
-    skos:prefLabel "Non-Metallic Mineral Mining and Quarrying"@en ;
-.
-
-icat:B1000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:B0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Exploration and Other Mining Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B1000" ;
-    skos:prefLabel "Exploration and Other Mining Support Services"@en ;
-.
-
-icat:C1200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Beverage and Tobacco Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1200" ;
-    skos:prefLabel "Beverage and Tobacco Product Manufacturing"@en ;
-.
-
-icat:C1400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Wood Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1400" ;
-    skos:prefLabel "Wood Product Manufacturing"@en ;
-.
-
-icat:C1500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Pulp, Paper and Converted Paper Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1500" ;
-    skos:prefLabel "Pulp, Paper and Converted Paper Product Manufacturing"@en ;
-.
-
-icat:C1600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Printing (including the Reproduction of Recorded Media)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1600" ;
-    skos:prefLabel "Printing (including the Reproduction of Recorded Media)"@en ;
-.
-
-icat:C1900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Polymer Product and Rubber Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1900" ;
-    skos:prefLabel "Polymer Product and Rubber Product Manufacturing"@en ;
-.
-
-icat:C2300
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Transport Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2300" ;
-    skos:prefLabel "Transport Equipment Manufacturing"@en ;
-.
-
-icat:C2500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Furniture and Other Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2500" ;
-    skos:prefLabel "Furniture and Other Manufacturing"@en ;
-.
-
-icat:D2900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Waste Collection, Treatment and Disposal Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2900" ;
-    skos:prefLabel "Waste Collection, Treatment and Disposal Services"@en ;
-.
-
-icat:E3000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Building Construction."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3000" ;
-    skos:prefLabel "Building Construction"@en ;
-.
-
-icat:F3400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Machinery and Equipment Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3400" ;
-    skos:prefLabel "Machinery and Equipment Wholesaling"@en ;
-.
-
-icat:G3900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motor Vehicle and Motor Vehicle Parts Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G3900" ;
-    skos:prefLabel "Motor Vehicle and Motor Vehicle Parts Retailing"@en ;
-.
-
-icat:G4100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Food Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4100" ;
-    skos:prefLabel "Food Retailing"@en ;
-.
-
-icat:G4300
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Non-Store Retailing and Retail Commission-Based Buying and/or Selling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4300" ;
-    skos:prefLabel "Non-Store Retailing and Retail Commission-Based Buying and/or Selling"@en ;
-.
-
-icat:I4600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Road Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4600" ;
-    skos:prefLabel "Road Transport"@en ;
-.
-
-icat:I4700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Rail Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4700" ;
-    skos:prefLabel "Rail Transport"@en ;
-.
-
-icat:I4800
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Water Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I4800" ;
-    skos:prefLabel "Water Transport"@en ;
-.
-
-icat:I5000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Transport."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5000" ;
-    skos:prefLabel "Other Transport"@en ;
-.
-
-icat:J5400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Publishing (except Internet and Music Publishing)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5400" ;
-    skos:prefLabel "Publishing (except Internet and Music Publishing)"@en ;
-.
-
-icat:J5500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Motion Picture and Sound Recording Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5500" ;
-    skos:prefLabel "Motion Picture and Sound Recording Activities"@en ;
-.
-
-icat:J5600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Broadcasting (except Internet)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5600" ;
-    skos:prefLabel "Broadcasting (except Internet)"@en ;
-.
-
-icat:J5900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Internet Service Providers, Web Search Portals and Data Processing Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J5900" ;
-    skos:prefLabel "Internet Service Providers, Web Search Portals and Data Processing Services"@en ;
-.
-
-icat:J6000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:J0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Library and Other Information Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J6000" ;
-    skos:prefLabel "Library and Other Information Services"@en ;
-.
-
-icat:K6400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Auxiliary Finance and Insurance Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6400" ;
-    skos:prefLabel "Auxiliary Finance and Insurance Services"@en ;
-.
-
-icat:L6700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Property Operators and Real Estate Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6700" ;
-    skos:prefLabel "Property Operators and Real Estate Services"@en ;
-.
-
-icat:N7300
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:N0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Building Cleaning, Pest Control and Other Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N7300" ;
-    skos:prefLabel "Building Cleaning, Pest Control and Other Support Services"@en ;
-.
-
-icat:O7700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Public Order, Safety and Regulatory Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7700" ;
-    skos:prefLabel "Public Order, Safety and Regulatory Services"@en ;
-.
-
-icat:P8000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:P0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Preschool and School Education."@en ;
-    skos:inScheme cs: ;
-    skos:notation "P8000" ;
-    skos:prefLabel "Preschool and School Education"@en ;
-.
-
-icat:Q8700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Social Assistance Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8700" ;
-    skos:prefLabel "Social Assistance Services"@en ;
-.
-
-icat:R8900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Heritage Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R8900" ;
-    skos:prefLabel "Heritage Activities"@en ;
-.
-
-<https://linked.data.gov.au/org/gsq>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Queensland" ;
-    sdo:url "https://www.business.qld.gov.au/industries/mining-energy-water/resources/geoscience-information/gsq"^^xsd:anyURI ;
-.
-
-icat:F3300
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Material Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3300" ;
-    skos:prefLabel "Basic Material Wholesaling"@en ;
-.
-
-icat:F3700
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:F0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Goods Wholesaling."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F3700" ;
-    skos:prefLabel "Other Goods Wholesaling"@en ;
-.
-
-icat:H0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Accommodation and Food Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "H0000" ;
-    skos:prefLabel "Accommodation and Food Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:H4500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:H0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Food and Beverage Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "H4500" ;
-    skos:prefLabel "Food and Beverage Services"@en ;
-.
-
-icat:I5200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:I0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Transport Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I5200" ;
-    skos:prefLabel "Transport Support Services"@en ;
-.
-
-icat:K6300
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Insurance and Superannuation Funds."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6300" ;
-    skos:prefLabel "Insurance and Superannuation Funds"@en ;
-.
-
-icat:L0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Rental, Hiring and Real Estate Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L0000" ;
-    skos:prefLabel "Rental, Hiring and Real Estate Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:M0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Professional, Scientific and Technical Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M0000" ;
-    skos:prefLabel "Professional, Scientific and Technical Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:N0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Administrative and Support Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N0000" ;
-    skos:prefLabel "Administrative and Support Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:N7200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:N0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Administrative Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "N7200" ;
-    skos:prefLabel "Administrative Services"@en ;
-.
-
-icat:R9100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:R0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Sports and Recreation Activities."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R9100" ;
-    skos:prefLabel "Sports and Recreation Activities"@en ;
-.
-
-icat:S9400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Repair and Maintenance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9400" ;
-    skos:prefLabel "Repair and Maintenance"@en ;
-.
-
-icat:X0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Undefined Industry."@en ;
-    skos:inScheme cs: ;
-    skos:notation "X0000" ;
-    skos:prefLabel "Undefined Industry"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:C2000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Non-Metallic Mineral Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2000" ;
-    skos:prefLabel "Non-Metallic Mineral Product Manufacturing"@en ;
-.
-
-icat:D2600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:D0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Electricity Supply."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D2600" ;
-    skos:prefLabel "Electricity Supply"@en ;
-.
-
-icat:E0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Construction."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E0000" ;
-    skos:prefLabel "Construction"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:K0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Financial and Insurance Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K0000" ;
-    skos:prefLabel "Financial and Insurance Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:K6200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:K0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Finance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "K6200" ;
-    skos:prefLabel "Finance"@en ;
-.
-
-icat:L6600
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:L0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Rental and Hiring Services (except Real Estate)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "L6600" ;
-    skos:prefLabel "Rental and Hiring Services (except Real Estate)"@en ;
-.
-
-icat:O0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Public Administration and Safety."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O0000" ;
-    skos:prefLabel "Public Administration and Safety"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:P0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Education and Training."@en ;
-    skos:inScheme cs: ;
-    skos:notation "P0000" ;
-    skos:prefLabel "Education and Training"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:Q8500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:Q0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Medical and Other Health Care Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q8500" ;
-    skos:prefLabel "Medical and Other Health Care Services"@en ;
-.
-
-icat:S0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S0000" ;
-    skos:prefLabel "Other Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:C1300
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Textile, Leather, Clothing and Footwear Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1300" ;
-    skos:prefLabel "Textile, Leather, Clothing and Footwear Manufacturing"@en ;
-.
-
-icat:C2100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel "Metal Processing"@en ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Primary Metal and Metal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2100" ;
-    skos:prefLabel "Primary Metal and Metal Product Manufacturing"@en ;
-.
-
-icat:C2200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Fabricated Metal Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2200" ;
-    skos:prefLabel "Fabricated Metal Product Manufacturing"@en ;
-.
-
-icat:D0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Electricity, Gas, Water and Waste Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "D0000" ;
-    skos:prefLabel "Electricity, Gas, Water and Waste Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:E3200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:E0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Construction Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "E3200" ;
-    skos:prefLabel "Construction Services"@en ;
-.
-
-icat:O7500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:O0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Public Administration."@en ;
-    skos:inScheme cs: ;
-    skos:notation "O7500" ;
-    skos:prefLabel "Public Administration"@en ;
-.
-
-icat:Q0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Health Care and Social Assistance."@en ;
-    skos:inScheme cs: ;
-    skos:notation "Q0000" ;
-    skos:prefLabel "Health Care and Social Assistance"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:R0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Arts and Recreation Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "R0000" ;
-    skos:prefLabel "Arts and Recreation Services"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:S9500
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:S0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Personal and Other Services."@en ;
-    skos:inScheme cs: ;
-    skos:notation "S9500" ;
-    skos:prefLabel "Personal and Other Services"@en ;
-.
-
-icat:A0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Agriculture, Forestry and Fishing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0000" ;
-    skos:prefLabel "Agriculture, Forestry and Fishing"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:B0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Mining."@en ;
-    skos:inScheme cs: ;
-    skos:notation "B0000" ;
-    skos:prefLabel "Mining"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:C1800
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Basic Chemical and Chemical Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1800" ;
-    skos:prefLabel "Basic Chemical and Chemical Product Manufacturing"@en ;
-.
-
-icat:G0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Retail Trade."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G0000" ;
-    skos:prefLabel "Retail Trade"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:C2400
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Machinery and Equipment Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C2400" ;
-    skos:prefLabel "Machinery and Equipment Manufacturing"@en ;
-.
-
-icat:F0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Wholesale Trade."@en ;
-    skos:inScheme cs: ;
-    skos:notation "F0000" ;
-    skos:prefLabel "Wholesale Trade"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:G4200
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:G0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Other Store-Based Retailing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "G4200" ;
-    skos:prefLabel "Other Store-Based Retailing"@en ;
-.
-
-icat:J0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Information Media and Telecommunications."@en ;
-    skos:inScheme cs: ;
-    skos:notation "J0000" ;
-    skos:prefLabel "Information Media and Telecommunications"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:M6900
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:M0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Professional, Scientific and Technical Services (Except Computer System Design and Related Services)."@en ;
-    skos:inScheme cs: ;
-    skos:notation "M6900" ;
-    skos:prefLabel "Professional, Scientific and Technical Services (Except Computer System Design and Related Services)"@en ;
-.
-
-icat:A0100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:A0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Agriculture."@en ;
-    skos:inScheme cs: ;
-    skos:notation "A0100" ;
-    skos:prefLabel "Agriculture"@en ;
-.
-
-icat:C1100
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:broader icat:C0000 ;
-    skos:definition "An individual business entity whose predominant economic activity is Food Product Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C1100" ;
-    skos:prefLabel "Food Product Manufacturing"@en ;
-.
-
-icat:I0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:definition "An individual business entity whose predominant economic activity is Transport, Postal and Warehousing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "I0000" ;
-    skos:prefLabel "Transport, Postal and Warehousing"@en ;
-    skos:topConceptOf cs: ;
-.
-
-icat:C0000
-    a skos:Concept ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    rdfs:isDefinedBy cs: ;
-    skos:altLabel "Other Processing"@en ;
-    skos:definition "An individual business entity whose predominant economic activity is Manufacturing."@en ;
-    skos:inScheme cs: ;
-    skos:notation "C0000" ;
-    skos:prefLabel "Manufacturing"@en ;
-    skos:topConceptOf cs: ;
-.
-
-cs:
-    a
-        owl:Ontology ,
-        skos:ConceptScheme ;
-    dcterms:created "2020-02-17"^^xsd:date ;
-    dcterms:creator <https://linked.data.gov.au/org/gsq> ;
-    dcterms:modified "2023-03-16"^^xsd:date ;
-    dcterms:publisher <https://linked.data.gov.au/org/gsq> ;
-    dcterms:source "https://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1292.02006%20(Revision%202.0)?OpenDocument"^^xsd:anyURI ;
-    reg:status agldwgstatus:stable ;
-    skos:definition """An industrial classification organises data about business units. It provides a standard framework under which business units carrying out similar production activities can be grouped together, with each resultant group referred to as an industry.\r
-    An individual business entity is assigned to an industry based on its predominant economic activity. The term business entity is used in its widest sense to include any organisation undertaking productive activities, including companies, non-profit organisations, government departments and enterprises. ANZSIC has four hierarchic levels: Divisions (the broadest level), Subdivisions, Groups and Classes (the finest level).\r
-    At the Divisional level, the main purpose is to provide a limited number of categories which provide a broad overall picture of the economy and are suitable for the publication of summary tables in official statistics. The Subdivision, Group and Class levels provide increasingly detailed dissections of these categories for the compilation of more specific and detailed statistics."""@en ;
-    skos:hasTopConcept
-        icat:A0000 ,
-        icat:B0000 ,
-        icat:C0000 ,
-        icat:D0000 ,
-        icat:E0000 ,
-        icat:F0000 ,
-        icat:G0000 ,
-        icat:H0000 ,
-        icat:I0000 ,
-        icat:J0000 ,
-        icat:K0000 ,
-        icat:L0000 ,
-        icat:M0000 ,
-        icat:N0000 ,
-        icat:O0000 ,
-        icat:P0000 ,
-        icat:Q0000 ,
-        icat:R0000 ,
-        icat:S0000 ,
-        icat:X0000 ;
-    skos:prefLabel "Australian and New Zealand Standard Industrial Classification 2006 - Codes and Titles"@en ;
-.
-


### PR DESCRIPTION
Update to align with more fidelity to the original ANZSIC standards

Notations updated as per ABS
iris updated to match, preventing overlaps between subdivisions and groups. definitions derived directly from standard where available examples included from ABS primary activities.

Have preserved the coal buys collection and remapped the relevant categories where necessary.

Have preserved custom X categories for unknown and undefined industry.

@nicholascar @GSQ-AI 