### PR TITLE
Update sample-type.ttl - add core run concept

### DIFF
--- a/vocabularies-gsq/sample-type.ttl
+++ b/vocabularies-gsq/sample-type.ttl
@@ -679,6 +679,18 @@ sampty:core
     skos:topConceptOf cs: ;
 .
 
+sampty:core-run
+    a skos:Concept ;
+    skos:historyNote "Compiled by the Geological Survey of Queensland" ;
+    rdfs:isDefinedBy cs: ;
+    skos:broader sampty:core ;
+    skos:definition " A core run is a segment of a geological core sample that corresponds to the length of material recovered from a single core barrel during a coring operation."@en ;
+    skos:inScheme cs: ;
+    skos:notation "CORN" ;
+    skos:prefLabel "Core Run"@en ;
+    skos:topConceptOf cs: ;
+.
+
 cs:
     a
         owl:Ontology ,
@@ -701,6 +713,7 @@ cs:
         sampty:continuous-channel-sample ,
         sampty:core ,
         sampty:core-plug ,
+        sampty:core-run ,
         sampty:crushed-rock ,
         sampty:cuttings ,
         sampty:deviation-log ,


### PR DESCRIPTION
Introduce the 'core-run' concept as a narrower concept of the core, describing the discrete samples that make up the core core concept. Core-run concept is experimental, but necessary to assign the existing core runs to in the GeoProperties system as a part of the WIMS data remediation project.