### PR TITLE
Update sampling-method.ttl

### DIFF
--- a/vocabularies-gsq/sampling-method.ttl
+++ b/vocabularies-gsq/sampling-method.ttl
@@ -1,7 +1,7 @@
 PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <http://linked.data.gov.au/def/sampling-method>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX gasmp: <https://pid.geoscience.gov.au/def/voc/ga/samplingmethod/>
+PREFIX gasmp: <http://pid.geoscience.gov.au/def/voc/ga/samplingmethod/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>


### PR DESCRIPTION
Revert https://pid.geoscience.gov.au to http//pid.geoscience.gov.au to support GDMP system validation.