### PR TITLE
fix IRIs for rdflicense

### DIFF
--- a/vocabularies-qldgov/qg-data-licenses.ttl
+++ b/vocabularies-qldgov/qg-data-licenses.ttl
@@ -5,7 +5,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-qlic:cc-by-4.0
+qlic:cc-by4.0
     a skos:Concept ;
     skos:historyNote "Vocabulary built from original sourced from http://registry.it.csiro.au/_licence." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/qld-data-licenses> ;
@@ -16,7 +16,7 @@ qlic:cc-by-4.0
     skos:topConceptOf <https://linked.data.gov.au/def/qld-data-licenses> ;
 .
 
-qlic:cc-by-nd-4.0
+qlic:cc-by-nd4.0
     a skos:Concept ;
     skos:historyNote "Vocabulary built from original sourced from http://registry.it.csiro.au/_licence." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/qld-data-licenses> ;
@@ -27,7 +27,7 @@ qlic:cc-by-nd-4.0
     skos:topConceptOf <https://linked.data.gov.au/def/qld-data-licenses> ;
 .
 
-qlic:cc-by-sa-4.0
+qlic:cc-by-sa4.0
     a skos:Concept ;
     skos:historyNote "Vocabulary built from original sourced from http://registry.it.csiro.au/_licence." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/qld-data-licenses> ;
@@ -49,9 +49,9 @@ qlic:cc-by-sa-4.0
     dcterms:publisher <https://linked.data.gov.au/org/des> ;
     skos:definition "Licenses for use of software, data, documents and other resources within Queensland Government"@en ;
     skos:hasTopConcept
-        qlic:cc-by-4.0 ,
-        qlic:cc-by-nd-4.0 ,
-        qlic:cc-by-sa-4.0 ;
+        qlic:cc-by4.0 ,
+        qlic:cc-by-nd4.0 ,
+        qlic:cc-by-sa4.0 ;
     skos:prefLabel "Queensland Government Software and Data Licenses"@en ;
 .
 


### PR DESCRIPTION
The IRIs for the linked-to RDF Licenses were incorrect. Here fixed.