### PR TITLE
Update ANZIC2006-industry-classifications.ttl

### DIFF
--- a/vocabularies-gsq/ANZIC2006-industry-classifications.ttl
+++ b/vocabularies-gsq/ANZIC2006-industry-classifications.ttl
@@ -1031,7 +1031,7 @@ icat:F3320
     skos:inScheme cs: ;
     skos:notation "F3320" ;
     skos:altLabel "Mineral, Metal and Chemical Wholesaling"@en ;
-    skos:prefLabel "Commodity Wholesaling"@en ;
+    skos:prefLabel "Coal Wholesaling"@en ;
 .
 
 icat:F3330


### PR DESCRIPTION
Updated to 'coal' as per INTEL request. 
This will cause issue if this entry is to be used for any other commodity in the future, and is in part, contrary to the definition.